### PR TITLE
feat(python): sympy bridge — exact two-way conversion + solve round trip

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -332,7 +332,7 @@ jobs:
           # (and locally); the older blame on "MPFR 3.1.6" was a misdiagnosis.  Running
           # the full suite here is the in-container proof of the fix.  If it flakes or
           # fails, revert to the import smoke test per ADR-0003 (kept there as fallback).
-          CIBW_TEST_REQUIRES_LINUX: "pytest numpy"
+          CIBW_TEST_REQUIRES_LINUX: "pytest numpy sympy"
           CIBW_TEST_COMMAND_LINUX: "cd {project} && python -m pytest python/test/ -q"
 
       - uses: actions/upload-artifact@v5
@@ -443,7 +443,7 @@ jobs:
 
       - name: Run Python tests
         run: |
-          pip install pytest
+          pip install pytest sympy
           python -m pytest python/test/ -v
 
   test_wheels_windows:
@@ -480,5 +480,5 @@ jobs:
           conda install -y python=${{ matrix.python-version }} --update-deps
           $py = "C:\Miniconda\envs\b2-windows\python.exe"
           & $py -m pip install --no-index --find-links dist/ bertini2
-          & $py -m pip install pytest
+          & $py -m pip install pytest sympy
           & $py -m pytest python/test/ -v

--- a/python/bertini/sympy_bridge.py
+++ b/python/bertini/sympy_bridge.py
@@ -1,0 +1,258 @@
+# This file is part of Bertini 2.
+#
+# python/bertini/sympy_bridge.py is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# python/bertini/sympy_bridge.py is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with python/bertini/sympy_bridge.py.  If not, see <http://www.gnu.org/licenses/>.
+#
+#  Copyright(C) Bertini2 Development Team
+#
+#  See <http://www.gnu.org/licenses/> for a copy of the license,
+#  as well as COPYING.  Bertini2 is provided with permitted
+#  additional terms in the b2/licenses/ directory.
+
+#  individual authors of this file include:
+#
+#  silviana amethyst
+#  University of Wisconsin - Eau Claire
+#  Spring 2026
+#
+
+"""Exact two-way conversion between sympy expressions and bertini function trees.
+
+sympy is an optional dependency of bertini; this module raises a helpful
+ImportError if it is missing.
+
+The conversions are EXACT for symbols and exact number types: sympy Rationals
+become bertini Rationals (never a float64 round-trip), Integers stay integers
+of any size, and Floats travel as strings carrying their precision.  This is
+why ``sympy.lambdify`` is deliberately not used -- it lowers ``Rational(1,3)``
+to a float literal.
+
+Forward (define in sympy, solve with bertini)::
+
+    import sympy
+    from bertini.sympy_bridge import system_from_sympy
+    from bertini.nag_algorithm import ZeroDimCauchyAdaptivePrecisionTotalDegree
+
+    x, y = sympy.symbols('x y')
+    sys = system_from_sympy([x**2 + y**2 - 1, x + y], [x, y])
+    solver = ZeroDimCauchyAdaptivePrecisionTotalDegree(sys)
+    solver.solve()
+    solver.solutions()   # in your variables, comparable with sympy.solve output
+
+Reverse (inspect bertini trees symbolically)::
+
+    from bertini.sympy_bridge import to_sympy
+    expr = to_sympy(sys.function(0).root())
+"""
+
+try:
+    import sympy as _sp
+except ImportError as _e:
+    raise ImportError(
+        "bertini.sympy_bridge requires sympy, which is an optional dependency "
+        "of bertini.  install it with: pip install sympy") from _e
+
+import bertini as _pb
+import bertini.function_tree as _ft
+from bertini.function_tree import operator as _op
+from bertini.function_tree import symbol as _sym
+from bertini import multiprec as _mp
+
+
+__all__ = ['from_sympy', 'to_sympy', 'system_from_sympy']
+
+
+_SYMPY_FUNCTION_MAP = {
+    _sp.sin: _ft.sin, _sp.cos: _ft.cos, _sp.tan: _ft.tan,
+    _sp.asin: _ft.asin, _sp.acos: _ft.acos, _sp.atan: _ft.atan,
+    _sp.exp: _ft.exp, _sp.log: _ft.log,
+}
+
+_HYPERBOLICS = (_sp.sinh, _sp.cosh, _sp.tanh, _sp.asinh, _sp.acosh, _sp.atanh)
+
+
+def _normalize_variables(variables):
+    """name -> bertini Variable dict, from a dict or iterable of Variables."""
+    if variables is None:
+        return {}
+    if isinstance(variables, dict):
+        return dict(variables)
+    return {v.name: v for v in variables}
+
+
+def from_sympy(expr, variables=None):
+    """Convert a sympy expression to a bertini function-tree node, exactly.
+
+    ``variables`` may be an iterable of bertini Variables or a name->Variable
+    dict; sympy Symbols are matched to them by name.  Symbols not supplied are
+    created fresh, and repeated occurrences share one Variable.
+
+    Raises NotImplementedError for sympy heads bertini has no node for
+    (e.g. the hyperbolics -- rewrite first: ``expr.rewrite(sympy.exp)``).
+    """
+    var_map = _normalize_variables(variables)
+
+    def walk(e):
+        if isinstance(e, _sp.Symbol):
+            name = e.name
+            if name not in var_map:
+                var_map[name] = _pb.Variable(name)
+            return var_map[name]
+        if isinstance(e, _sp.Integer):
+            return _sym.Integer(str(e))
+        if isinstance(e, _sp.Rational):  # after Integer: Integer is a Rational in sympy
+            return _sym.Rational(f'{e.p}/{e.q}')
+        if isinstance(e, _sp.Float):
+            return _sym.Float(str(e))
+        if e is _sp.pi:
+            return _sym.make_pi()
+        if e is _sp.E:
+            return _sym.make_e()
+        if e is _sp.I:
+            return _sym.make_i()
+        if isinstance(e, _sp.Add):
+            result = walk(e.args[0])
+            for a in e.args[1:]:
+                result = result + walk(a)
+            return result
+        if isinstance(e, _sp.Mul):
+            result = walk(e.args[0])
+            for a in e.args[1:]:
+                result = result * walk(a)
+            return result
+        if isinstance(e, _sp.Pow):
+            base, exponent = e.args
+            if isinstance(exponent, _sp.Integer):
+                return walk(base) ** int(exponent)
+            return walk(base) ** walk(exponent)
+        if isinstance(e, _HYPERBOLICS):
+            raise NotImplementedError(
+                f"bertini has no node for {type(e).__name__}; rewrite the "
+                f"expression first, e.g. expr.rewrite(sympy.exp)")
+        # note: sympy has no sqrt head -- sympy.sqrt(x) IS Pow(x, 1/2), handled above
+        for head, fn in _SYMPY_FUNCTION_MAP.items():
+            if isinstance(e, head):
+                return fn(walk(e.args[0]))
+        raise NotImplementedError(
+            f"no bertini equivalent for sympy node of type {type(e).__name__}: {e}")
+
+    return walk(_sp.sympify(expr))
+
+
+def system_from_sympy(exprs, variables):
+    """Build a bertini System from sympy expressions, with one affine variable group.
+
+    ``variables`` fixes the variable order (iterable of sympy Symbols, bertini
+    Variables, or names).  Returns the System; its ``variable_ordering()``
+    matches the order given.
+    """
+    bertini_vars = []
+    for v in variables:
+        if isinstance(v, _sp.Symbol):
+            bertini_vars.append(_pb.Variable(v.name))
+        elif isinstance(v, str):
+            bertini_vars.append(_pb.Variable(v))
+        else:
+            bertini_vars.append(v)  # assume already a bertini Variable
+
+    var_map = {v.name: v for v in bertini_vars}
+    sys = _pb.System()
+    for e in exprs:
+        sys.add_function(from_sympy(e, var_map))
+    sys.add_variable_group(_pb.VariableGroup(bertini_vars))
+    return sys
+
+
+def _exact_rational(r):
+    """bertini multiprec Rational (printed as p/q or integer) -> sympy Rational."""
+    return _sp.Rational(str(r))
+
+
+def to_sympy(node):
+    """Convert a bertini function-tree node to a sympy expression, exactly.
+
+    Walks the tree via the introspection API.  Variables map to sympy Symbols
+    by name; Integer/Rational leaves convert exactly; Float leaves carry their
+    mpfr precision into sympy's.
+
+    Raises NotImplementedError for Differential leaves (trees built by the
+    no-argument Jacobian form of differentiate; differentiate with an explicit
+    variable instead) and for node types with no sympy equivalent.
+    """
+    n = node
+
+    if isinstance(n, _op.Sum):
+        terms = []
+        for i in range(n.num_operands()):
+            t = to_sympy(n.operand(i))
+            terms.append(t if n.sign(i) else -t)
+        return _sp.Add(*terms)
+    if isinstance(n, _op.Mult):
+        factors = []
+        for i in range(n.num_operands()):
+            f = to_sympy(n.operand(i))
+            factors.append(f if n.mult_or_div(i) else _sp.Pow(f, -1))
+        return _sp.Mul(*factors)
+    if isinstance(n, _op.Power):
+        return _sp.Pow(to_sympy(n.get_base()), to_sympy(n.get_exponent()))
+    if isinstance(n, _op.IntegerPower):
+        return _sp.Pow(to_sympy(n.operand()), int(n.exponent))
+    if isinstance(n, _op.Negate):
+        return -to_sympy(n.operand())
+    if isinstance(n, _op.Sqrt):
+        return _sp.sqrt(to_sympy(n.operand()))
+    if isinstance(n, _op.Exp):
+        return _sp.exp(to_sympy(n.operand()))
+    if isinstance(n, _op.Log):
+        return _sp.log(to_sympy(n.operand()))
+    if isinstance(n, _op.Sin):
+        return _sp.sin(to_sympy(n.operand()))
+    if isinstance(n, _op.Cos):
+        return _sp.cos(to_sympy(n.operand()))
+    if isinstance(n, _op.Tan):
+        return _sp.tan(to_sympy(n.operand()))
+    if isinstance(n, _op.ArcSin):
+        return _sp.asin(to_sympy(n.operand()))
+    if isinstance(n, _op.ArcCos):
+        return _sp.acos(to_sympy(n.operand()))
+    if isinstance(n, _op.ArcTan):
+        return _sp.atan(to_sympy(n.operand()))
+
+    if isinstance(n, _sym.Differential):
+        raise NotImplementedError(
+            "this tree contains Differential leaves (built by the no-argument, "
+            "Jacobian form of differentiate); differentiate with an explicit "
+            "variable instead, e.g. f.differentiate(x)")
+    if isinstance(n, _sym.Variable):
+        return _sp.Symbol(n.name)
+    if isinstance(n, _sym.Pi):
+        return _sp.pi
+    if isinstance(n, _sym.E):
+        return _sp.E
+    if isinstance(n, _sym.Integer):
+        return _sp.Integer(int(str(n.value())))
+    if isinstance(n, _sym.Rational):
+        re = _exact_rational(n.value_real())
+        im = _exact_rational(n.value_imag())
+        return re if im == 0 else re + _sp.I * im
+    if isinstance(n, _sym.Float):
+        v = n.value()
+        digits = v.real.precision
+        # repr is full-precision (str truncates to ostream's default 6 digits)
+        re = _sp.Float(repr(v.real), digits)
+        if v.imag == _mp.Float(0):
+            return re
+        return re + _sp.I * _sp.Float(repr(v.imag), digits)
+
+    raise NotImplementedError(
+        f"no sympy equivalent for bertini node of type {type(n).__name__}: {n}")

--- a/python/test/classes/sympy_bridge_test.py
+++ b/python/test/classes/sympy_bridge_test.py
@@ -1,0 +1,190 @@
+# This file is part of Bertini 2.
+#
+# python/test/classes/sympy_bridge_test.py is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# python/test/classes/sympy_bridge_test.py is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with python/test/classes/sympy_bridge_test.py.  If not, see <http://www.gnu.org/licenses/>.
+#
+#  Copyright(C) Bertini2 Development Team
+#
+#  See <http://www.gnu.org/licenses/> for a copy of the license,
+#  as well as COPYING.  Bertini2 is provided with permitted
+#  additional terms in the b2/licenses/ directory.
+
+#  individual authors of this file include:
+#
+#  silviana amethyst
+#  University of Wisconsin - Eau Claire
+#  Spring 2026
+#
+
+"""Tests for the sympy bridge: exact two-way conversion and the solve round trip.
+
+The whole suite skips cleanly when sympy is not installed -- it is an optional
+dependency.
+"""
+
+import numpy as np
+import pytest
+
+sp = pytest.importorskip('sympy')
+
+import bertini as pb
+import bertini.multiprec as mp
+from bertini.function_tree import sin, gather_variables
+from bertini.function_tree.symbol import Rational
+from bertini.sympy_bridge import from_sympy, to_sympy, system_from_sympy
+
+
+@pytest.fixture
+def sxy():
+    return sp.symbols('x y')
+
+
+# --- forward: sympy -> bertini ---
+
+def test_forward_values_match(sxy):
+    sx, sy = sxy
+    expr = sx**3 * sy + 2 * sx * sy - sp.Rational(1, 3) + sp.sin(sx * sy) * sp.pi
+
+    x, y = pb.Variable('x'), pb.Variable('y')
+    tree = from_sympy(expr, [x, y])
+
+    x0, y0 = complex(1.25, -0.3), complex(-0.5, 0.75)
+    x.set_current_value(x0)
+    y.set_current_value(y0)
+
+    want = complex(expr.subs({sx: x0, sy: y0}).evalf())
+    got = tree.eval_d()
+    assert abs(got - want) / abs(want) < 1e-13
+
+
+def test_forward_reuses_supplied_variables(sxy):
+    sx, sy = sxy
+    x = pb.Variable('x')
+    tree = from_sympy(sx**2, [x])
+    x.set_current_value(complex(3.0, 0))
+    assert abs(tree.eval_d() - 9.0) < 1e-14
+    x.set_current_value(complex(2.0, 0))
+    tree.reset()
+    assert abs(tree.eval_d() - 4.0) < 1e-14  # same Variable object is live
+
+
+def test_forward_exact_rational(sxy):
+    sx, _ = sxy
+    tree = from_sympy(sp.Rational(1, 3) * sx)
+    # the coefficient leaf is an exact bertini Rational, not a float64 dump
+    leaf = next(tree.operand(i) for i in range(tree.num_operands())
+                if isinstance(tree.operand(i), Rational))
+    assert leaf.value_real() == mp.Rational('1/3')
+
+
+def test_forward_big_integer():
+    big = sp.Integer(10)**40 + 1
+    tree = from_sympy(big)
+    assert tree.value() == mp.Int('1' + '0' * 39 + '1')
+
+
+def test_forward_hyperbolic_raises(sxy):
+    sx, _ = sxy
+    with pytest.raises(NotImplementedError, match='rewrite'):
+        from_sympy(sp.sinh(sx))
+    # ...and the suggested rewrite makes it convertible
+    tree = from_sympy(sp.sinh(sx).rewrite(sp.exp), [pb.Variable('x')])
+    assert tree is not None
+
+
+def test_forward_unknown_head_raises(sxy):
+    sx, _ = sxy
+    with pytest.raises(NotImplementedError):
+        from_sympy(sp.gamma(sx))
+
+
+# --- reverse: bertini -> sympy ---
+
+def test_reverse_symbolic_equality(sxy):
+    sx, sy = sxy
+    x, y = pb.Variable('x'), pb.Variable('y')
+    tree = x**3 * y + 2 * x * y - Rational('1/3') * sin(x * y)
+    expr = to_sympy(tree)
+    want = sx**3 * sy + 2 * sx * sy - sp.Rational(1, 3) * sp.sin(sx * sy)
+    assert sp.simplify(expr - want) == 0
+
+
+def test_reverse_of_derivative(sxy):
+    """the original motivation: symbolic access to bertini's derivative trees."""
+    sx, sy = sxy
+    x, y = pb.Variable('x'), pb.Variable('y')
+    f = x**3 * y + sin(x * y)
+    fx = to_sympy(f.differentiate(x))
+    want = sp.diff(sx**3 * sy + sp.sin(sx * sy), sx)
+    assert sp.simplify(fx - want) == 0
+
+
+def test_reverse_jacobian_form_raises():
+    x = pb.Variable('x')
+    f = x**2
+    with pytest.raises(NotImplementedError, match='explicit'):
+        to_sympy(f.differentiate())  # no-arg form has Differential leaves
+
+
+def test_reverse_float_precision_carry():
+    mp.default_precision(50)
+    fifty = '1.' + '3' * 49
+    from bertini.function_tree.symbol import Float
+    expr = to_sympy(Float(fifty))
+    # the mpfr precision rides into sympy's Float; allow the last digits to round
+    assert str(expr)[:48] == fifty[:48]
+
+
+# --- round trips ---
+
+def test_round_trip_sympy_to_bertini_to_sympy(sxy):
+    sx, sy = sxy
+    cases = [
+        sx**2 + 2 * sx * sy - 1,
+        sp.Rational(3, 7) * sx - sp.exp(sy) + sp.sqrt(sx),
+        sp.cos(sx) * sp.pi + sp.E,
+    ]
+    for e in cases:
+        back = to_sympy(from_sympy(e))
+        assert sp.simplify(back - e) == 0
+
+
+def test_round_trip_bertini_to_sympy_to_bertini():
+    x, y = pb.Variable('x'), pb.Variable('y')
+    tree = x**2 * y - Rational('2/5') + sin(x)
+    rebuilt = from_sympy(to_sympy(tree), [x, y])
+    x.set_current_value(complex(0.6, -0.2))
+    y.set_current_value(complex(-1.1, 0.4))
+    assert abs(rebuilt.eval_d() - tree.eval_d()) < 1e-14
+    assert mp.abs(rebuilt.eval_mp() - tree.eval_mp()) <= mp.Float('1e-25')
+
+
+# --- the acceptance test: define in sympy, solve with bertini ---
+
+def test_end_to_end_solve_matches_sympy(sxy):
+    from bertini.nag_algorithm import ZeroDimCauchyAdaptivePrecisionTotalDegree
+
+    sx, sy = sxy
+    eqs = [sx**2 + sy**2 - 1, sx + sy]
+
+    sys = system_from_sympy(eqs, [sx, sy])
+    solver = ZeroDimCauchyAdaptivePrecisionTotalDegree(sys)
+    solver.solve()
+    got = [np.array([complex(s[i]) for i in range(len(s))]) for s in solver.solutions()]
+
+    exact = sp.solve(eqs, [sx, sy])
+    want = [np.array([complex(r[0]), complex(r[1])]) for r in exact]
+
+    assert len(got) == len(want) == 2
+    for g in got:
+        assert min(np.linalg.norm(g - w) for w in want) < 1e-8


### PR DESCRIPTION
## Summary

Closes the sympy interoperability project. `bertini.sympy_bridge` provides:

- **`from_sympy(expr, variables=None)`** — sympy → bertini, a recursive walker (deliberately **not** `lambdify`, which silently lowers `Rational(1,3)` to a float64 literal). Exact Rational/Integer transport, string-based Floats, `pi/E/I` → special nodes, trig/exp/log via the function_tree free functions. Hyperbolics raise `NotImplementedError` suggesting `.rewrite(sympy.exp)` (and the rewrite is tested to work).
- **`to_sympy(node)`** — bertini → sympy, dispatching over the introspection API from #7 (`operand(i)`/`sign(i)`/`mult_or_div(i)`, power parts, exact leaf values). Floats carry their mpfr precision into `sp.Float` (via `repr`; `str()` of multiprec scalars truncates to 6 digits — pre-existing wart, possible follow-up). Differential-leaf trees raise with a pointer to explicit-variable differentiation.
- **`system_from_sympy(exprs, variables)`** — sympy equations → ready-to-solve `System`.

sympy remains an **optional** dependency: helpful ImportError without it, tests `importorskip` (265 passed + 1 skipped without; 278 passed with). Added `sympy` to CI wheel-test deps on all three platforms.

**The acceptance test** is the project's definition of done: define circle∩line in sympy, solve with bertini, match `solutions()` (user coordinates — #12/ADR-0013) against `sp.solve`'s exact roots by distance. Also tested: symbolic equality of round trips (`sp.simplify(diff)==0`), exactness of `1/3` both ways, 50-digit Float precision carry, derivative trees inspected symbolically against `sp.diff` (the original motivation), and error paths.

Built on today's stack: introspection (#7), `float()`/`complex()` crash fix (#8), user-coordinate solutions + `homogenize_point` lift (#12).

## Test plan

- [x] full pytest 278 passed (13 new bridge tests)
- [x] sympy-absent smoke: helpful ImportError; suite 265 passed + 1 skipped
- [x] `sympy_bridge.py` verified present in the built wheel (git-tracked before build)
- [x] CI matrix (now exercising the bridge via the added test dep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)