### PR TITLE
fix(bindings): float()/complex() on multiprec scalars segfaulted via numpy recursion

### DIFF
--- a/python/test/classes/mpfr_test.py
+++ b/python/test/classes/mpfr_test.py
@@ -388,3 +388,31 @@ def test_change_prec_complex(cvals):
     t = t**(-2)
     assert mp.abs(t.real - mp.Float("0.16560329111110602501494676510297183141930819429")) <= tol
     assert mp.abs(t.imag - mp.Float("0.028838165251841866149715852522538399390278791818")) <= tol
+
+
+# --- conversion to python builtins ---
+# regression: without __float__/__complex__ on the bound scalar types, CPython's
+# conversion fell into the numpy user-dtype dispatch and recursed until the C
+# stack overflowed (SIGSEGV).  values chosen exactly representable in binary.
+
+def test_float_of_Float():
+    assert float(mp.Float("2.5")) == 2.5
+
+
+def test_complex_of_Float():
+    assert complex(mp.Float("-0.25")) == -0.25 + 0j
+
+
+def test_complex_of_Complex():
+    assert complex(mp.Complex("2.5", "-0.25")) == complex(2.5, -0.25)
+
+
+def test_float_of_Complex_raises():
+    with pytest.raises(TypeError):
+        float(mp.Complex("2.5", "-0.25"))
+
+
+def test_complex_of_numpy_element():
+    import numpy as np
+    a = np.zeros((2,), dtype=mp.Complex)
+    assert complex(a[0]) == 0j

--- a/python_bindings/src/mpfr_export.cpp
+++ b/python_bindings/src/mpfr_export.cpp
@@ -384,6 +384,10 @@ namespace bertini{
 
 			.def(init<mpz_int>((arg("self"),arg("val")),"Construct an variable-precision float from an arbitrary-precision integer."))
 
+			// without an explicit __float__, CPython's float()/complex() fall into the
+			// numpy user-dtype dispatch and recurse until the C stack overflows (SIGSEGV)
+			.def("__float__", +[](T const& x) { return x.convert_to<double>(); }, (arg("self")), "convert to a python float.  truncates to double precision, losing digits beyond the 16th -- for full precision, use strings.")
+
 			.def(RealStrVisitor<T>())
 			.def(PrecisionVisitor<T>())
 
@@ -472,6 +476,12 @@ namespace bertini{
 
 			.def(init<mpz_int>((arg("self"),arg("real")),"Construct variable-precision complex number from an arbitrary-precision integer, with 0 imaginary part"))
 			.def(init<mpz_int, mpz_int>((arg("self"),arg("real"),arg("imag")),"Construct variable-precision complex number from a pair of arbitrary-precision integers"))
+
+			// without an explicit __complex__, CPython's complex() falls into the
+			// numpy user-dtype dispatch and recurses until the C stack overflows (SIGSEGV)
+			.def("__complex__", +[](T const& z) { return std::complex<double>(z.real().convert_to<double>(), z.imag().convert_to<double>()); }, (arg("self")), "convert to a python complex.  truncates to double precision, losing digits beyond the 16th -- for full precision, use strings.")
+			// raise the TypeError ourselves; the slot-less fallback path crashes the same way
+			.def("__float__", +[](T const&) -> double { PyErr_SetString(PyExc_TypeError, "can't convert Complex to float; use complex(), or .real/.imag"); boost::python::throw_error_already_set(); return 0.0; }, (arg("self")), "raises TypeError, as for python complex")
 
 			.def(ComplexVisitor<T>())
 


### PR DESCRIPTION
## Summary

`float(multiprec.Float)` and `complex(multiprec.Complex)` crashed with SIGSEGV: the bound scalar classes had no `__float__`/`__complex__`, so CPython's conversion fell into the numpy user-dtype dispatch (Float/Complex are eigenpy-registered dtypes), which called `PyNumber_Float` on the object again — unbounded recursion until the C stack overflowed. Same family as the `Float.__eq__` recursion fixed 2026-06-06. `Int`/`Rational` are not numpy-registered and always raised clean TypeErrors.

Fix: a real `__float__` on `Float` and `__complex__` on `Complex` (truncating to double, documented in the docstrings), plus an explicit TypeError-raising `__float__` on `Complex` — matching python complex semantics — because the slot-less fallback path is exactly the one that crashes.

Found while investigating sympy interop: this blocked the natural way to hand solution values to sympy or any plain-python consumer.

## Test plan

- [x] 5 regression tests in mpfr_test.py, incl. conversion of a numpy array element (`complex(np.zeros(2, dtype=Complex)[0])`)
- [x] original segfault repro now returns values
- [x] full pytest 224 passed on this branch
- [x] CI matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)