### PR TITLE
perf(zerodim): run well-conditioned AMP paths in double precision (5-7x)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,4 +122,4 @@ bertini2_tests_*.log
 /failed_paths
 
 # Compiled benchmark binaries (keep the .cpp sources)
-/benchmarks/arithmetic_cost
+/tuning/arithmetic_cost

--- a/benchmark/inputs/huge_seeded.b2
+++ b/benchmark/inputs/huge_seeded.b2
@@ -1,0 +1,24 @@
+CONFIG
+
+tracktype: 0;
+
+randomseed: 314159;
+
+END;
+
+INPUT
+
+variable_group x1, x2, x3, x4, x5, x6, x7, x8, x9;
+function f1, f2, f3, f4, f5, f6, f7, f8, f9;
+
+f1 = x1^3 - 2;
+f2 = x2^3 - 3;
+f3 = x3^3 - 5;
+f4 = x4^3 - 7;
+f5 = x5^3 - 11;
+f6 = x6^3 - 13;
+f7 = x7^3 - 17;
+f8 = x8^3 - 19;
+f9 = x9^3 - 23;
+
+END;

--- a/benchmark/inputs/large_seeded.b2
+++ b/benchmark/inputs/large_seeded.b2
@@ -1,0 +1,21 @@
+CONFIG
+
+tracktype: 0;
+
+randomseed: 314159;
+
+END;
+
+INPUT
+
+variable_group x1, x2, x3, x4, x5, x6;
+function f1, f2, f3, f4, f5, f6;
+
+f1 = x1^3 - 2;
+f2 = x2^3 - 3;
+f3 = x3^3 - 5;
+f4 = x4^3 - 7;
+f5 = x5^3 - 11;
+f6 = x6^3 - 13;
+
+END;

--- a/benchmark/inputs/medium_seeded.b2
+++ b/benchmark/inputs/medium_seeded.b2
@@ -1,0 +1,20 @@
+CONFIG
+
+tracktype: 0;
+
+randomseed: 314159;
+
+END;
+
+INPUT
+
+variable_group x1, x2, x3, x4, x5;
+function f1, f2, f3, f4, f5;
+
+f1 = x1^3 - 2;
+f2 = x2^3 - 3;
+f3 = x3^3 - 5;
+f4 = x4^3 - 7;
+f5 = x5^3 - 11;
+
+END;

--- a/benchmark/inputs/small_seeded.b2
+++ b/benchmark/inputs/small_seeded.b2
@@ -1,0 +1,18 @@
+CONFIG
+
+tracktype: 0;
+
+randomseed: 314159;
+
+END;
+
+INPUT
+
+variable_group x1, x2, x3;
+function f1, f2, f3;
+
+f1 = x1^3 - 2;
+f2 = x2^3 - 3;
+f3 = x3^3 - 5;
+
+END;

--- a/benchmark/inputs/xlarge_seeded.b2
+++ b/benchmark/inputs/xlarge_seeded.b2
@@ -1,0 +1,22 @@
+CONFIG
+
+tracktype: 0;
+
+randomseed: 314159;
+
+END;
+
+INPUT
+
+variable_group x1, x2, x3, x4, x5, x6, x7;
+function f1, f2, f3, f4, f5, f6, f7;
+
+f1 = x1^3 - 2;
+f2 = x2^3 - 3;
+f3 = x3^3 - 5;
+f4 = x4^3 - 7;
+f5 = x5^3 - 11;
+f6 = x6^3 - 13;
+f7 = x7^3 - 17;
+
+END;

--- a/core/include/bertini2/nag_algorithms/zero_dim_solve.hpp
+++ b/core/include/bertini2/nag_algorithms/zero_dim_solve.hpp
@@ -211,18 +211,26 @@ struct EGBoundaryMetaData
 	Vec<ComplexT> path_point;
 	SuccessCode success_code = SuccessCode::NeverStarted;
 	RealT last_used_stepsize;
+	// The precision the tracker was actually using when it reached the endgame boundary.
+	// Carried explicitly (rather than inferred from Precision(path_point)) because the
+	// path_point is always stored as the tracker's BaseComplexT (multiprecision for AMP);
+	// a path that tracked in double gets widened on output, so its mantissa precision no
+	// longer reflects the precision that was in use.  The endgame should resume at this
+	// precision.  See zero_dim_solve TrackSinglePathDuringEG.
+	unsigned precision = DoublePrecision();
 
 	EGBoundaryMetaData() = default;
 	EGBoundaryMetaData(EGBoundaryMetaData const&) = default;
-	EGBoundaryMetaData(Vec<ComplexT> const& pt, SuccessCode const& code, RealT const& ss) :
-		path_point(pt), success_code(code), last_used_stepsize(ss)
+	EGBoundaryMetaData(Vec<ComplexT> const& pt, SuccessCode const& code, RealT const& ss, unsigned prec) :
+		path_point(pt), success_code(code), last_used_stepsize(ss), precision(prec)
 	{}
-	
+
 	bool operator==(const EGBoundaryMetaData<ComplexT> & other){
-		bool result = 
+		bool result =
 			this->path_point == other.path_point
 			&& this->success_code == other.success_code
 			&& this->last_used_stepsize == other.last_used_stepsize
+			&& this->precision == other.precision
 		;
 
 		return result;
@@ -235,6 +243,7 @@ std::ostream& operator<<(std::ostream & out, const EGBoundaryMetaData<NumT> & me
 	out << "path_point = " << meta.path_point << std::endl;
 	out << "success_code = " << meta.success_code << std::endl;
 	out << "last_used_stepsize = " << meta.last_used_stepsize << std::endl;
+	out << "precision = " << meta.precision << std::endl;
 	return out;
 }
 
@@ -826,10 +835,26 @@ std::ostream& operator<<(std::ostream & out, const EGBoundaryMetaData<NumT> & me
 				auto t_endgame_boundary = this->template Get<ZeroDimConf>().endgame_boundary;
 				auto start_point = StartSystem().template StartPoint<BaseComplexT>(soln_ind);
 
+				// Begin tracking at the intended ambient precision rather than the start
+				// point's incidental precision.  Total-degree start points are generated at
+				// LowestMultiplePrecision (the generator's arithmetic widens past the requested
+				// digits, see issue #308), so without this the AMP tracker would start every
+				// well-conditioned path in multiprecision and never drop to double.
+				if constexpr (tracking::TrackerTraits<TrackerType>::IsAdaptivePrec)
+					GetTracker().SetStartPrecision(this->template Get<ZeroDimConf>().initial_ambient_precision);
+
 				Vec<BaseComplexT> result;
 				auto tracking_success = GetTracker().TrackPath(result, t_start, t_endgame_boundary, start_point);
 
-				solutions_at_endgame_boundary_[soln_ind] = EGBoundaryMetaDataT({ result, tracking_success, GetTracker().CurrentStepsize() });
+				solutions_at_endgame_boundary_[soln_ind] = EGBoundaryMetaDataT({ result, tracking_success, GetTracker().CurrentStepsize(), GetTracker().CurrentPrecision() });
+
+				// Clear the start-precision override so it does not leak into the endgame,
+				// which shares this tracker instance (endgame_(tracker_)) for its sample
+				// circles and must be free to begin those at the sample points' precision.
+				if constexpr (tracking::TrackerTraits<TrackerType>::IsAdaptivePrec)
+				{
+					GetTracker().SetStartPrecision(std::nullopt);
+				}
 
 					smd.pre_endgame_success = tracking_success;
 
@@ -925,12 +950,23 @@ std::ostream& operator<<(std::ostream & out, const EGBoundaryMetaData<NumT> & me
 					start_point = StartSystem().template StartPoint<BaseComplexT>(soln_ind);
 				}
 
+				// Begin tracking at the intended ambient precision rather than the start
+				// point's incidental precision (see TrackSinglePathBeforeEG / issue #308).
+				if constexpr (tracking::TrackerTraits<TrackerType>::IsAdaptivePrec)
+					state.tracker.SetStartPrecision(initial_prec);
+
 				Vec<BaseComplexT> result;
 				auto tracking_success = state.tracker.TrackPath(result, t_start, t_endgame_boundary, start_point);
 
 				// Each soln_ind is unique per thread — no locking needed.
 				solutions_at_endgame_boundary_[soln_ind] =
-					EGBoundaryMetaDataT({ result, tracking_success, state.tracker.CurrentStepsize() });
+					EGBoundaryMetaDataT({ result, tracking_success, state.tracker.CurrentStepsize(), state.tracker.CurrentPrecision() });
+
+				// Clear the start-precision override so it does not leak into the endgame
+				// (which shares this tracker instance for its sample circles).
+				if constexpr (tracking::TrackerTraits<TrackerType>::IsAdaptivePrec)
+					state.tracker.SetStartPrecision(std::nullopt);
+
 				smd.pre_endgame_success = tracking_success;
 
 					if (tracking::TrackerTraits<TrackerType>::IsAdaptivePrec)
@@ -974,7 +1010,10 @@ std::ostream& operator<<(std::ostream & out, const EGBoundaryMetaData<NumT> & me
 				state.tracker.SetStepSize(solutions_at_endgame_boundary_[soln_ind].last_used_stepsize);
 				state.tracker.ReinitializeInitialStepSize(false);
 
-				auto start_prec = Precision(bdry_point);
+				// Resume the endgame at the precision the path was actually using at the
+				// boundary, rather than inferring it from the (always-multiprecision) point's
+				// mantissa, which is unreliable for paths that tracked in double.
+				auto start_prec = solutions_at_endgame_boundary_[soln_ind].precision;
 
 				SetThreadPrecision(start_prec);
 
@@ -1111,7 +1150,10 @@ std::ostream& operator<<(std::ostream & out, const EGBoundaryMetaData<NumT> & me
 				GetTracker().SetStepSize(solutions_at_endgame_boundary_[soln_ind].last_used_stepsize);
 				GetTracker().ReinitializeInitialStepSize(false);
 
-				auto start_prec = Precision(bdry_point);
+				// Resume the endgame at the precision the path was actually using at the
+				// boundary, rather than inferring it from the (always-multiprecision) point's
+				// mantissa, which is unreliable for paths that tracked in double.
+				auto start_prec = solutions_at_endgame_boundary_[soln_ind].precision;
 
 				DefaultPrecision(start_prec);
 
@@ -1223,6 +1265,7 @@ std::ostream& operator<<(std::ostream & out, const EGBoundaryMetaData<NumT> & me
 				r.pre_endgame_success  = solutions_at_endgame_boundary_[idx].success_code;
 				r.boundary_point       = solutions_at_endgame_boundary_[idx].path_point;
 				r.boundary_stepsize    = solutions_at_endgame_boundary_[idx].last_used_stepsize;
+				r.boundary_precision   = solutions_at_endgame_boundary_[idx].precision;
 				r.precision_changed    = solution_final_metadata_[idx].precision_changed;
 				r.time_of_first_prec_increase = solution_final_metadata_[idx].time_of_first_prec_increase;
 				r.max_precision_used   = solution_final_metadata_[idx].max_precision_used;
@@ -1233,7 +1276,7 @@ std::ostream& operator<<(std::ostream & out, const EGBoundaryMetaData<NumT> & me
 			{
 				auto idx = static_cast<SolnIndT>(r.path_index);
 				solutions_at_endgame_boundary_[idx] =
-					EGBoundaryMetaDataT{r.boundary_point, r.pre_endgame_success, r.boundary_stepsize};
+					EGBoundaryMetaDataT{r.boundary_point, r.pre_endgame_success, r.boundary_stepsize, r.boundary_precision};
 				auto& smd = solution_final_metadata_[idx];
 				smd.path_index             = idx;
 				smd.solution_index         = idx;

--- a/core/include/bertini2/parallel/path_result.hpp
+++ b/core/include/bertini2/parallel/path_result.hpp
@@ -70,6 +70,8 @@ struct PathBeforeEGResult
 	bool          precision_changed      = false;
 	ComplexT      time_of_first_prec_increase;
 	unsigned      max_precision_used     = 0;
+	// The precision the tracker was using at the endgame boundary; see EGBoundaryMetaData.
+	unsigned      boundary_precision     = DoublePrecision();
 
 	template<class Archive>
 	void serialize(Archive& ar, unsigned const)
@@ -81,6 +83,7 @@ struct PathBeforeEGResult
 		ar & precision_changed;
 		ar & time_of_first_prec_increase;
 		ar & max_precision_used;
+		ar & boundary_precision;
 	}
 };
 

--- a/core/include/bertini2/trackers/amp_tracker.hpp
+++ b/core/include/bertini2/trackers/amp_tracker.hpp
@@ -102,7 +102,7 @@ namespace bertini{
 		 Calibrated by benchmarking three operations representative of path tracking
 		 (dot product / SLP evaluation, dense matvec, LU factorization+solve) using
 		 GNU MPC (\c mpfr_complex) vs \c std::complex<double> on modern hardware.
-		 See \c benchmarks/arithmetic_cost.cpp for the methodology and compile instructions.
+		 See \c tuning/arithmetic_cost.cpp for the methodology and compile instructions.
 
 		 The paper \cite AMP2 reports \f$C(P) = 10.35 + 0.04 P_\mathrm{bits}\f$ (measured on
 		 a 2009 Opteron 250).  Converting to decimal digits gives \f$10.35 + 0.13 P\f$, which

--- a/docs/adr/0009-amp-endgame-internal-double-state.md
+++ b/docs/adr/0009-amp-endgame-internal-double-state.md
@@ -1,0 +1,142 @@
+# ADR-0009: AMP endgame needs internal double-precision state, mirroring the tracker
+
+**Status:** Proposed (design conclusion; implementation deferred)
+**Date:** 2026-06-09
+**Related:** ADR-0002 (endgame `Run` single-arg API), ADR-0007 (rational-config precision trap)
+
+## Context
+
+A performance investigation (PR with `SetStartPrecision` + explicit endgame-boundary precision,
+"Fix 1 + Fix 4") removed the dominant cost in adaptive (AMP) zero-dim solves: the pre-endgame
+homotopy track now runs in `std::complex<double>` for well-conditioned paths, giving ~5–7× on the
+`medium`/`large` benchmarks. That left a residual: the **endgame** is still far slower than a
+fixed-double solve of the same problem (`medium`: ~8.3 s adaptive vs ~0.5 s `mptype:0`).
+
+We chased two *lighter* alternatives to a full endgame change and both dead-ended at the same wall:
+
+1. **A `variant<Vec<dbl>,Vec<mpfr_complex>>` as the AMP *public contract* type.** Feasible and
+   moderate in the C++ core, but it leaks to the boundaries: Boost.Python/eigenpy have no
+   `std::variant` support (exposing it needs ~100 LOC of custom converters and breaks
+   `solutions()[i][j]` / `final_approximation()`), MPI needs variant serialization, and it does
+   nothing for *accuracy*. It also runs against the project's deliberate design that an AMP
+   algorithm carries **one authoritative multiprecision type** (Bertini 1 experience: threading two
+   types through every signature is miserable to reason about).
+
+2. **"Make precision-16 mpfr honestly mean double" / lower `LowestMultiplePrecision()` 20→16.** An
+   audit + a direct measurement disproved the premise:
+   - `LowestMultiplePrecision()=20` is the *escalation floor* (skip the useless 16–19-digit mpfr
+     dead zone), not the widening precision; asserts (amp_tracker.hpp:1507,1551) forbid mp ≤16.
+   - The tracker's double output is *already* honest mpfr@16 (`CopyFinalSolution`, amp_tracker.hpp:618,
+     at thread precision 16).
+   - **Measurement** (instrumented `medium_seeded`, probes in `base_endgame::Run`,
+     `CauchyEndgame::CircleTrack`, `AMPEndgame::RefineSampleImpl`, since reverted): the endgame
+     **already runs at precision 16** — 229/243 boundary points at 16; 1859/1975 `CircleTrack`s and
+     7436/7900 `RefineSampleImpl`s at `tracker_current_prec=16` (the remainder at 40 are genuinely
+     ill-conditioned paths that correctly escalated). So the endgame's *tracker calls already execute
+     in `std::complex<double>` internally*. There is no precision-20 contamination to remove, and no
+     speedup to be had from this idea.
+
+**Root of the residual.** Even though the tracker work inside the endgame runs in double, the
+endgame *carries every value as `mpfr_complex@16`*. Across ~10k circle-track/refine operations it
+pays mpfr allocate/convert churn at every tracker boundary, plus its own extrapolation / norm /
+dehomogenization arithmetic in mpfr@16. That cost is intrinsic to the endgame's base type being
+`mpfr_complex`. The only way to remove it is for the endgame to *execute in
+`std::complex<double>`* on the regimes where double suffices — which is precisely what the **tracker
+already does internally** and the endgame does not.
+
+The tracker solved this years ago: `current_space_`/`tentative_`/`temporary_` are a
+`tuple<Vec<dbl>,Vec<mpfr_complex>>` (via `NeededTypes`/`detail::TypeList`, config.hpp:333,
+typelist.hpp:45); `current_precision_` selects the live arm; `TrackerIteration()` dispatches **per
+step** to `TrackerIteration<dbl>` vs `<mpfr_complex>`; and `MultipleToDouble`/`DoubleToMultiple`
+convert the one current point on a precision transition. All of this is *internal* — the tracker's
+public contract is `mpfr_complex`.
+
+An earlier attempt to give the endgame a double path by templating `Run`/`RunImpl` on the complex
+type and adding a `RunImpl<dbl>` cascaded and was reverted: the endgame drives the **tracker** for
+its sample circles (`GetTracker().TrackPath(...)`, cauchy.hpp:1040), and the AMP tracker's public
+`TrackPath` is mpfr-only. A `RunImpl<dbl>` would therefore require a *public double `TrackPath`* on
+the tracker — a second public type, contradicting the single-authoritative-type design.
+
+## Decision
+
+The AMP endgame should gain **internal double-precision state**, mirroring the tracker's existing
+internal variant/tuple pattern, **behind an unchanged `mpfr_complex` public contract**.
+
+Two distinct ideas must not be fused (an earlier draft did fuse them):
+
+- **Precision as honest provenance (prerequisite cleanup).** Today precision *shadows* the regime —
+  a widened double can land at 20 (via the parser floor and the double-meaning of
+  `LowestMultiplePrecision`), indistinguishable from a number that genuinely needed 20 digits. That
+  is a *bug*, not an inherent limit. Once the shadowing is fixed — decouple the two meanings of
+  `LowestMultiplePrecision` (dead-zone/escalation boundary vs. parser storage floor) and stop
+  widening double-regime values past `DoublePrecision()` — **a number's precision faithfully records
+  the precision of the process that computed it.** Precision then *is* provenance (of precision), and
+  serves as the regime signal directly, exactly as the tracker's `current_precision_` tag already
+  does. (It still does **not** record *accuracy* — how many of those digits are correct — which
+  remains separate metadata.)
+- **The double arm is for speed, not signaling.** Even with precision honest, doing arithmetic in
+  `mpfr@16` is ~100× slower than `std::complex<double>`. The dbl arm exists to *execute* the double
+  regime in native double; precision already tells you *which* regime you're in. The two are
+  orthogonal and reinforce each other: a dbl-arm value, widened to the contract, is an `mpfr@16` that
+  honestly reports "computed in double."
+
+Concretely:
+
+- Set the endgame's `NeededTypes` to `{dbl, mpfr_complex}` (as the AMP tracker does), instead of
+  `TypeList<BCT>`. The sample/time/derivative containers (`cauchy_samples_`, `pseg_samples_`, …) are
+  **already** `TupleOfSamps`/`TupleOfTimes` over `NeededTypes`, so they gain a `dbl` slot
+  automatically. Promote the remaining single-type state — `final_approximation_`,
+  `previous_approximation_` (currently `Vec<BCT>`, base_endgame.hpp:124), and `start_time_` /
+  `target_time_` — to the same tuple shape.
+- Track a **current precision regime** in the endgame and **dispatch the main loop per iteration**
+  on it, the way `Tracker::TrackerIteration()` does — rather than the present monolithic
+  `RunImpl<ComplexT>` (cauchy.hpp:1076) whose type is fixed for the whole run and so cannot change
+  regime mid-loop. The loop body becomes an outer driver owning the regime + tuple state, calling
+  templated per-iteration step functions.
+- On a double→multiprecision escalation (precision is expected to *rise* as the path converges
+  toward a singularity), **migrate the accumulated sample history** (the deques), not just one
+  point. Extend the existing deque-walking precision machinery — `ChangePrecision`,
+  `adaptive::EnsureAtUniformPrecision` (adaptive_precision_utilities.hpp), which today re-precision
+  mpfr samples to a uniform level — to convert the `dbl` arm into the `mpfr` arm at the regime
+  boundary (the endgame analog of `DoubleToMultiple`). Template `RefineSampleImpl` (currently
+  hardcoded `Vec<mpfr_complex>`, amp_endgame.hpp:94).
+- Prefer the **tuple + regime-tag** representation (the tracker's choice, and the containers are
+  already tuples) over a `std::variant` of the whole state. A variant is more honest that only one
+  arm is live, but forces `std::visit` at every state access for no functional gain here.
+
+Because all of this is internal, the **public contract stays `mpfr_complex`**: the Python bindings
+and the MPI serialization (`parallel/path_result.hpp`) are **unaffected**, and the design stays
+inside the one-authoritative-type philosophy — it is the *same* compromise already accepted for the
+tracker, applied one level up.
+
+## Consequences
+
+**Positive**
+- Removes the endgame's intrinsic mpfr@16 cost on well-conditioned regimes by executing in
+  `std::complex<double>` there; this is the remaining lever toward the ~88× that `mptype:0` shows is
+  achievable.
+- Philosophically consistent: internal double, mpfr contract — identical posture to the tracker.
+- No Python/MPI blast radius (contract unchanged), unlike the variant-as-contract alternative.
+
+**Negative / cost**
+- The endgame's Cauchy/PowerSeries main loops must be **restructured** from a monolithic
+  `RunImpl<ComplexT>` into a per-iteration regime-dispatched driver — the bulk of the work, and
+  numerically delicate (this is the most sensitive code in the library).
+- New complexity the tracker does *not* have: migrating the **sample-history deques** across a
+  mid-run precision transition, not just a single current point.
+- `RefineSampleImpl` and any other hardcoded-mpfr endgame internals must be templated; the fixed
+  (double / multiple) precision endgames must continue to compile with single-type `NeededTypes`.
+
+**Does not address**
+- **Accuracy** (how many digits are *correct*) remains orthogonal: it is carried separately in
+  `SolutionMetaData` (`accuracy_estimate`, `condition_number`, `newton_residual`; computed in
+  cauchy.hpp). This internal-double change neither solves nor worsens it. A unified
+  precision-and-accuracy-aware solution type is a separate, larger decision.
+
+## Status / next step
+
+Recorded as the agreed *direction*; implementation is **deferred** (the loop restructuring is
+substantial and delicate). The shipped Fix 1 + Fix 4 stand independently. If/when pursued, the first
+implementation milestone is hoisting the Cauchy main loop into a per-iteration regime-dispatched
+driver over tuple state, with a double→mp deque-migration step, validated against the full C++ +
+pytest suites and the seeded benchmarks.

--- a/tuning/arithmetic_cost.cpp
+++ b/tuning/arithmetic_cost.cpp
@@ -45,11 +45,11 @@
  *       -I/home/helper/micromamba/envs/b2-ubuntu/include \
  *       -L/home/helper/micromamba/envs/b2-ubuntu/lib \
  *       -Wl,-rpath,/home/helper/micromamba/envs/b2-ubuntu/lib \
- *       benchmarks/arithmetic_cost.cpp -o benchmarks/arithmetic_cost \
+ *       tuning/arithmetic_cost.cpp -o tuning/arithmetic_cost \
  *       -lmpfr -lgmp -lmpc
  *
  * Run:
- *   ./benchmarks/arithmetic_cost
+ *   ./tuning/arithmetic_cost
  */
 
 #include <boost/multiprecision/mpc.hpp>


### PR DESCRIPTION
## Summary

The default adaptive (AMP) zero-dim solve was running the **entire homotopy in MPFR** even for trivially-conditioned systems — forcing fixed double (`mptype:0`) was 55–88× faster and gave identical solutions. This PR lands two of the underlying precision-handling fixes for a measured **5–7×** speedup (for small examples), with no change to results.

## Root cause

A default solve sets `initial_ambient_precision = DoublePrecision() = 16` and `SetThreadPrecision(16)` — both correct — but the total-degree start-point generator's arithmetic widens the point to **precision 20** (its own comment flags this as issue #308: *"prec16 / ulonglog = prec19"*). So `initial_precision_ = Precision(start_point) = 20`, the AMP tracker starts every path in MPFR, and short well-conditioned paths never claw back to double. callgrind on a 27-path cubic showed **30.6 B instructions**, ~100% MPFR/GMP, with the double evaluator called only ~2×/path.

## Changes

**Fix 1 — start the pre-endgame track at the intended ambient precision.** Call the existing `AMPTracker::SetStartPrecision(initial_ambient_precision)` before the before-EG `TrackPath` (guarded by `if constexpr`, AMP-only), and clear it immediately after so it can't leak into the endgame, which shares the same tracker instance.

**Fix 4 — carry the path's working precision explicitly into the endgame.** The during-EG setup inferred precision from `Precision(bdry_point)`, but the boundary point is always stored as the tracker's multiprecision `BaseComplexT`; a path that tracked in double is widened on output, so its mantissa precision is meaningless. `EGBoundaryMetaData` (and the MPI `PathBeforeEGResult`) now carries an explicit precision from `tracker.CurrentPrecision()`. No optionals — a plain `unsigned` beside the always-multiprecision container.

Plus reproducible-benchmark inputs (`benchmark/inputs/*_seeded.b2`) — pinning `randomseed:` drops run-to-run variance from ~3× to <1%.

## Results (serial, seeded)

| input  | paths | before | after | speedup |
|--------|-------|--------|-------|---------|
| medium | 243   | 44.7 s | 8.3 s | 5.4× |
| large  | 729   |143.9 s |20.7 s | 7.0× |

Solution counts identical in every case.

## Testing

- All 10 C++ `ctest` suites pass (incl. 353 endgame cases + zero-dim).
- All 219 `pytest` tests pass (bindings rebuilt).
- MPI 2-rank solve verified (new serialized `boundary_precision` round-trips).

## Follow-up (not in this PR)

The residual cost is the AMP **endgame** running `mpfr_complex` even at precision 16 — it has no `std::complex<double>` execution path, and the AMP tracker's public `TrackPath` is mpfr-only. Closing that to ~88× is a tracker+endgame co-change: expose a double-precision `TrackPath` entry on the AMP tracker, then the endgame dual-typing follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)