### PR TITLE
docs(adr): ADR-0010/0011/0012 for the function_tree overhaul; index + 0006 updates

### DIFF
--- a/docs/adr/0006-eigenpy-uninitialized-numpy-slot-guards.md
+++ b/docs/adr/0006-eigenpy-uninitialized-numpy-slot-guards.md
@@ -112,3 +112,13 @@ Regression tests live in
   `Eigen::Ref`* converter corrupting an *adjacent argument's* storage. This ADR is about
   *uninitialized dtype slots*. Both are eigenpy-interaction hazards with workarounds on our
   side, not upstream.
+
+- **A third pathology in the same family (fixed 2026-06-11, PR #8):** because
+  Float/Complex are numpy-registered dtypes, `float()`/`complex()` on the bound
+  scalars with no `__float__`/`__complex__` fell into the numpy user-dtype dispatch,
+  which re-invoked `PyNumber_Float` — unbounded recursion → C-stack overflow SIGSEGV
+  (same family as the `Float.__eq__` recursion of 2026-06-06). The bound scalar
+  classes now define `__float__`/`__complex__` explicitly (and a TypeError-raising
+  `__float__` on Complex, since the slot-less fallback is exactly the crashing path).
+  Rule of thumb: numpy-registered scalar types must define every numeric-conversion
+  dunder a Python consumer could trigger; absence means recursion, not a TypeError.

--- a/docs/adr/0010-function-tree-single-inheritance-capability-classes.md
+++ b/docs/adr/0010-function-tree-single-inheritance-capability-classes.md
@@ -1,0 +1,64 @@
+# ADR-0010: function_tree uses single inheritance; cross-cutting traits are capability classes
+
+**Status:** Accepted
+**Date:** 2026-06-11 (PR #6)
+
+## Context
+
+Every class in `function_tree/` inherited with `public virtual`, forced by exactly two
+diamond sources:
+
+1. `EnableSharedFromThisVirtual<T> : public virtual Node` — a mixin giving derived
+   classes a typed `shared_from_this`. Mixed into ~24 concrete classes, it created a
+   diamond with each class's real base chain (its own comment said it existed to
+   "solve the diamond problem" — the one it created). It was barely load-bearing:
+   every SLP call site already did its own `dynamic_pointer_cast` on
+   `Node::shared_from_this()`; the single typed caller was `Variable::Differentiate`.
+2. `Pi`/`E : public virtual Number, public virtual NamedSymbol` — the only genuine
+   semantic diamond (both bases derive from `Symbol`).
+
+Costs of the virtual inheritance: dynamic base-pointer adjustments in the eval hot
+paths, awkward `dynamic_pointer_cast` where a static cast should do, dual-path
+serialization for Pi/E (`base_object<Number>` *and* `base_object<NamedSymbol>` into a
+shared virtual base), constructor rules that let derived classes initialize
+grandparent bases (six trig ctors did), and a Python-visible hierarchy that could not
+be expressed in single-inheritance binding frameworks (nanobind, a likely future
+target — see the migration assessment notes).
+
+Which base do Pi/E keep? Differentiation's constant detection does
+`dynamic_pointer_cast<Number>` (`SumOperator::Differentiate`), and Pi/E flow through
+it — so they must remain `Number`s. Nothing in core ever casts to `NamedSymbol`; its
+only contribution is a `name_` string and a one-line `print`.
+
+## Decision
+
+- **Delete the mixin.** `Node` keeps plain `std::enable_shared_from_this<Node>`; the
+  one typed caller casts explicitly (`static_pointer_cast`, valid under non-virtual
+  inheritance).
+- **Cross-cutting traits become capability classes that do NOT derive from Node.**
+  `Named` (symbol.hpp) carries `name_`/`name()`; `Pi : public Number, public Named`.
+  A capability class adds no second path to the Node root, needs no vtable (protected
+  non-virtual destructor), and costs nothing in the bound hierarchy.
+- **De-virtualize the whole subsystem**: all `public virtual` base specifiers in
+  function_tree became plain `public`, including `Node : VisitableBase<>` (its sole
+  inheritor). Derived constructors initialize only their direct base (trig ctors call
+  `TrigOperator(N)`, which forwards).
+- Python bindings: Pi/E declare `bases<Number>` and apply `NamedSymbolVisitor`
+  directly (they no longer descend from `AbstractNamedSymbol`), so `pi.name` is
+  unchanged from Python.
+
+## Consequences
+
+**Positive**
+- Static base adjustments; plain `shared_from_this`; single-path serialization;
+  every bound class is straightforwardly single-inheritance (nanobind-ready).
+- The hierarchy is honest: one IS-A chain per class, capabilities by composition.
+
+**Negative / to watch**
+- Object layout and Pi/E archive layout changed: anything linking the old
+  `libbertini2` needs a rebuild (automatic in-repo; no archives persist across
+  versions).
+- New classes must NOT reintroduce a second Node-derived base. If a node needs a
+  cross-cutting trait, write a capability class like `Named`, not a second Node base.
+- Grep-proof used in CI review: `grep -rn "public  *virtual" core/include/bertini2/function_tree/`
+  must stay empty.

--- a/docs/adr/0011-differentiation-simplified-construction-no-mutation.md
+++ b/docs/adr/0011-differentiation-simplified-construction-no-mutation.md
@@ -1,0 +1,69 @@
+# ADR-0011: Differentiation emits already-simplified trees; held functions are never mutated
+
+**Status:** Accepted
+**Date:** 2026-06-11 (PR #7)
+
+## Context
+
+Derivative trees came out full of junk (`(0*x^2*1+2*x*1*3*1+0*3*x^2)*y+...` for fxx of
+`x^3*y`). Two root causes:
+
+1. The ad-hoc pruning inside `Differentiate()` was type-narrow:
+   `MultOperator::Differentiate` cast candidate derivatives to **`Float`** only, while
+   the chain rules actually emit `Integer(0)`/`Integer(1)` — so the zero/one terms
+   sailed through. (`SumOperator` cast to `Number` and worked.)
+2. The cleanup path was worse than the disease: `Simplify()` / `EliminateZeros` /
+   `EliminateOnes` / `ReduceDepth` all **mutate trees in place** (swapping
+   `operands_`/`signs_` vectors), and `DefaultAutoSimplify()` was `true`, so plain
+   `System::Differentiate()` ran that machinery over derivative trees — which **share
+   subtrees with the user's original functions**. Holding `f` while differentiating a
+   System could restructure `f` itself (and System copies share whole trees, making
+   this thread-hostile as well).
+
+A user holding `f` (or any subexpression of it) must never observe it change because
+something was differentiated; and a derivative must never sprout variables that were
+not in `f`.
+
+## Decision
+
+**Simplify at construction time inside `Differentiate()`; never rewrite after the fact.**
+
+- `Node` gains exact `IsLiteralZero()` / `IsLiteralOne()` (overridden by
+  Integer/Float/Rational on their stored literal values — no double-eval round trips,
+  no underflow surprises; non-literal expressions that happen to evaluate to zero are
+  deliberately NOT detected).
+- Free factories `SimplifiedNegate` / `SimplifiedSum` / `SimplifiedMult`
+  (arithmetic.hpp/.cpp) build **fresh** nodes from (operand, flag) pairs: literal
+  zeros vanish; a multiplied literal zero collapses the product; literal ones drop;
+  singletons unwrap; nested Mult factors flatten (reading, never writing, their
+  operands — flag-inverting through divisions); exact Integer/Rational constants fold
+  via mpq arithmetic (`6*x*y`, not `3*2*x*y`). **Floats are never folded** (precision
+  semantics stay untouched) and **a literal-zero divisor is left visible** (no
+  silent x/0 rewrites).
+- Every operator `Differentiate` (arithmetic + trig) routes through the factories.
+  `Differential` leaves (the no-arg Jacobian form) are not Numbers and are never
+  pruned.
+- **`DefaultAutoSimplify()` now returns `false`.** The post-hoc mutating pass is
+  redundant for derivatives and was the channel by which held functions changed.
+  `System::Simplify()` / `AutoSimplify(true)` remain available as *explicit* opt-ins —
+  mutation is then the user's deliberate choice.
+
+## Consequences
+
+**Positive**
+- Derivative degrees are exact (`fxx` of `x^3*y` has degree 2 — algebra, not an upper
+  bound); printed derivative forms are canonical and pinned by tests
+  (`d/dx sin(x)` is `cos(x)`).
+- The user-visible contract is enforced by `differentiation_safety_test.py`: f and
+  held subexpressions byte- and value-identical after every flavor of
+  differentiation; `gather_variables(f')` never a superset of f's; shared Variable
+  objects stay live (one `set_current_value` drives f and f').
+
+**Negative / to watch**
+- Behavior change: code relying on auto-simplify of derivatives must now call
+  `Simplify()` explicitly (and accept its in-place mutation of shared subtrees).
+- The in-place Eliminate*/ReduceDepth machinery still exists and still mutates; a
+  copy-on-write replacement is a possible future ADR. Do not wire it back into any
+  default path.
+- New `Differentiate` implementations must route through the factories; building
+  `Sum`/`Mult` nodes directly reintroduces junk.

--- a/docs/adr/0012-precedence-aware-printing-reparse-invariant.md
+++ b/docs/adr/0012-precedence-aware-printing-reparse-invariant.md
@@ -1,0 +1,39 @@
+# ADR-0012: Precedence-aware printing; printed trees must re-parse to the same values
+
+**Status:** Accepted
+**Date:** 2026-06-11 (PR #7)
+
+## Context
+
+Printing wrapped every operator unconditionally — `(((x^2)+((2*x)*y))-1)` — which made
+trees unreadable and derivative output absurd. Dropping parentheses is only safe if it
+can never change meaning: the printed form is fed back through the classic-format
+parser (round-trip tests, user-written input files derived from printed systems).
+
+## Decision
+
+- Nodes report a printing precedence (`PrecSum < PrecNegate < PrecMult < PrecPower <
+  PrecAtom`, node.hpp). A printing parent wraps a child **only when its precedence is
+  too low for the position it occupies**: subtracted/divided operands group their own
+  kind (`x-(y+z)`, `x/(y*z)`); `^` wraps any non-atom on either side (keeping
+  `x^y^z` unambiguous); negation wraps sums and other leading-`-` printers (never
+  emits `--`). Function-call operators (`sin(...)` etc.) and complex pairs
+  self-delimit as atoms.
+- **Literal constants participate in precedence by their printed shape, not their
+  type.** Negative literals report `PrecNegate` (they print a leading `-`).
+  Real-valued Rationals print bare as `p/q` — textually a division — so they report
+  `PrecMult`: `x/(1/3)`, never `x/1/3`, which would re-parse as `x/9`. Real-valued
+  Floats print bare; genuinely complex constants keep the self-delimiting `(re,im)`
+  pair form.
+
+## Consequences
+
+- The load-bearing invariant, enforced by `printing_test.py`'s round-trip test
+  (print → `bertini.parse` → identical evaluation): **removing parentheses must never
+  change the parsed value.** Any printer change must keep that test green.
+- A node whose printed form is textually an expression (contains an operator
+  character) must report the corresponding precedence, not `PrecAtom` — the rational
+  literal is the canonical example; a future literal type with a composite print form
+  needs the same care.
+- The exact printed forms are now a documented surface (tests assert them); cosmetic
+  printer changes are API-visible.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -26,3 +26,7 @@ Each ADR follows the template:
 | [0006](0006-eigenpy-uninitialized-numpy-slot-guards.md) | Guard numpy mpfr/mpc dtypes against uninitialized slots | Python bindings / numerics |
 | [0007](0007-rational-config-constants-default-construct-precision-trap.md) | Rational config constants, and the DefaultConstruct static-precision trap | Numerics / config |
 | [0008](0008-track-path-result-numpy-object-not-writable-ref.md) | Take writable-Ref binding outputs as numpy objects (supersedes 0001) | Python bindings |
+| [0009](0009-amp-endgame-internal-double-state.md) | AMP endgame needs internal double-precision state, mirroring the tracker _(proposed; implementation deferred)_ | Numerics / performance |
+| [0010](0010-function-tree-single-inheritance-capability-classes.md) | function_tree uses single inheritance; cross-cutting traits are capability classes | Core / function_tree |
+| [0011](0011-differentiation-simplified-construction-no-mutation.md) | Differentiation emits already-simplified trees; held functions are never mutated | Core / function_tree |
+| [0012](0012-precedence-aware-printing-reparse-invariant.md) | Precedence-aware printing; printed trees must re-parse to the same values | Core / function_tree |


### PR DESCRIPTION
ADRs for today's load-bearing decisions, so the *why* survives the session:

- **ADR-0010** — function_tree single inheritance; cross-cutting traits are capability classes (`Named`), not second Node bases (PR #6: why Pi/E kept `Number`, why the mixin died, the no-new-diamonds rule + grep-proof).
- **ADR-0011** — differentiation emits already-simplified trees (Simplified* factories, exact `IsLiteralZero/One`); held functions are never mutated; `DefaultAutoSimplify()` flipped to false, in-place `Simplify()` is explicit-opt-in only (PR #7).
- **ADR-0012** — precedence-aware printing and the re-parse invariant: printed trees must parse back to the same values; literal constants take the precedence of their printed *shape* (bare `p/q` binds like Mult) (PR #7).
- **ADR-0006** gains the third numpy-dispatch pathology (the `float()`/`complex()` recursion SIGSEGV fixed in PR #8) and the rule: numpy-registered scalar types must define every numeric-conversion dunder — absence means recursion, not TypeError.
- **README index**: adds 0009 (was missing from the table) through 0012.

Docs only; no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)