### PR TITLE
feat!: solutions in user coordinates by default; internal coords explicit; homogenize_point lift (ADR-0013)

### DIFF
--- a/core/include/bertini2/nag_algorithms/output.hpp
+++ b/core/include/bertini2/nag_algorithms/output.hpp
@@ -75,7 +75,7 @@ struct Classic <ZeroDim<A,B,C,D,E>>
 		NumVariables(out, zd);
 		Variables(out, zd,"\n\n");
 
-		const auto& s = zd.FinalSolutions();
+		const auto& s = zd.SolutionsInternalCoords();
 		const auto n = s.size();
 		for (decltype(s.size()) ii{0}; ii<n; ++ii)
 		{
@@ -99,9 +99,9 @@ struct Classic <ZeroDim<A,B,C,D,E>>
 	static 
 	void RawData(OutT & out, ZDT const& zd)
 	{
-		const auto n = zd.FinalSolutions().size();
+		const auto n = zd.SolutionsInternalCoords().size();
 		NumVariables(out, zd,"\n\n");
-		for (decltype(zd.FinalSolutions().size()) ii{0}; ii<n; ++ii)
+		for (decltype(zd.SolutionsInternalCoords().size()) ii{0}; ii<n; ++ii)
 		{
 			// only successful endgames have a final approximation to report
 			if (zd.FinalSolutionMetadata()[ii].endgame_success != SuccessCode::Success)
@@ -160,7 +160,7 @@ struct Classic <ZeroDim<A,B,C,D,E>>
 	static
 	void EndPoint(IndexT const& ind, OutT & out, ZDT const& zd, std::string const& additional = "")
 	{	
-		generators::Classic::generate(boost::spirit::ostream_iterator(out), zd.FinalSolutions()[ind]);
+		generators::Classic::generate(boost::spirit::ostream_iterator(out), zd.SolutionsInternalCoords()[ind]);
 		out << additional;
 	}
 
@@ -168,9 +168,9 @@ struct Classic <ZeroDim<A,B,C,D,E>>
 	static
 	void EndPointDehom(IndexT const& ind, OutT & out, ZDT const& zd, std::string const& additional = "")
 	{	
-		DefaultPrecision(Precision(zd.FinalSolutions()[ind]));
+		DefaultPrecision(Precision(zd.SolutionsInternalCoords()[ind]));
 
-		generators::Classic::generate(boost::spirit::ostream_iterator(out), zd.TargetSystem().DehomogenizePoint(zd.FinalSolutions()[ind]));
+		generators::Classic::generate(boost::spirit::ostream_iterator(out), zd.SolutionsUserCoords()[ind]);
 		out << additional;
 	}
 
@@ -202,7 +202,7 @@ struct Classic <ZeroDim<A,B,C,D,E>>
 	static
 	void EndPointMDRaw(IndexT const& ind, OutT & out, ZDT const& zd, std::string const& additional = "\n")
 	{
-		const auto& pt = zd.FinalSolutions()[ind];
+		const auto& pt = zd.SolutionsInternalCoords()[ind];
 		const auto& data = zd.FinalSolutionMetadata()[ind];
 		out << data.path_index << '\n'
 			<< Precision(pt) << '\n';
@@ -232,11 +232,9 @@ struct NonsingularSolutions
 	{
 		using BCT = typename AlgoTraits<AlgoT>::BaseComplexT;
 
-		const auto& sys = alg.TargetSystem();
-
 		SampCont<BCT> solns;
 
-		const auto& s = alg.FinalSolutions();
+		const auto& s = alg.SolutionsUserCoords();
 		const auto& m = alg.FinalSolutionMetadata();
 		const auto n = s.size();
 		for (decltype(s.size()) ii{0}; ii<n; ++ii)
@@ -245,8 +243,8 @@ struct NonsingularSolutions
 			if (d.endgame_success == SuccessCode::Success &&
 				d.multiplicity==1)
 			{
-				solns.push_back(sys.DehomogenizePoint(s[ii]));
-			}	
+				solns.push_back(s[ii]);
+			}
 		}
 
 		return solns;
@@ -264,16 +262,13 @@ struct AllSolutions
 	{
 		using BCT = typename AlgoTraits<AlgoT>::BaseComplexT;
 
-		const auto& sys = alg.TargetSystem();
-
 		SampCont<BCT> solns;
 
-		const auto& s = alg.FinalSolutions();
-		const auto& m = alg.FinalSolutionMetadata();
+		const auto& s = alg.SolutionsUserCoords();
 		const auto n = s.size();
 		for (decltype(s.size()) ii{0}; ii<n; ++ii)
 		{
-			solns.push_back(sys.DehomogenizePoint(s[ii]));
+			solns.push_back(s[ii]);
 		}
 
 		return solns;

--- a/core/include/bertini2/nag_algorithms/zero_dim_solve.hpp
+++ b/core/include/bertini2/nag_algorithms/zero_dim_solve.hpp
@@ -363,6 +363,8 @@ std::ostream& operator<<(std::ostream & out, const EGBoundaryMetaData<NumT> & me
 				using Phase2T      = parallel::Phase2Task<BaseComplexT>;
 				using DuringResult = parallel::PathDuringEGResult<BaseComplexT>;
 
+				solutions_user_coords_fresh_ = false;
+
 				PreSolveChecks();
 				PreSolveSetup();
 
@@ -727,6 +729,8 @@ std::ostream& operator<<(std::ostream & out, const EGBoundaryMetaData<NumT> & me
 			*/
 			void Solve()
 			{
+				solutions_user_coords_fresh_ = false;
+
 				PreSolveChecks();
 
 				PreSolveSetup();
@@ -744,9 +748,41 @@ std::ostream& operator<<(std::ostream & out, const EGBoundaryMetaData<NumT> & me
 
 
 			/**
-			\brief Get the final computed solutions
+			\brief Get the computed solutions, in the coordinates of the user's
+			original variables.
+
+			The stored internal solutions are dehomogenized through the target
+			system, once, lazily, into a cache; repeated calls return the cached
+			container by const reference.  Assumes post-solve serial access, like
+			the other accessors here.
+
+			\see SolutionsInternalCoords
 			*/
-			const auto& FinalSolutions() const
+			const auto& SolutionsUserCoords() const
+			{
+				if (!solutions_user_coords_fresh_)
+				{
+					solutions_user_coords_.clear();
+					solutions_user_coords_.reserve(solutions_post_endgame_.size());
+					for (const auto& s : solutions_post_endgame_)
+						solutions_user_coords_.push_back(this->TargetSystem().DehomogenizePoint(s));
+					solutions_user_coords_fresh_ = true;
+				}
+				return solutions_user_coords_;
+			}
+
+			/**
+			\brief Get the computed solutions in the solver's internal coordinates:
+			homogenized, and lying on the target system's patch.
+
+			These are the coordinates for continuing work -- start points for further
+			tracking re-using the target system's patch, refinement, etc.  Take a
+			user-coordinates point back to this representation with
+			System::HomogenizePoint on the target system.
+
+			\see SolutionsUserCoords
+			*/
+			const auto& SolutionsInternalCoords() const
 			{
 				return solutions_post_endgame_;
 			}
@@ -1355,6 +1391,8 @@ std::ostream& operator<<(std::ostream & out, const EGBoundaryMetaData<NumT> & me
 			/// computed data
 			SolnCont< EGBoundaryMetaDataT > solutions_at_endgame_boundary_; // the BaseRealT is the last used stepsize
 			SolnCont<Vec<BaseComplexT> > solutions_post_endgame_;
+			mutable SolnCont<Vec<BaseComplexT> > solutions_user_coords_; ///< lazy cache for SolutionsUserCoords; serial post-solve access assumed
+			mutable bool solutions_user_coords_fresh_ = false;
 			SolnCont<SolutionMetaDataT> solution_final_metadata_;
 
 

--- a/core/include/bertini2/system/system.hpp
+++ b/core/include/bertini2/system/system.hpp
@@ -1250,6 +1250,48 @@ namespace bertini {
 			}
 
 
+		/**
+		\brief Take a point in user (dehomogenized) coordinates into this system's internal coordinates.
+
+		Two steps: (1) insert the homogenizing coordinate, with value 1, for each affine
+		variable group, per the FIFO variable ordering; (2) if the system is patched,
+		rescale the result onto the patch.  The result is the projectively-identical
+		point expressed in the coordinates the solver works in -- suitable for
+		comparison with internal-coordinate solutions, or as a start point for further
+		tracking re-using this system's patch.
+
+		This is the inverse of DehomogenizePoint: DehomogenizePoint(HomogenizePoint(p)) == p.
+		On an unhomogenized, unpatched system this is the identity.
+
+		\tparam T the number-type.  Probably dbl=std::complex<double>, or mpfr_complex=bertini::mpfr_complex.
+
+		\throws std::runtime_error, if there is a mismatch between the number of variables in the input point, and the number of natural variables of the system.
+		*/
+		template<typename T>
+		Vec<T> HomogenizePoint(Vec<T> const& x) const
+			{
+
+				if (x.size()!=static_cast<Eigen::Index>(NumNaturalVariables())){
+					std::stringstream message;
+					message << "homogenizing point with incorrect number of coordinates. input has ";
+					message << x.size();
+					message << " but system expects ";
+					message << NumNaturalVariables();
+					throw std::runtime_error(message.str());
+				}
+
+				if (!have_ordering_)
+					ConstructOrdering();
+
+				auto x_homogenized = HomogenizePointFIFO(x);
+
+				if (IsPatched())
+					RescalePointToFitPatchInPlace(x_homogenized);
+
+				return x_homogenized;
+			}
+
+
 
 
 		/**
@@ -1677,6 +1719,7 @@ namespace bertini {
 					{
 						for (unsigned ii = 0; ii < hom_variable_groups_[hom_group_counter].size(); ++ii)
 							x_dehomogenized(dehom_index++) = x(hom_index++);
+						hom_group_counter++; // was missing; mattered only for multiple hom groups of differing sizes
 						break;
 					}
 					case VariableGroupType::Ungrouped:
@@ -1693,6 +1736,65 @@ namespace bertini {
 			}
 
 			return x_dehomogenized;
+		}
+
+
+		/**
+		\brief FIFO-ordering implementation of HomogenizePoint's first step: insert
+		the homogenizing coordinate, with value 1, at each affine group's slot.
+		Homogeneous groups and ungrouped variables pass through.  Patch rescaling is
+		the caller's job.
+		*/
+		template<typename T>
+		Vec<T> HomogenizePointFIFO(Vec<T> const& x) const
+		{
+			#ifndef BERTINI_DISABLE_ASSERTS
+			assert(homogenizing_variables_.size()==0 || homogenizing_variables_.size()==NumVariableGroups() && "must have either 0 homogenizing variables, or the number of homogenizing variables must match the number of affine variable groups.");
+			#endif
+
+			bool is_homogenized = homogenizing_variables_.size()!=0;
+			if (!is_homogenized)
+				return x;
+
+			Vec<T> x_homogenized(NumVariables());
+
+			unsigned affine_group_counter = 0;
+			unsigned hom_group_counter = 0;
+
+			unsigned dehom_index = 0; // index into x, the user-coordinates point
+			unsigned hom_index = 0; // index into x_homogenized, the point we are computing
+
+			for (auto& iter : time_order_of_variable_groups_)
+			{
+				switch (iter){
+					case VariableGroupType::Affine:
+					{
+						x_homogenized(hom_index++) = T(1);
+						for (unsigned ii = 0; ii < variable_groups_[affine_group_counter].size(); ++ii)
+							x_homogenized(hom_index++) = x(dehom_index++);
+						affine_group_counter++;
+						break;
+					}
+					case VariableGroupType::Homogeneous:
+					{
+						for (unsigned ii = 0; ii < hom_variable_groups_[hom_group_counter].size(); ++ii)
+							x_homogenized(hom_index++) = x(dehom_index++);
+						hom_group_counter++;
+						break;
+					}
+					case VariableGroupType::Ungrouped:
+					{
+						x_homogenized(hom_index++) = x(dehom_index++);
+						break;
+					}
+					default:
+					{
+						throw std::runtime_error("unacceptable VariableGroupType in HomogenizePointFIFO");
+					}
+				}
+			}
+
+			return x_homogenized;
 		}
 
 		void DifferentiateUsingDerivatives() const;

--- a/core/test/classes/system_test.cpp
+++ b/core/test/classes/system_test.cpp
@@ -989,6 +989,104 @@ BOOST_AUTO_TEST_CASE(system_dehomogenize_FIFO_one_hom_group)
 
 /**
 \class bertini::System
+\test \b system_homogenize_point_unhomogenized_is_identity HomogenizePoint on an unhomogenized, unpatched system returns the point unchanged.
+*/
+BOOST_AUTO_TEST_CASE(system_homogenize_point_unhomogenized_is_identity)
+{
+	bertini::System sys;
+	Var x = Variable::Make("x"), y = Variable::Make("y");
+	VariableGroup vars{x, y};
+	sys.AddVariableGroup(vars);
+
+	Vec<dbl> p(2);
+	p << dbl(3,4), dbl(4,5);
+
+	auto h = sys.HomogenizePoint(p);
+
+	BOOST_CHECK_EQUAL(h.size(),2);
+	BOOST_CHECK(abs(h(0) - p(0)) < threshold_clearance_d);
+	BOOST_CHECK(abs(h(1) - p(1)) < threshold_clearance_d);
+}
+
+
+/**
+\class bertini::System
+\test \b system_homogenize_point_FIFO_one_aff_group HomogenizePoint inserts the homogenizing coordinate with value 1, and dehomogenization inverts it.
+*/
+BOOST_AUTO_TEST_CASE(system_homogenize_point_FIFO_one_aff_group)
+{
+	bertini::System sys;
+	Var x = Variable::Make("x"), y = Variable::Make("y");
+	VariableGroup vars{x, y};
+	sys.AddVariableGroup(vars);
+
+	sys.Homogenize();
+
+	Vec<dbl> p(2);
+	p << dbl(3,4), dbl(4,5);
+
+	auto h = sys.HomogenizePoint(p);
+
+	BOOST_CHECK_EQUAL(h.size(),3);
+	BOOST_CHECK(abs(h(0) - dbl(1)) < threshold_clearance_d);
+	BOOST_CHECK(abs(h(1) - p(0)) < threshold_clearance_d);
+	BOOST_CHECK(abs(h(2) - p(1)) < threshold_clearance_d);
+
+	auto p_again = sys.DehomogenizePoint(h);
+	BOOST_CHECK_EQUAL(p_again.size(),2);
+	BOOST_CHECK(abs(p_again(0) - p(0)) < threshold_clearance_d);
+	BOOST_CHECK(abs(p_again(1) - p(1)) < threshold_clearance_d);
+}
+
+
+/**
+\class bertini::System
+\test \b system_homogenize_point_FIFO_mixed_groups HomogenizePoint handles affine groups, hom groups, and dehomogenization inverts it, with multiple group types in play.
+*/
+BOOST_AUTO_TEST_CASE(system_homogenize_point_FIFO_mixed_groups)
+{
+	bertini::System sys;
+	Var x = Variable::Make("x"), y = Variable::Make("y");
+	Var z = Variable::Make("z"), w = Variable::Make("w");
+	Var h1 = Variable::Make("h1"), h2 = Variable::Make("h2");
+	VariableGroup vars{x, y};
+	VariableGroup vars2{h1,h2};
+	VariableGroup vars3{z, w};
+	sys.AddVariableGroup(vars);
+	sys.AddHomVariableGroup(vars2);
+	sys.AddVariableGroup(vars3);
+
+	sys.Homogenize();
+
+	Vec<dbl> p(6);
+	p << dbl(3,4), dbl(4,5),
+		 dbl(10,11), dbl(11,12),
+		 dbl(6,7), dbl(7,8);
+
+	auto h = sys.HomogenizePoint(p);
+
+	BOOST_CHECK_EQUAL(h.size(),8);
+	// [hom0, x, y, hom-group passthrough, hom1, z, w]
+	BOOST_CHECK(abs(h(0) - dbl(1)) < threshold_clearance_d);
+	BOOST_CHECK(abs(h(1) - p(0)) < threshold_clearance_d);
+	BOOST_CHECK(abs(h(2) - p(1)) < threshold_clearance_d);
+	BOOST_CHECK(abs(h(3) - p(2)) < threshold_clearance_d);
+	BOOST_CHECK(abs(h(4) - p(3)) < threshold_clearance_d);
+	BOOST_CHECK(abs(h(5) - dbl(1)) < threshold_clearance_d);
+	BOOST_CHECK(abs(h(6) - p(4)) < threshold_clearance_d);
+	BOOST_CHECK(abs(h(7) - p(5)) < threshold_clearance_d);
+
+	auto p_again = sys.DehomogenizePoint(h);
+	BOOST_CHECK_EQUAL(p_again.size(),6);
+	for (int ii = 0; ii < 6; ++ii)
+		BOOST_CHECK(abs(p_again(ii) - p(ii)) < threshold_clearance_d);
+}
+
+
+
+
+/**
+\class bertini::System
 \test \b system_dehomogenize_FIFO_one_hom_group_two_ungrouped_vars Test the dehomogenization of a point using the first-in-first-out variable ordering which is standard in Bertini 1.
 */
 BOOST_AUTO_TEST_CASE(system_dehomogenize_FIFO_one_hom_group_two_ungrouped_vars)
@@ -1146,6 +1244,53 @@ BOOST_AUTO_TEST_CASE(system_estimate_coeff_bound_homogenized_quartic)
 	mpfr_float coefficient_bound = sys.CoefficientBound<mpfr>();
 	BOOST_CHECK(coefficient_bound < mpfr_float("10"));
 	BOOST_CHECK(coefficient_bound > mpfr_float("2"));
+}
+
+
+// NOTE: this test calls AutoPatch, whose coefficients come from the RandomMp
+// generator, which is deterministic-per-run but NOT reseedable (SetGlobalSeed
+// does not touch it).  Any AutoPatch call shifts that stream for every later
+// test in this binary, and system_estimate_coeff_bound_homogenized_quartic's
+// <10 threshold is sensitive to the draws.  Hence this test sits AFTER it.
+// The durable fix is making RandomMp seedable -- tracked RNG work.
+/**
+\class bertini::System
+\test \b system_homogenize_point_lands_on_patch On a patched system, HomogenizePoint produces a point ON the patch (rescaling it again is the identity), and dehomogenizing recovers the user point.
+*/
+BOOST_AUTO_TEST_CASE(system_homogenize_point_lands_on_patch)
+{
+	bertini::System sys;
+	Var x = Variable::Make("x"), y = Variable::Make("y");
+	VariableGroup vars{x, y};
+	sys.AddVariableGroup(vars);
+
+	sys.Homogenize();
+	sys.AutoPatch();
+
+	Vec<dbl> p(2);
+	p << dbl(3,4), dbl(4,5);
+
+	auto h = sys.HomogenizePoint(p);
+	BOOST_CHECK_EQUAL(h.size(),3);
+
+	// already on the patch: rescaling is the identity
+	auto h_rescaled = sys.RescalePointToFitPatch(h);
+	for (int ii = 0; ii < 3; ++ii)
+		BOOST_CHECK(abs(h_rescaled(ii) - h(ii)) < threshold_clearance_d);
+
+	// projectively the same point: dehomogenizing recovers the user coordinates
+	auto p_again = sys.DehomogenizePoint(h);
+	BOOST_CHECK(abs(p_again(0) - p(0)) < threshold_clearance_d);
+	BOOST_CHECK(abs(p_again(1) - p(1)) < threshold_clearance_d);
+
+	// and the round trip from an on-patch internal point is exact:
+	// Hom(Dehom(s)) == s for s on the patch
+	Vec<dbl> v(3);
+	v << dbl(2,3), dbl(3,4), dbl(4,5);
+	auto s = sys.RescalePointToFitPatch(v);
+	auto s_again = sys.HomogenizePoint(sys.DehomogenizePoint(s));
+	for (int ii = 0; ii < 3; ++ii)
+		BOOST_CHECK(abs(s_again(ii) - s(ii)) < threshold_clearance_d);
 }
 
 /**

--- a/docs/adr/0013-solutions-in-user-coordinates.md
+++ b/docs/adr/0013-solutions-in-user-coordinates.md
@@ -1,0 +1,55 @@
+# ADR-0013: Solutions are reported in user coordinates by default; internal coordinates are an explicit choice
+
+**Status:** Accepted
+**Date:** 2026-06-11
+
+## Context
+
+The zero-dim algorithm clones the supplied system (`CloneGiven`, policies.hpp),
+homogenizes and auto-patches the clone, and tracks in those coordinates. Solutions
+were stored AND returned in that internal representation: a 2-variable affine system
+yields 3-vectors `[h, x, y]`. Nothing in the python surface dehomogenized, the
+zero-dim python test asserted only solution *counts*, and the representation leaked
+solver implementation into every consumer — during the sympy-interop investigation
+it cost real time to recognize the "wrong-looking" values as patched projective
+coordinates.
+
+Both representations are legitimately needed: user coordinates for reading off
+answers, internal coordinates for continuing work (start points for further
+tracking, re-using the same patch, refinement).
+
+## Decision
+
+- **The unqualified accessor means user coordinates.** A user probably expects
+  solutions in their own variables; that is the default mode.
+- **Language-appropriate idiom for the toggle, same semantics:**
+  - python: pandas-style bool kwarg — `solutions(user_coords=True)`; passing
+    `False` is *declining* the usual behavior to get internal coordinates.
+  - C++: explicit method names — `SolutionsUserCoords()` /
+    `SolutionsInternalCoords()` (no mysterious bools at C++ call sites). The old
+    `FinalSolutions()` is gone ("Final" was filler; solutions are solutions).
+- **Reference semantics, no recompute:** the user-coordinates container is
+  dehomogenized once, lazily, into a solver-owned cache (invalidated when a solve
+  starts), returned by const reference; the python binding wraps it
+  (`return_internal_reference`) so repeated `solutions()[i]` neither recomputes nor
+  copies the container.
+- **The lift completes the round trip:** `System::HomogenizePoint` /
+  `homogenize_point` takes a user-coordinates point to internal coordinates —
+  insert the homogenizing coordinate (value 1) per affine group in FIFO layout,
+  then rescale onto the system's patch. It is the inverse of `DehomogenizePoint`.
+- **Coordinate labels come from the system that owns the representation:**
+  `variable_ordering` on your original system labels user coordinates;
+  `target_system()` (the prepared clone, now exposed) labels internal ones. No
+  separate ordering API.
+
+## Consequences
+
+- **Breaking change in python:** `solutions()` previously returned internal
+  coordinates. Code that wants the old behavior writes
+  `solutions(user_coords=False)`. The new value-asserting zero-dim tests pin both
+  representations and the round trip.
+- House style for future representation/mode toggles (e.g. an eventual NID
+  surface): bool kwarg in python with the default being what a user expects;
+  named methods in C++.
+- The lazy cache assumes post-solve serial access, like the algorithm's other
+  accessors; both `Solve()` and `RunParallel()` invalidate it on entry.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -30,3 +30,4 @@ Each ADR follows the template:
 | [0010](0010-function-tree-single-inheritance-capability-classes.md) | function_tree uses single inheritance; cross-cutting traits are capability classes | Core / function_tree |
 | [0011](0011-differentiation-simplified-construction-no-mutation.md) | Differentiation emits already-simplified trees; held functions are never mutated | Core / function_tree |
 | [0012](0012-precedence-aware-printing-reparse-invariant.md) | Precedence-aware printing; printed trees must re-parse to the same values | Core / function_tree |
+| [0013](0013-solutions-in-user-coordinates.md) | Solutions reported in user coordinates by default; internal coords explicit; HomogenizePoint lift | Core / API |

--- a/python/test/zero_dim/basics_test.py
+++ b/python/test/zero_dim/basics_test.py
@@ -79,3 +79,86 @@ def test_power_series_endgame_variant():
     solver.solve()
     solns = solver.solutions()
     assert len(solns) == 2
+
+
+# --- coordinate representations of solutions ---
+# solutions() returns USER coordinates by default (the variables you wrote);
+# solutions(user_coords=False) is the explicit opt-out giving the solver's
+# internal representation: homogenized, lying on the target system's patch.
+# see ADR-0013.
+
+import numpy as np
+
+INV_SQRT2 = 1 / np.sqrt(2)
+KNOWN_SOLUTIONS = (
+    np.array([complex(INV_SQRT2), complex(-INV_SQRT2)]),
+    np.array([complex(-INV_SQRT2), complex(INV_SQRT2)]),
+)
+
+
+def _as_complex(pt):
+    return np.array([complex(pt[i]) for i in range(len(pt))])
+
+
+def _distance_to_known(pt):
+    return min(np.linalg.norm(_as_complex(pt) - k) for k in KNOWN_SOLUTIONS)
+
+
+@pytest.fixture
+def solved():
+    """the circle/line system, its variables, and a solved solver."""
+    x, y = pb.Variable('x'), pb.Variable('y')
+    sys = pb.System()
+    sys.add_function(x**2 + y**2 - 1)
+    sys.add_function(x + y)
+    sys.add_variable_group(pb.VariableGroup([x, y]))
+    solver = ZeroDimCauchyAdaptivePrecisionTotalDegree(sys)
+    solver.solve()
+    return sys, solver
+
+
+def test_solutions_are_in_user_coordinates_by_default(solved):
+    _, solver = solved
+    sols = solver.solutions()
+    assert len(sols) == 2
+    for s in sols:
+        assert len(s) == 2  # the user's variables, not [h, x, y]
+        assert _distance_to_known(s) < 1e-8
+
+
+def test_solutions_internal_coords_are_explicit_optout(solved):
+    _, solver = solved
+    internal = solver.solutions(user_coords=False)
+    assert len(internal) == 2
+    ts = solver.target_system()
+    user = solver.solutions()
+    for i in range(2):
+        assert len(internal[i]) == 3  # [hom_var, x, y]
+        dehomed = ts.dehomogenize_point(internal[i])
+        assert np.linalg.norm(_as_complex(dehomed) - _as_complex(user[i])) < 1e-25
+
+
+def test_homogenize_point_reenters_internal_coordinates(solved):
+    """the lift: user coords -> homogenized, on the target system's patch."""
+    _, solver = solved
+    ts = solver.target_system()
+    user = solver.solutions()
+    internal = solver.solutions(user_coords=False)
+    for i in range(2):
+        lifted = ts.homogenize_point(user[i])
+        assert len(lifted) == 3
+        # projectively the same point, on the same patch -> numerically equal
+        assert np.linalg.norm(_as_complex(lifted) - _as_complex(internal[i])) < 1e-8
+        # already on the patch: rescaling is the identity
+        rescaled = ts.rescale_point_to_fit_patch(lifted)
+        assert np.linalg.norm(_as_complex(rescaled) - _as_complex(lifted)) < 1e-25
+
+
+def test_variable_orderings_label_the_representations(solved):
+    sys, solver = solved
+    user_names = [v.name for v in sys.variable_ordering()]
+    assert user_names == ['x', 'y']
+
+    internal_names = [v.name for v in solver.target_system().variable_ordering()]
+    assert len(internal_names) == 3
+    assert internal_names[1:] == ['x', 'y']  # leading entry is the homogenizing variable

--- a/python_bindings/include/zero_dim_export.hpp
+++ b/python_bindings/include/zero_dim_export.hpp
@@ -153,7 +153,17 @@ void ZDVisitor<AlgoT>::visit(PyClass& cl) const
 		"Run the zero-dim algorithm. Pass an mpi4py communicator for parallel execution.")
 	.def("get_tracker", GetTrackerMutable(), return_internal_reference<>(), "get a mutable reference to the Tracker being used")
 	.def("get_endgame", GetEndgameMutable(), return_internal_reference<>(), "get a mutable reference to the Endgame being used")
-	.def("solutions", &AlgoT::FinalSolutions, return_internal_reference<>(), "get the solutions at the target time")
+	.def("solutions",
+		+[](AlgoT const& self, bool user_coords) -> decltype(self.SolutionsInternalCoords()) {
+			return user_coords ? self.SolutionsUserCoords() : self.SolutionsInternalCoords();
+		},
+		(boost::python::arg("self"), boost::python::arg("user_coords") = true),
+		return_internal_reference<>(),
+		"get the computed solutions.  by default they are in the coordinates of YOUR variables (dehomogenized, depatched).  pass user_coords=False to decline, getting the solver's internal coordinates instead: homogenized, lying on the target system's patch -- the representation to use for continuing work.  the container is computed at most once per solve; repeated calls and indexing do not recompute it.")
+	.def("target_system",
+		+[](AlgoT& self) -> decltype(self.TargetSystem()) { return self.TargetSystem(); },
+		return_internal_reference<>(),
+		"get the prepared target system: the homogenized, auto-patched clone of the system you supplied.  its patch is the one internal-coordinate solutions lie on; use its dehomogenize_point/homogenize_point/variable_ordering to move between representations.")
 	.def("solution_metadata", &AlgoT::FinalSolutionMetadata, return_internal_reference<>(), "get the metadata for the solutions at the target time")
 	.def("endgame_boundary_data", &AlgoT::EndgameBoundaryData, return_internal_reference<>(), "get the data for the state at the endgame boundary (when we switch from regular tracking to endgame tracking")
 	;

--- a/python_bindings/src/system_export.cpp
+++ b/python_bindings/src/system_export.cpp
@@ -156,6 +156,11 @@ namespace bertini{
 			.def("dehomogenize_point",&SystemBaseT::template DehomogenizePoint<dbl>,(arg("self"), arg("point")), "Dehomogenize a vector of doubles (complex), using the variable structure in this System")
 			.def("dehomogenize_point",&SystemBaseT::template DehomogenizePoint<mpfr>,(arg("self"), arg("point")), "Dehomogenize a vector of mpfr's (complex), using the variable structure in this System")
 
+			.def("homogenize_point",&SystemBaseT::template HomogenizePoint<dbl>,(arg("self"), arg("point")), "Take a point in user (dehomogenized) coordinates to this system's internal coordinates: inserts the homogenizing coordinate for each affine variable group, then rescales onto the system's patch if patched.  Inverse of dehomogenize_point.")
+			.def("homogenize_point",&SystemBaseT::template HomogenizePoint<mpfr>,(arg("self"), arg("point")), "Take a point in user (dehomogenized) coordinates to this system's internal coordinates: inserts the homogenizing coordinate for each affine variable group, then rescales onto the system's patch if patched.  Inverse of dehomogenize_point.")
+
+			.def("variable_ordering",&SystemBaseT::VariableOrdering,(arg("self")), "The ordering of variables saying what each coordinate of a point in THIS system's coordinates means.  On your original system these are your variables; on a solver's target_system() the homogenizing variables appear too.")
+
 			.def(self_ns::str(self_ns::self))//, "String representation of the system"
 			.def(self_ns::repr(self_ns::self))//, "Round-trippable representation of the system.  Probably not functional"
 			.def(self += self)


### PR DESCRIPTION
## Summary

**Deliberate python API behavior change** (the `!`): `solver.solutions()` now returns solutions in **your variables** — a 2-variable system gives 2-vectors, not the internal `[h, x, y]` that confused everyone (including us, during the sympy investigation). A user probably expects solutions in their coordinates; that's the default mode now.

The two representations and the round trip:

- **`solutions(user_coords=True)`** (python, pandas-style bool; default) ↔ **`SolutionsUserCoords()`** (C++, explicit name — no mysterious bools at C++ call sites). Dehomogenized once, lazily, into a solver-owned cache; both python branches return reference wrappers, so repeated `solutions()[i]` neither recomputes nor copies.
- **`solutions(user_coords=False)`** ↔ **`SolutionsInternalCoords()`**: the homogenized vectors lying on the target system's patch — the representation for continuing work (start points re-using the patch, refinement). The old `FinalSolutions()` is gone ("Final" was filler).
- **`homogenize_point`** — the new lift, inverse of `dehomogenize_point`: insert the homogenizing coordinate per affine group, then rescale onto the system's patch. With the newly-bound **`target_system()`** (the prepared clone) and **`variable_ordering`** (labels come from whichever system's coordinates you hold), the full round trip is: solve → read answers in your variables → lift any point back onto the same patch → keep tracking.

Also fixed in passing: `DehomogenizePointFIFO`'s `Homogeneous` case never incremented `hom_group_counter` — latent bug for multiple hom groups of differing sizes.

Test notes: zero_dim `basics_test` finally asserts **values** (circle∩line = ±(1/√2, ∓1/√2) by distance), plus internal↔user correspondence, the lift landing on-patch, and ordering labels. C++ `system_test` covers HomogenizePoint layouts and round trips; the patch-using case is deliberately ordered after the coefficient-bound test because `AutoPatch` draws from the per-run-deterministic but **unseedable** `RandomMp` stream and that test's `<10` threshold is draw-sensitive (commented at the site; the durable fix is making RandomMp seedable — known RNG work item).

Heads-up: trivial README-index conflict with #11 (both append ADR rows) — whichever merges second resolves in seconds.

## Test plan

- [x] ctest 10/10 (incl. 4 new HomogenizePoint cases)
- [x] pytest 265 passed (incl. 4 new value-asserting coordinate tests)
- [x] CI matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)