### PR TITLE
fix(random): unify RandomMp onto the shared ThreadEngine so one seed controls all types

### DIFF
--- a/core/include/bertini2/random.hpp
+++ b/core/include/bertini2/random.hpp
@@ -44,8 +44,10 @@ namespace bertini
 {
 
 	/**
-	Returns this thread's canonical mt19937 engine.  All tracking-phase random
-	draws route through here so that ReseedThisThread() controls them uniformly.
+	Returns this thread's canonical mt19937 engine.  Every random draw of every
+	type routes through here — integer/rational (RandomInt/RandomRat), double
+	(rand_complex/RandReal), and multiprecision (RandomMp and everything built on
+	it) — so SetGlobalSeed()/ReseedThisThread() control them all uniformly.
 	*/
 	std::mt19937& ThreadEngine();
 
@@ -104,15 +106,19 @@ namespace bertini
 	 */
 	template <unsigned int length_in_digits>
 	mpfr_float RandomMp()
-	{	
+	{
 
 		using namespace boost::multiprecision;
    		using namespace boost::random;
 
    		static thread_local uniform_real_distribution<number<mpfr_float_backend<length_in_digits>, et_on> > distribution(0,1);
-   		static thread_local independent_bits_engine<mt19937, length_in_digits*1000L/301L, mpz_int> bit_generator;
 
-		mpfr_float a{distribution(bit_generator)};
+		// Draw from the single per-thread engine shared by every random type
+		// (RandomInt/RandomRat, the double-typed draws, and now the multiprecision
+		// ones), so SetGlobalSeed()/ReseedThisThread() control them all uniformly.
+		// The distribution fills the full mp mantissa from the 32-bit engine via
+		// generate_canonical.
+		mpfr_float a{distribution(ThreadEngine())};
 		return a;
 	}
 	

--- a/core/test/classes/fundamentals_test.cpp
+++ b/core/test/classes/fundamentals_test.cpp
@@ -27,6 +27,7 @@
 #include <boost/multiprecision/mpfr.hpp>
 
 #include <iostream>
+#include <vector>
 
 #include "bertini2/double_extensions.hpp"
 #include "bertini2/num_traits.hpp"
@@ -293,6 +294,42 @@ BOOST_AUTO_TEST_CASE(RandomMP_nondefault_precision_100)
 
 	BOOST_CHECK_EQUAL(a.precision(), 500);
 	BOOST_CHECK_EQUAL(100, DefaultPrecision());
+}
+
+// The multiprecision RandomMp generator now draws from the single per-thread
+// engine (ThreadEngine) shared by every random type, so SetGlobalSeed controls
+// it.  Before this it used a private, unseedable independent_bits_engine.  These
+// tests pin that contract: same seed -> identical mp draws; different seed ->
+// different draws.
+BOOST_AUTO_TEST_CASE(RandomMP_honors_global_seed)
+{
+	using namespace bertini;
+	DefaultPrecision(50);
+
+	auto draw_five = []{
+		std::vector<mpfr_float> v;
+		for (int ii = 0; ii < 5; ++ii)
+			v.push_back(RandomMp(50));
+		return v;
+	};
+
+	SetGlobalSeed(1234u);
+	auto first = draw_five();
+
+	SetGlobalSeed(1234u);
+	auto second = draw_five();
+
+	for (int ii = 0; ii < 5; ++ii)
+		BOOST_CHECK_EQUAL(first[ii], second[ii]);
+
+	SetGlobalSeed(5678u);
+	auto third = draw_five();
+
+	bool any_different = false;
+	for (int ii = 0; ii < 5; ++ii)
+		if (third[ii] != first[ii])
+			any_different = true;
+	BOOST_CHECK(any_different);
 }
 
 BOOST_AUTO_TEST_CASE(max_et_on)

--- a/core/test/classes/system_test.cpp
+++ b/core/test/classes/system_test.cpp
@@ -1228,6 +1228,11 @@ BOOST_AUTO_TEST_CASE(system_estimate_coeff_bound_homogenized_quartic)
 {
 	bertini::DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
 
+	// AutoPatch coefficients come from RandomMp; seeding makes this test's draws
+	// (and hence the <10 threshold below) deterministic regardless of which other
+	// tests ran first.  RandomMp now honors SetGlobalSeed (it shares ThreadEngine).
+	bertini::SetGlobalSeed(1u);
+
 	bertini::System sys;
 	Var x = Variable::Make("x"), y = Variable::Make("y"), z = Variable::Make("z");
 
@@ -1247,12 +1252,6 @@ BOOST_AUTO_TEST_CASE(system_estimate_coeff_bound_homogenized_quartic)
 }
 
 
-// NOTE: this test calls AutoPatch, whose coefficients come from the RandomMp
-// generator, which is deterministic-per-run but NOT reseedable (SetGlobalSeed
-// does not touch it).  Any AutoPatch call shifts that stream for every later
-// test in this binary, and system_estimate_coeff_bound_homogenized_quartic's
-// <10 threshold is sensitive to the draws.  Hence this test sits AFTER it.
-// The durable fix is making RandomMp seedable -- tracked RNG work.
 /**
 \class bertini::System
 \test \b system_homogenize_point_lands_on_patch On a patched system, HomogenizePoint produces a point ON the patch (rescaling it again is the identity), and dehomogenizing recovers the user point.

--- a/python/test/random/seeding_test.py
+++ b/python/test/random/seeding_test.py
@@ -1,0 +1,131 @@
+# This file is part of Bertini 2.
+#
+# python/test/random/seeding_test.py is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# python/test/random/seeding_test.py is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this file.  If not, see <http://www.gnu.org/licenses/>.
+#
+#  Copyright(C) Bertini2 Development Team
+#
+#  See <http://www.gnu.org/licenses/> for a copy of the license,
+#  as well as COPYING.  Bertini2 is provided with permitted
+#  additional terms in the b2/licenses/ directory.
+
+"""Determinism contract for the global RNG seed.
+
+set_random_seed() controls EVERY random type, including the multiprecision draws
+(complex_in_minus_one_to_one / complex_unit / real_as_complex, which feed gamma
+and patch coefficients).  These used to slip through an unseedable private engine;
+they now share the one per-thread engine, so the same seed reproduces a whole run.
+"""
+
+import numpy as np
+import pytest
+
+import bertini as pb
+from bertini.nag_algorithm import ZeroDimCauchyAdaptivePrecisionTotalDegree
+
+
+def _draw_sequence(n=6):
+    """A sequence of multiprecision random draws, as full-precision strings."""
+    return [repr(pb.random.complex_in_minus_one_to_one()) for _ in range(n)]
+
+
+def test_get_returns_what_was_set():
+    pb.random.set_random_seed(424242)
+    assert pb.random.get_random_seed() == 424242
+
+
+def test_same_seed_reproduces_multiprecision_draws():
+    pb.random.set_random_seed(1234)
+    first = _draw_sequence()
+
+    pb.random.set_random_seed(1234)
+    second = _draw_sequence()
+
+    assert first == second
+
+
+def test_different_seed_changes_multiprecision_draws():
+    pb.random.set_random_seed(1234)
+    first = _draw_sequence()
+
+    pb.random.set_random_seed(5678)
+    other = _draw_sequence()
+
+    assert first != other
+
+
+def test_unit_draws_also_honor_the_seed():
+    pb.random.set_random_seed(99)
+    first = [repr(pb.random.complex_unit()) for _ in range(4)]
+
+    pb.random.set_random_seed(99)
+    second = [repr(pb.random.complex_unit()) for _ in range(4)]
+
+    assert first == second
+
+
+# --- end-to-end: a whole solve is reproducible under a fixed seed ---
+# The solver's target system carries a random patch; solutions(user_coords=False)
+# exposes those patched (internal) coordinates.  Same seed -> identical patch ->
+# identical internal coordinates.  Either seed -> the same user solutions, since
+# the patch is just a representation.
+
+INV_SQRT2 = 1 / np.sqrt(2)
+KNOWN = (
+    np.array([complex(INV_SQRT2), complex(-INV_SQRT2)]),
+    np.array([complex(-INV_SQRT2), complex(INV_SQRT2)]),
+)
+
+
+def _solve_circle_line(seed):
+    """Set the seed, then build and solve x^2+y^2-1, x+y from scratch."""
+    pb.random.set_random_seed(seed)
+    x, y = pb.Variable('x'), pb.Variable('y')
+    sys = pb.System()
+    sys.add_function(x**2 + y**2 - 1)
+    sys.add_function(x + y)
+    sys.add_variable_group(pb.VariableGroup([x, y]))
+    solver = ZeroDimCauchyAdaptivePrecisionTotalDegree(sys)
+    solver.solve()
+    return solver
+
+
+def _as_complex(pt):
+    return np.array([complex(pt[i]) for i in range(len(pt))])
+
+
+def _sorted_internal(solver):
+    """Internal (patched) coords, sorted to a canonical order for comparison."""
+    internal = [_as_complex(s) for s in solver.solutions(user_coords=False)]
+    return sorted(internal, key=lambda v: (round(v[1].real, 9), round(v[1].imag, 9)))
+
+
+def test_same_seed_reproduces_patched_solution_coordinates():
+    a = _sorted_internal(_solve_circle_line(31415))
+    b = _sorted_internal(_solve_circle_line(31415))
+
+    assert len(a) == len(b) == 2
+    for va, vb in zip(a, b):
+        # identical seed -> identical random patch -> identical internal coords
+        assert np.linalg.norm(va - vb) < 1e-10
+
+
+def test_user_solutions_are_seed_independent():
+    """The patch differs by seed, but the actual solutions do not."""
+    for seed in (31415, 27182):
+        solver = _solve_circle_line(seed)
+        sols = solver.solutions()
+        assert len(sols) == 2
+        for s in sols:
+            d = min(np.linalg.norm(_as_complex(s) - k) for k in KNOWN)
+            assert d < 1e-8


### PR DESCRIPTION
## Problem

There were two independent RNG engines and the seed only reached one. `ThreadEngine()` (reseeded by `SetGlobalSeed` / `set_random_seed`) already drove the integer, rational, and double draws. But `RandomMp<N>()` had its own private `independent_bits_engine` (`random.hpp`), default-seeded at the fixed value 5489 and unreachable from the seed. Every **multiprecision** draw — gamma, patch coefficients, slices — flowed through that private engine, so `set_random_seed` silently failed to make those reproducible.

## Fix

`RandomMp<N>()` now draws from `ThreadEngine()`, the same per-thread engine everything else uses; the private engine is deleted. After this, the existing `SetGlobalSeed` / `ReseedThisThread` and Python `set_random_seed` / `get_random_seed` cover **all** types with no new plumbing — one engine, one seed, shared across types. The boost `uniform_real_distribution` fills the full mp mantissa from the 32-bit engine via `generate_canonical`.

## Tests

- **C++** `RandomMP_honors_global_seed` (`fundamentals_test.cpp`): same seed → identical mp draws; different seed → different.
- **Python** `python/test/random/seeding_test.py` (6 cases) including end-to-end "same seed reproduces patched solution coordinates."
- Removed the test-ordering "standing tax" in `system_test.cpp` by seeding the patch-sensitive coefficient-bound test directly.

## Verification

- `ctest` 10/10 suites pass; `pytest` 284 passed.
- CLI: same `randomseed:` → byte-identical `raw_data`; different seed → differs, same solution count.

## Note

The multiprecision random *value stream* shifts one time (new engine). Only precision-asserting `RandomMp` tests existed, so nothing pinned breaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)