### PR TITLE
Randomize overdetermined systems via a first-class RandomizationBlock

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -115,6 +115,13 @@ jobs:
       - name: Install bertini from built wheel
         run: pip install --no-index --find-links dist/ bertini2
 
+      - name: Run tutorial doctests (Sphinx)
+        # Execute the `.. testcode::` / `>>>` blocks in the docs against the installed wheel, so
+        # the tutorials are verified code, not just prose.  Fails the build if any doctest fails.
+        working-directory: python/docs
+        run: |
+          sphinx-build -b doctest --keep-going source ../../build/docs/doctest
+
       - name: Build Python docs (Sphinx)
         working-directory: python/docs
         env:

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -696,6 +696,7 @@ if (ENABLE_UNIT_TESTING)
 		test/classes/products_of_linears_block_test.cpp
 		test/classes/linear_forms_block_test.cpp
 		test/classes/blend_block_test.cpp
+		test/classes/randomization_block_test.cpp
 		test/classes/system_blocks_test.cpp
 		test/classes/degrees_test.cpp
 		test/classes/class_test.cpp

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -697,6 +697,7 @@ if (ENABLE_UNIT_TESTING)
 		test/classes/linear_forms_block_test.cpp
 		test/classes/blend_block_test.cpp
 		test/classes/randomization_block_test.cpp
+		test/classes/moving_homotopy_test.cpp
 		test/classes/system_blocks_test.cpp
 		test/classes/degrees_test.cpp
 		test/classes/class_test.cpp

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -698,6 +698,7 @@ if (ENABLE_UNIT_TESTING)
 		test/classes/blend_block_test.cpp
 		test/classes/randomization_block_test.cpp
 		test/classes/moving_homotopy_test.cpp
+		test/classes/system_printing_test.cpp
 		test/classes/system_blocks_test.cpp
 		test/classes/degrees_test.cpp
 		test/classes/class_test.cpp

--- a/core/include/bertini2/system/blocks/blend_block.hpp
+++ b/core/include/bertini2/system/blocks/blend_block.hpp
@@ -68,6 +68,7 @@ follow-up (block-operand Clone semantics).
 #include "bertini2/num_traits.hpp"
 #include "bertini2/eigen_extensions.hpp"
 #include "bertini2/function_tree.hpp"
+#include "bertini2/system/blocks/describe.hpp"
 
 namespace bertini {
 namespace blocks {
@@ -112,6 +113,31 @@ public:
 	std::vector<Nd> const& Coefficients() const { return coefficients_; }
 	std::vector<OperandPtr> const& Operands() const { return operands_; }
 	Var const& PathVariable() const { return path_variable_; }
+
+	/// Human-facing description: terse shows the blend `f_a..f_b = c_0(t)*A + c_1(t)*B`, with the
+	/// coefficient nodes shown symbolically and the operands labelled A, B, ...; verbose lists each
+	/// operand's functions indented.
+	void Describe(std::ostream& out, size_t& row, VariableGroup const& /*vars*/, bool verbose) const
+	{
+		const size_t k = NumFunctions();
+		out << "  ";
+		describe_detail::PrintRowLabel(out, row, k);
+		out << " = ";
+		for (size_t i = 0; i < coefficients_.size(); ++i)
+			out << (i ? " + " : "") << "(" << coefficients_[i] << ")*"
+			    << static_cast<char>('A' + (i < 26 ? i : 25));
+		out << "   (blend of " << operands_.size() << " systems)\n";
+		row += k;
+		if (verbose)
+			for (size_t i = 0; i < operands_.size(); ++i)
+			{
+				const char label = static_cast<char>('A' + (i < 26 ? i : 25));
+				out << "    " << label << ":\n";
+				auto f = operands_[i]->NaturalFunctionsAsNodes();
+				for (size_t j = 0; j < f.size(); ++j)
+					out << "      " << label << "_" << j << " = " << f[j] << "\n";
+			}
+	}
 
 	/// The blend c_0(t)f_0 + c_1(t)f_1 + ... has, per function, the max degree of its operands
 	/// in the space variables (the t-coefficients are constant in space).

--- a/core/include/bertini2/system/blocks/block.hpp
+++ b/core/include/bertini2/system/blocks/block.hpp
@@ -71,6 +71,7 @@ detection trait below + static_assert), not via a C++20 concept.
 #include "bertini2/system/blocks/products_of_linears_block.hpp"
 #include "bertini2/system/blocks/linear_forms_block.hpp"
 #include "bertini2/system/blocks/blend_block.hpp"
+#include "bertini2/system/blocks/randomization_block.hpp"
 
 namespace bertini {
 namespace blocks {
@@ -120,13 +121,16 @@ static_assert(is_block_v<LinearFormsBlock>,
 
 } // namespace blocks
 
-// Forward declaration: BlendBlock holds its operands by shared_ptr<const System>, and a
-// System contains Blocks -- the template parameter keeps System a dependent name so the
-// recursive type closes without System being complete here.
+// Forward declaration: BlendBlock and RandomizationBlock hold their operands by
+// shared_ptr<System>, and a System contains Blocks -- the template parameter keeps System a
+// dependent name so the recursive type closes without System being complete here.  (For the
+// same reason these two block types are absent from the is_block_v static_assert list above:
+// detecting the contract instantiates their templated eval entry points, which need System
+// complete; that check happens structurally at the std::visit site instead.)
 class System;
 
 /// The closed set of evaluation blocks a System can be composed of.  Grows as block
 /// types are added (eventually a PolynomialBlock so the polynomial part is uniform too).
-using Block = std::variant<blocks::PolynomialBlock, blocks::ProductsOfLinearsBlock, blocks::LinearFormsBlock, blocks::BlendBlock<System>>;
+using Block = std::variant<blocks::PolynomialBlock, blocks::ProductsOfLinearsBlock, blocks::LinearFormsBlock, blocks::BlendBlock<System>, blocks::RandomizationBlock<System>>;
 
 } // namespace bertini

--- a/core/include/bertini2/system/blocks/describe.hpp
+++ b/core/include/bertini2/system/blocks/describe.hpp
@@ -1,0 +1,96 @@
+//This file is part of Bertini 2.
+//
+//describe.hpp is free software: you can redistribute it and/or modify
+//it under the terms of the GNU General Public License as published by
+//the Free Software Foundation, either version 3 of the License, or
+//(at your option) any later version.
+//
+//describe.hpp is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//GNU General Public License for more details.
+//
+//You should have received a copy of the GNU General Public License
+//along with describe.hpp.  If not, see <http://www.gnu.org/licenses/>.
+//
+// Copyright(C) Bertini2 Development Team
+
+/**
+\file bertini2/system/blocks/describe.hpp
+
+\brief Small shared helpers for the per-block `Describe` methods -- the human-facing printing of a
+block-composed System.  Each block prints the rows it owns, labelled by a running global index
+`f_k`.  Two levels: **terse** (default) uses placeholder symbols for matrices/coefficients so only
+the structure shows; **verbose** reveals the actual numbers.  This output is for reading, not for
+re-parsing.
+*/
+
+#pragma once
+
+#include <ostream>
+#include <string>
+
+#include "bertini2/num_traits.hpp"
+#include "bertini2/function_tree.hpp"
+
+namespace bertini {
+namespace blocks {
+namespace describe_detail {
+
+/// Print one (mpfr_complex) coefficient compactly: a real prints as its real part, a pure imaginary
+/// as `b*i`, otherwise as `(a+b*i)`.
+inline void PrintCoeff(std::ostream& out, mpfr_complex const& c)
+{
+	const bool re0 = (c.real() == 0), im0 = (c.imag() == 0);
+	if (im0)            out << c.real();
+	else if (re0)       out << c.imag() << "*i";
+	else                out << "(" << c.real() << "+" << c.imag() << "*i)";
+}
+
+/// `f_k` for a single row, or `f_a..f_b` for a contiguous range of `n` rows starting at `row`.
+inline void PrintRowLabel(std::ostream& out, size_t row, size_t n)
+{
+	out << "f_" << row;
+	if (n > 1)
+		out << "..f_" << (row + n - 1);
+}
+
+/// The augmenting variable list `[x, y, 1]` (affine) or `[h, x, y]` (homogeneous: no trailing 1).
+inline void PrintAugmentedVars(std::ostream& out, VariableGroup const& vars, size_t num_vars, bool homogeneous)
+{
+	out << "[";
+	for (size_t c = 0; c < num_vars && c < vars.size(); ++c)
+		out << (c ? ", " : "") << *vars[c];
+	if (!homogeneous)
+		out << ", 1";
+	out << "]";
+}
+
+/// One affine linear form, row r of an augmented coefficient matrix M (num_vars+1 cols affine, or
+/// num_vars cols homogeneous).  Verbose prints the actual sum `2*x + 1*y - 1`; otherwise nothing
+/// (the caller prints the placeholder `c.[...]`).
+inline void PrintLinearFormVerbose(std::ostream& out, Mat<mpfr_complex> const& M, Eigen::Index r,
+                                   VariableGroup const& vars, size_t num_vars, bool homogeneous)
+{
+	bool first = true;
+	const size_t ncol = homogeneous ? num_vars : num_vars + 1;
+	for (size_t c = 0; c < ncol; ++c)
+	{
+		mpfr_complex const& coeff = M(r, static_cast<Eigen::Index>(c));
+		if (coeff.real() == 0 && coeff.imag() == 0)
+			continue;
+		if (!first) out << " + ";
+		first = false;
+		out << "(";
+		PrintCoeff(out, coeff);
+		out << ")";
+		if (c < num_vars && c < vars.size())     // a variable column (the last affine column is the constant)
+			out << "*" << *vars[c];
+	}
+	if (first)
+		out << "0";
+}
+
+} // namespace describe_detail
+} // namespace blocks
+} // namespace bertini

--- a/core/include/bertini2/system/blocks/linear_forms_block.hpp
+++ b/core/include/bertini2/system/blocks/linear_forms_block.hpp
@@ -119,6 +119,13 @@ public:
 	/// Number of variables the block expects in the input vector.
 	size_t NumVariables() const { return num_vars_; }
 
+	/// The master coefficient matrix (one row per form).  Affine: num_vars+1 columns, the last being
+	/// the constant term.  Homogeneous (post-Homogenize): num_vars columns, all variable columns.
+	/// Exposed for the function-tree expansion (System::NaturalFunctionsAsNodes).
+	Mat<mpfr_complex> const& Coefficients() const { return coefficients_highest_precision_; }
+	/// Whether Homogenize has folded the constant column onto a homogenizing variable.
+	bool IsHomogenized() const { return homogeneous_; }
+
 	/// Linear forms do not depend on the path variable.
 	bool DependsOnPathVariable() const { return false; }
 

--- a/core/include/bertini2/system/blocks/linear_forms_block.hpp
+++ b/core/include/bertini2/system/blocks/linear_forms_block.hpp
@@ -51,6 +51,7 @@ mpfr copy.
 
 #include "bertini2/num_traits.hpp"
 #include "bertini2/eigen_extensions.hpp"
+#include "bertini2/system/blocks/describe.hpp"
 
 namespace bertini {
 namespace blocks {
@@ -125,6 +126,24 @@ public:
 	Mat<mpfr_complex> const& Coefficients() const { return coefficients_highest_precision_; }
 	/// Whether Homogenize has folded the constant column onto a homogenizing variable.
 	bool IsHomogenized() const { return homogeneous_; }
+
+	/// Human-facing description: terse shows the placeholder `c.[x, y, 1]` (a linear form whose
+	/// coefficients are hidden); verbose shows the actual affine combination `2*x + 1*y - 1`.
+	void Describe(std::ostream& out, size_t& row, VariableGroup const& vars, bool verbose) const
+	{
+		for (Eigen::Index r = 0; r < coefficients_highest_precision_.rows(); ++r)
+		{
+			out << "  f_" << row++ << " = ";
+			if (verbose)
+				describe_detail::PrintLinearFormVerbose(out, coefficients_highest_precision_, r, vars, num_vars_, homogeneous_);
+			else
+			{
+				out << "c.";
+				describe_detail::PrintAugmentedVars(out, vars, num_vars_, homogeneous_);
+			}
+			out << "\n";
+		}
+	}
 
 	/// Linear forms do not depend on the path variable.
 	bool DependsOnPathVariable() const { return false; }

--- a/core/include/bertini2/system/blocks/polynomial_block.hpp
+++ b/core/include/bertini2/system/blocks/polynomial_block.hpp
@@ -141,6 +141,14 @@ public:
 	size_t NumFunctions() const { return functions_.size(); }
 	bool DependsOnPathVariable() const { return static_cast<bool>(path_variable_); }
 
+	/// Human-facing description: one line per function, `f_k = <expression>`.  Polynomials are the
+	/// content, so terse and verbose are the same (the expression is shown either way).
+	void Describe(std::ostream& out, size_t& row, VariableGroup const& /*vars*/, bool /*verbose*/) const
+	{
+		for (auto const& f : functions_)
+			out << "  f_" << row++ << " = " << f->EntryNode() << "\n";
+	}
+
 	unsigned Precision() const { return precision_; }
 	void Precision(unsigned new_precision) const
 	{

--- a/core/include/bertini2/system/blocks/products_of_linears_block.hpp
+++ b/core/include/bertini2/system/blocks/products_of_linears_block.hpp
@@ -48,6 +48,7 @@ an mpfr master plus per-type working copies, with Precision() recasting the mpfr
 
 #include "bertini2/num_traits.hpp"
 #include "bertini2/eigen_extensions.hpp"
+#include "bertini2/system/blocks/describe.hpp"
 
 namespace bertini {
 namespace blocks {
@@ -106,6 +107,35 @@ public:
 	/// (#factors_i) x (num_vars+1), the last column being the constant/augmenting term.  Exposed
 	/// so the function-tree expansion (System::ExpandToFunctionTree) can rebuild f_i = prod_r L_r.
 	std::vector<Mat<mpfr_complex>> const& Factors() const { return factors_highest_precision_; }
+
+	/// Human-facing description: terse shows `prod of k linear forms`; verbose shows the actual
+	/// product of affine factors `(x - 1) * (x + 1)`.
+	void Describe(std::ostream& out, size_t& row, VariableGroup const& vars, bool verbose) const
+	{
+		for (auto const& M : factors_highest_precision_)
+		{
+			out << "  f_" << row++ << " = ";
+			const Eigen::Index k = M.rows();
+			if (!verbose)
+			{
+				out << "prod of " << k << " linear form" << (k == 1 ? "" : "s");
+			}
+			else if (k == 0)
+			{
+				out << "1";
+			}
+			else
+			{
+				for (Eigen::Index r = 0; r < k; ++r)
+				{
+					out << (r ? " * " : "") << "(";
+					describe_detail::PrintLinearFormVerbose(out, M, r, vars, num_vars_, false);
+					out << ")";
+				}
+			}
+			out << "\n";
+		}
+	}
 
 	/// Products of linears do not depend on the path variable.
 	bool DependsOnPathVariable() const { return false; }

--- a/core/include/bertini2/system/blocks/randomization_block.hpp
+++ b/core/include/bertini2/system/blocks/randomization_block.hpp
@@ -68,6 +68,7 @@ block operand is a shared follow-up with BlendBlock).
 #include "bertini2/num_traits.hpp"
 #include "bertini2/eigen_extensions.hpp"
 #include "bertini2/function_tree.hpp"
+#include "bertini2/system/blocks/describe.hpp"
 
 namespace bertini {
 namespace blocks {
@@ -187,6 +188,36 @@ public:
 	std::vector<Var> const& HomVars() const { return hom_vars_; }
 	std::vector<std::vector<int>> const& TargetMultidegrees() const { return target_multidegrees_; }
 	std::vector<std::vector<int>> const& OperandMultidegrees() const { return operand_multidegrees_; }
+
+	/// Human-facing description: terse shows `f_a..f_b = R . g  (R: nxN)` then the underlying
+	/// functions `g_j` indented (they are the interesting part); verbose additionally prints R's
+	/// entries.
+	void Describe(std::ostream& out, size_t& row, VariableGroup const& /*vars*/, bool verbose) const
+	{
+		const size_t n = NumFunctions();
+		const size_t N = static_cast<size_t>(coefficients_highest_precision_.cols());
+		out << "  ";
+		describe_detail::PrintRowLabel(out, row, n);
+		out << " = R . g   (R: " << n << "x" << N << " randomization matrix)\n";
+		row += n;
+		auto g = operand_->NaturalFunctionsAsNodes();
+		for (size_t j = 0; j < g.size(); ++j)
+			out << "      g_" << j << " = " << g[j] << "\n";
+		if (verbose)
+		{
+			out << "    R =\n";
+			for (Eigen::Index i = 0; i < coefficients_highest_precision_.rows(); ++i)
+			{
+				out << "      [ ";
+				for (Eigen::Index j = 0; j < coefficients_highest_precision_.cols(); ++j)
+				{
+					if (j) out << ", ";
+					describe_detail::PrintCoeff(out, coefficients_highest_precision_(i, j));
+				}
+				out << " ]\n";
+			}
+		}
+	}
 
 	unsigned Precision() const { return precision_; }
 

--- a/core/include/bertini2/system/blocks/randomization_block.hpp
+++ b/core/include/bertini2/system/blocks/randomization_block.hpp
@@ -1,0 +1,466 @@
+//This file is part of Bertini 2.
+//
+//randomization_block.hpp is free software: you can redistribute it and/or modify
+//it under the terms of the GNU General Public License as published by
+//the Free Software Foundation, either version 3 of the License, or
+//(at your option) any later version.
+//
+//randomization_block.hpp is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//GNU General Public License for more details.
+//
+//You should have received a copy of the GNU General Public License
+//along with randomization_block.hpp.  If not, see <http://www.gnu.org/licenses/>.
+//
+// Copyright(C) Bertini2 Development Team
+//
+// See <http://www.gnu.org/licenses/> for a copy of the license,
+// as well as COPYING.  Bertini2 is provided with permitted
+// additional terms in the b2/licenses/ directory.
+
+/**
+\file bertini2/system/blocks/randomization_block.hpp
+
+\brief A System evaluation block that randomizes an overdetermined operand system down to a
+square one, so its isolated solutions can be found by homotopy continuation.
+
+An overdetermined system F = (f_1, ..., f_N) of N functions in n variables (N > n) cannot be
+fed to a total-degree start system (which requires squareness).  Randomization replaces F with
+n generic combinations whose isolated-solution set still contains that of F; the square result
+is solved and the extraneous solutions discarded.
+
+This block holds the overdetermined system as a `shared_ptr<SystemT>` operand (mirroring
+`BlendBlock<SystemT>`) and a constant coefficient matrix, and emits the n randomized rows
+
+    g_i(x) = sum_j  c_ij * f_j(x) * prod_g  h_g^{(D_{i,g} - d_{j,g})}
+
+where f_j is the operand's j-th natural function (homogenized to its own multidegree d_j),
+D_i is row i's target multidegree, h_g is the homogenizing variable of variable group g, and
+c_ij = 0 whenever any deficit D_{i,g} - d_{j,g} is negative.  The h-power factors are what make
+a constant-coefficient combination of functions of *differing* degree homogenize correctly:
+before homogenization every h_g = 1 and the formula collapses to g_i = sum_j c_ij f_j.
+
+Construction (degrees, sorting, the [I|C] / common-target-multidegree matrix) is done by
+`System::Randomize`, which hands this block the finished coefficient matrix and the per-row /
+per-function multidegrees.  The block is multidegree-native so single-affine-group and
+multihomogeneous randomization share one evaluator.
+
+Templated on the system type so `SystemT` stays a dependent name in the `Block` variant (a
+System contains a Block which contains a RandomizationBlock<System> holding a shared_ptr<System>
+-- the template parameter breaks the recursive type), exactly as for `BlendBlock<SystemT>`.
+
+\note Like BlendBlock, the operand is held by shared_ptr and its mutable per-evaluation state
+(variable values) is shared across copies; per-thread tracking must Clone (the deep-clone of a
+block operand is a shared follow-up with BlendBlock).
+*/
+
+#pragma once
+
+#include <vector>
+#include <memory>
+#include <stdexcept>
+
+#include <boost/serialization/vector.hpp>
+#include <boost/serialization/shared_ptr.hpp>
+#include <boost/serialization/split_member.hpp>
+
+#include "bertini2/num_traits.hpp"
+#include "bertini2/eigen_extensions.hpp"
+#include "bertini2/function_tree.hpp"
+
+namespace bertini {
+namespace blocks {
+
+template <typename SystemT>
+class RandomizationBlock
+{
+public:
+	using Var = std::shared_ptr<node::Variable>;
+	using OperandPtr = std::shared_ptr<SystemT>;
+
+	RandomizationBlock() : num_groups_(0), precision_(DefaultPrecision()) {}
+
+	/**
+	\param operand              The overdetermined system being randomized (N natural functions).
+	\param coefficients         The n x N constant matrix; row i, column j is c_ij.
+	\param target_multidegrees  n rows, each a length-num_groups vector D_i (row i's target degree
+	                            per variable group).
+	\param operand_multidegrees N rows, each a length-num_groups vector d_j (operand function j's
+	                            degree per variable group), measured on the affine operand.
+	\param num_groups           The number of (affine) variable groups G.
+	*/
+	RandomizationBlock(OperandPtr operand,
+	                   Mat<mpfr_complex> coefficients,
+	                   std::vector<std::vector<int>> target_multidegrees,
+	                   std::vector<std::vector<int>> operand_multidegrees,
+	                   size_t num_groups)
+		: operand_(std::move(operand)),
+		  coefficients_highest_precision_(std::move(coefficients)),
+		  target_multidegrees_(std::move(target_multidegrees)),
+		  operand_multidegrees_(std::move(operand_multidegrees)),
+		  num_groups_(num_groups),
+		  precision_(DefaultPrecision())
+	{
+		BuildWorking();
+	}
+
+	/// Number of randomized functions (rows this block contributes) = n.
+	size_t NumFunctions() const { return static_cast<size_t>(coefficients_highest_precision_.rows()); }
+
+	/// The randomized functions' degrees: the (total) target degree of each row, i.e. the sum of
+	/// its target multidegree over the variable groups.  This is the degree-reporting hook -- the
+	/// path count of the squared system is the product of these.
+	std::vector<int> Degrees() const
+	{
+		std::vector<int> d(NumFunctions(), 0);
+		for (size_t i = 0; i < target_multidegrees_.size(); ++i)
+			for (int e : target_multidegrees_[i])
+				d[i] += e;
+		return d;
+	}
+	/// Per-group target degree.  We match the group against the operand's variable groups by
+	/// identity so the correct column of the target multidegree is returned; an unrecognized group
+	/// reports the total (defensive -- the owning System asks per its own groups).
+	std::vector<int> Degrees(VariableGroup const& vars) const
+	{
+		const int g = GroupIndex(vars);
+		if (g < 0)
+			return Degrees();
+		std::vector<int> d(NumFunctions(), 0);
+		for (size_t i = 0; i < target_multidegrees_.size(); ++i)
+			d[i] = target_multidegrees_[i][static_cast<size_t>(g)];
+		return d;
+	}
+
+	/// The randomized system is polynomial / homogeneous exactly when the operand is (System's
+	/// IsPolynomial/IsHomogeneous are whole-system, no-argument checks -- as BlendBlock delegates).
+	bool IsPolynomial(VariableGroup const& /*vars*/) const { return operand_->IsPolynomial(); }
+	bool IsHomogeneous(VariableGroup const& /*vars*/) const { return homogenized_ ? operand_->IsHomogeneous() : false; }
+
+	/**
+	\brief Homogenize: thread the owning system's homogenizing variable for this group into the
+	operand, so the operand's functions and this block's h-power deficit factors share one set of
+	homogenizing variables.
+
+	The owning System calls this once per affine variable group, in group order.  We accumulate the
+	supplied hom vars; once we have one per group we homogenize the operand with exactly those
+	variables (System::Homogenize(VariableGroup const&) reuses them rather than minting fresh ones)
+	and record each hom var's position in the operand's variable ordering for the h-power factors.
+	*/
+	void Homogenize(VariableGroup const& /*group*/, Var const& hom_var)
+	{
+		if (homogenized_)
+			return;
+		hom_vars_.push_back(hom_var);
+		if (hom_vars_.size() == num_groups_)
+		{
+			operand_->Homogenize(VariableGroup(hom_vars_));
+			homogenized_ = true;
+			// the hom var of group g now sits at a fixed position of the (shared) variable ordering;
+			// the block reads h_g from there during evaluation.
+			hom_var_index_.assign(num_groups_, -1);
+			auto const& ordering = operand_->Variables();
+			for (size_t g = 0; g < num_groups_; ++g)
+				for (size_t k = 0; k < ordering.size(); ++k)
+					if (ordering[k] == hom_vars_[g]) { hom_var_index_[g] = static_cast<int>(k); break; }
+		}
+	}
+
+	/// The randomization itself adds no path-variable dependence; it inherits the operand's.
+	bool DependsOnPathVariable() const { return operand_->HavePathVariable(); }
+
+	/// The randomized Jacobian varies in x (operand Jacobian times constants, plus h-power terms).
+	bool HasConstantJacobian() const { return false; }
+
+	/// Analytic block: nothing symbolic to differentiate (the operand differentiates itself).
+	void Differentiate() const {}
+
+	/// The overdetermined operand, for the function-tree expansion oracle and the matrix getter.
+	OperandPtr const& Operand() const { return operand_; }
+	/// The randomization matrix R (master, highest precision); n x N, row i column j is c_ij.
+	Mat<mpfr_complex> const& RandomizationMatrix() const { return coefficients_highest_precision_; }
+
+	// Accessors for the function-tree expansion oracle (System::NaturalFunctionsAsNodes), which
+	// rebuilds g_i = sum_j c_ij * node(f_j) * prod_g h_g^{(D_{i,g}-d_{j,g})}.
+	bool IsHomogenized() const { return homogenized_; }
+	std::vector<Var> const& HomVars() const { return hom_vars_; }
+	std::vector<std::vector<int>> const& TargetMultidegrees() const { return target_multidegrees_; }
+	std::vector<std::vector<int>> const& OperandMultidegrees() const { return operand_multidegrees_; }
+
+	unsigned Precision() const { return precision_; }
+
+	/// Set the working precision: recast the mpfr working coefficients from the master and bring
+	/// the operand to the same precision (so a high-precision coefficient is not multiplied against
+	/// a low-precision operand value).
+	void Precision(unsigned new_precision) const
+	{
+		if (new_precision > DoublePrecision())
+		{
+			auto& wm = std::get<Mat<mpfr_complex>>(coefficients_working_);
+			for (Eigen::Index r = 0; r < wm.rows(); ++r)
+				for (Eigen::Index c = 0; c < wm.cols(); ++c)
+				{
+					wm(r, c).precision(new_precision);
+					if (new_precision > precision_)
+						wm(r, c) = coefficients_highest_precision_(r, c);
+				}
+		}
+		operand_->precision(new_precision);
+		precision_ = new_precision;
+	}
+
+	/**
+	\brief Evaluate the randomized function values into a caller-provided segment.
+
+	g_i = sum_j c_ij * f_j * prod_g h_g^{(D_{i,g} - d_{j,g})}.
+	*/
+	template <typename T>
+	void EvalInPlace(Eigen::Ref<Vec<T>> result, Vec<T> const& vars, T const& /*path_value*/) const
+	{
+		SyncPrecision(vars);
+		const size_t N = static_cast<size_t>(coefficients_highest_precision_.cols());
+		const Vec<T> f = operand_->template Eval<T>(vars).head(static_cast<Eigen::Index>(N));
+		const auto& C = Working<T>();
+
+		result.setZero();
+		for (size_t i = 0; i < NumFunctions(); ++i)
+		{
+			T acc = Zero<T>();
+			for (size_t j = 0; j < N; ++j)
+			{
+				const T& c = C(static_cast<Eigen::Index>(i), static_cast<Eigen::Index>(j));
+				if (IsZero(c))
+					continue;
+				acc += c * f(static_cast<Eigen::Index>(j)) * HPower<T>(i, j, vars);
+			}
+			result(static_cast<Eigen::Index>(i)) = acc;
+		}
+	}
+
+	/**
+	\brief Evaluate the randomized Jacobian into a caller-provided block.
+
+	By the product rule on  c_ij * f_j * W_ij(x)  (W_ij = prod_g h_g^{e_{ij,g}}):
+	    d g_i / d x_l = sum_j c_ij [ (d f_j / d x_l) W_ij + f_j (d W_ij / d x_l) ],
+	and dW_ij/dx_l is nonzero only when x_l is a homogenizing variable h_{g'} appearing in W_ij.
+	*/
+	template <typename T>
+	void JacobianInPlace(Eigen::Ref<Mat<T>> J, Vec<T> const& vars, T const& /*path_value*/) const
+	{
+		SyncPrecision(vars);
+		const size_t N = static_cast<size_t>(coefficients_highest_precision_.cols());
+		const Vec<T> f  = operand_->template Eval<T>(vars).head(static_cast<Eigen::Index>(N));
+		const Mat<T> Jf = operand_->template Jacobian<T>(vars).topRows(static_cast<Eigen::Index>(N));
+		const auto& C = Working<T>();
+
+		J.setZero();
+		for (size_t i = 0; i < NumFunctions(); ++i)
+		{
+			for (size_t j = 0; j < N; ++j)
+			{
+				const T& c = C(static_cast<Eigen::Index>(i), static_cast<Eigen::Index>(j));
+				if (IsZero(c))
+					continue;
+
+				const T W = HPower<T>(i, j, vars);                 // W_ij = prod_g h_g^{e_g}
+				// operand-Jacobian term: c_ij * W_ij * (d f_j / d x), across all columns.
+				J.row(static_cast<Eigen::Index>(i)) += (c * W) * Jf.row(static_cast<Eigen::Index>(j));
+
+				// h-power terms: only the homogenizing-variable columns pick up f_j * dW/dh_{g'}.
+				if (homogenized_)
+				{
+					for (size_t g = 0; g < num_groups_; ++g)
+					{
+						const int e = Deficit(i, j, g);
+						if (e <= 0 || hom_var_index_[g] < 0)
+							continue;                              // e<0 means c_ij==0 (already skipped); e==0 -> no dependence
+						// dW/dh_g = e * h_g^{e-1} * prod_{g2 != g} h_{g2}^{e_{g2}}
+						const T dW = MixedPartial<T>(i, j, g, vars);
+						J(static_cast<Eigen::Index>(i), hom_var_index_[g]) += c * f(static_cast<Eigen::Index>(j)) * dW;
+					}
+				}
+			}
+		}
+	}
+
+	/// Time-derivative.  The randomization is autonomous in the path variable; if the operand
+	/// depends on t (unusual for a randomized target) its rows would contribute, but the common
+	/// case is an autonomous operand, so this is zero.
+	template <typename T>
+	void TimeDerivInPlace(Eigen::Ref<Vec<T>> result, Vec<T> const& /*vars*/, T const& /*path_value*/) const
+	{
+		result.setZero();
+	}
+
+private:
+	template <typename T>
+	const Mat<T>& Working() const { return std::get<Mat<T>>(coefficients_working_); }
+
+	/// A precision-correct zero / one for the accumulators.
+	template <typename T>
+	T Zero() const
+	{
+		T z(0);
+		if constexpr (!std::is_same<T, dbl>::value) z.precision(precision_);
+		return z;
+	}
+
+	static bool IsZero(dbl const& c) { return c == dbl(0); }
+	static bool IsZero(mpfr_complex const& c) { return c.real() == 0 && c.imag() == 0; }
+
+	/// The (signed) degree deficit of operand function j against row i's target, in group g.
+	int Deficit(size_t i, size_t j, size_t g) const
+	{
+		return target_multidegrees_[i][g] - operand_multidegrees_[j][g];
+	}
+
+	/// W_ij = prod_g h_g^{(D_{i,g} - d_{j,g})}.  Before homogenization every h_g = 1, so 1.
+	template <typename T>
+	T HPower(size_t i, size_t j, Vec<T> const& vars) const
+	{
+		T w(1);
+		if constexpr (!std::is_same<T, dbl>::value) w.precision(precision_);
+		if (!homogenized_)
+			return w;
+		for (size_t g = 0; g < num_groups_; ++g)
+		{
+			const int e = Deficit(i, j, g);
+			if (e == 0 || hom_var_index_[g] < 0)
+				continue;
+			w *= IntPow<T>(vars(hom_var_index_[g]), e);
+		}
+		return w;
+	}
+
+	/// d W_ij / d h_{g} = e_g * h_g^{e_g - 1} * prod_{g2 != g} h_{g2}^{e_{g2}}  (e_g > 0 assumed).
+	template <typename T>
+	T MixedPartial(size_t i, size_t j, size_t g, Vec<T> const& vars) const
+	{
+		const int eg = Deficit(i, j, g);
+		T d(eg);
+		if constexpr (!std::is_same<T, dbl>::value) d.precision(precision_);
+		d *= IntPow<T>(vars(hom_var_index_[g]), eg - 1);
+		for (size_t g2 = 0; g2 < num_groups_; ++g2)
+		{
+			if (g2 == g)
+				continue;
+			const int e2 = Deficit(i, j, g2);
+			if (e2 == 0 || hom_var_index_[g2] < 0)
+				continue;
+			d *= IntPow<T>(vars(hom_var_index_[g2]), e2);
+		}
+		return d;
+	}
+
+	/// base^e for integer e >= 0, by repeated multiplication (exact, no branch-cut surprises).
+	template <typename T>
+	static T IntPow(T const& base, int e)
+	{
+		T result(1);
+		if constexpr (!std::is_same<T, dbl>::value) result.precision(bertini::Precision(base));
+		for (int k = 0; k < e; ++k)
+			result *= base;
+		return result;
+	}
+
+	/// Match a variable group against the operand's affine variable groups by identity; -1 if none.
+	int GroupIndex(VariableGroup const& vars) const
+	{
+		auto const& groups = operand_->VariableGroups();
+		for (size_t g = 0; g < groups.size(); ++g)
+			if (SameGroup(groups[g], vars))
+				return static_cast<int>(g);
+		return -1;
+	}
+	static bool SameGroup(VariableGroup const& a, VariableGroup const& b)
+	{
+		if (a.size() != b.size())
+			return false;
+		for (size_t k = 0; k < a.size(); ++k)
+			if (a[k] != b[k])
+				return false;
+		return true;
+	}
+
+	template <typename T>
+	void SyncPrecision(Vec<T> const& vars) const
+	{
+		if constexpr (!std::is_same<T, dbl>::value)
+		{
+			if (vars.size() > 0)
+			{
+				const unsigned p = bertini::Precision(vars(0));
+				if (p != precision_)
+					Precision(p);
+			}
+		}
+	}
+
+	void BuildWorking() const
+	{
+		const auto& M = coefficients_highest_precision_;
+		auto& wd = std::get<Mat<dbl>>(coefficients_working_);
+		auto& wm = std::get<Mat<mpfr_complex>>(coefficients_working_);
+		wd.resize(M.rows(), M.cols());
+		wm.resize(M.rows(), M.cols());
+		for (Eigen::Index r = 0; r < M.rows(); ++r)
+			for (Eigen::Index c = 0; c < M.cols(); ++c)
+			{
+				wd(r, c) = dbl(M(r, c));
+				wm(r, c) = M(r, c);
+			}
+	}
+
+	OperandPtr operand_;
+	Mat<mpfr_complex> coefficients_highest_precision_;             ///< master n x N randomization matrix
+	mutable std::tuple<Mat<dbl>, Mat<mpfr_complex>> coefficients_working_;
+	std::vector<std::vector<int>> target_multidegrees_;            ///< n x G
+	std::vector<std::vector<int>> operand_multidegrees_;           ///< N x G
+	size_t num_groups_;                                            ///< G (affine variable groups)
+	bool homogenized_ = false;
+	std::vector<Var> hom_vars_;                                    ///< the (shared) homogenizing variable per group
+	std::vector<int> hom_var_index_;                               ///< its position in the variable ordering
+	mutable unsigned precision_;
+
+	friend class boost::serialization::access;
+
+	// Operand held as shared_ptr<SystemT> (non-const, since Homogenize mutates the twin); split
+	// like BlendBlock so serialization never deserializes into a const object.
+	template <typename Archive>
+	void save(Archive& ar, const unsigned /*version*/) const
+	{
+		ar & operand_;
+		ar & coefficients_highest_precision_;
+		ar & std::get<0>(coefficients_working_);
+		ar & std::get<1>(coefficients_working_);
+		ar & target_multidegrees_;
+		ar & operand_multidegrees_;
+		ar & num_groups_;
+		ar & homogenized_;
+		ar & hom_vars_;
+		ar & hom_var_index_;
+		ar & precision_;
+	}
+
+	template <typename Archive>
+	void load(Archive& ar, const unsigned /*version*/)
+	{
+		ar & operand_;
+		ar & coefficients_highest_precision_;
+		ar & std::get<0>(coefficients_working_);
+		ar & std::get<1>(coefficients_working_);
+		ar & target_multidegrees_;
+		ar & operand_multidegrees_;
+		ar & num_groups_;
+		ar & homogenized_;
+		ar & hom_vars_;
+		ar & hom_var_index_;
+		ar & precision_;
+	}
+
+	BOOST_SERIALIZATION_SPLIT_MEMBER()
+};
+
+} // namespace blocks
+} // namespace bertini

--- a/core/include/bertini2/system/system.hpp
+++ b/core/include/bertini2/system/system.hpp
@@ -2115,6 +2115,32 @@ namespace bertini {
 	                    std::shared_ptr<node::Node> const& gamma = nullptr);
 
 	/**
+	\brief Form a homotopy that moves ONLY some rows, leaving the rest fixed and evaluated once.
+
+	The "regeneration" homotopy: `fixed` holds the equations that do not move (the polynomial system
+	and any static linear slices); `start_moving` and `end_moving` are systems holding just the rows
+	that move, agreeing in function count and variable structure.  The result is
+
+	    H = [ fixed's blocks (unchanged) ;  (1-t)*end_moving + gamma*t*start_moving ]
+
+	with the moving rows produced by a single `BlendBlock` over `end_moving`/`start_moving` and the
+	fixed rows kept as their own sibling blocks.  Because the fixed blocks are autonomous, they are
+	evaluated exactly once per point and contribute zero to `dH/dt` -- the fixed system is never
+	re-evaluated or scaled by the path coefficient as the moving rows slide.  At t=1 the moving rows
+	are `gamma*start_moving` (so the start points are roots of `fixed` together with `start_moving`),
+	at t=0 they are `end_moving`.
+
+	The fixed rows come first, then the moving rows; build the matching target (for the user-homotopy
+	pipeline) as `fixed` concatenated with `end_moving`, and the start points as the roots of `fixed`
+	together with `start_moving`.
+
+	\param gamma The gamma coefficient (a node).  If null, a random rational gamma is generated.
+	*/
+	System MakeMovingHomotopy(System const& fixed, System const& start_moving, System const& end_moving,
+	                          std::string const& path_variable_name = "t",
+	                          std::shared_ptr<node::Node> const& gamma = nullptr);
+
+	/**
 	\brief Do a deep clone of the system.  This includes the entire structure, variables, etc.  everything.
 	*/
 	System Clone(System const& sys);

--- a/core/include/bertini2/system/system.hpp
+++ b/core/include/bertini2/system/system.hpp
@@ -687,6 +687,18 @@ namespace bertini {
 		void Homogenize();
 
 		/**
+		Homogenize the system reusing externally-supplied homogenizing variables -- one per affine
+		variable group, in group order -- instead of minting fresh ones.  Used by
+		`RandomizationBlock` so a wrapped operand system shares the owning system's homogenizing
+		variables (the h-power deficit factors and the operand's functions must live in the same
+		homogeneous coordinates).  Otherwise behaves exactly like `Homogenize()` on a fresh system.
+
+		\throws std::runtime_error if the system is non-polynomial, already homogenized, or the
+		number of supplied homogenizing variables does not equal the number of affine variable groups.
+		*/
+		void Homogenize(VariableGroup const& provided_hom_vars);
+
+		/**
 		Checks whether a system is homogeneous, overall.  This means with respect to each variable group (including homogenizing variable if defined), homogeneous variable group, and ungrouped variables, if defined.
 
 		\throws std::runtime_error, if the number of homogenizing variables does not match the number of variable_groups.
@@ -1048,6 +1060,11 @@ namespace bertini {
 		*/
 		void AddBlock(Block b) { blocks_.push_back(std::move(b)); }
 
+		/// Read-only access to the system's evaluation blocks (in evaluation order).  For
+		/// introspection / testing -- e.g. reading a RandomizationBlock's matrix; the variant
+		/// itself stays out of the Python surface.
+		std::vector<Block> const& Blocks() const { return blocks_; }
+
 		/// Remove the polynomial block (the System's natural functions), leaving any structured
 		/// blocks and the variable structure / patch intact.  Used to turn a copy of a System
 		/// into a homotopy shell whose rows come from a blend block rather than its own
@@ -1098,6 +1115,46 @@ namespace bertini {
 		/// expanding any structured block.  Used by ExpandToFunctionTree and, recursively, by
 		/// BlendBlock expansion (a blend is sum_i c_i(t) * operand_i, each operand expanded).
 		std::vector<Nd> NaturalFunctionsAsNodes() const;
+
+
+		/**
+		\brief Randomize an overdetermined system down to a square one, returning a NEW system.
+
+		An overdetermined system (N natural functions, n variables, N > n) is replaced by n generic
+		combinations whose isolated solutions still contain this system's -- the standard squaring-up
+		so the isolated solutions can be found by homotopy continuation (solve the square result,
+		then discard the extraneous solutions by re-evaluating this system).
+
+		The returned system carries a single `RandomizationBlock` wrapping a copy of this system; the
+		combination is `g_i = sum_j R_ij f_j` (the block applies the homogenizing-variable powers
+		needed when the functions differ in degree).  **This system is not mutated** -- any internal
+		degree sorting happens on the copy.
+
+		Auto form: for a single affine variable group the functions are sorted by descending degree
+		and `R = [I | C]` (C random), giving the optimal total-degree path count (the product of the
+		n largest degrees); for several variable groups a dense random `R` is used with a common
+		target multidegree.
+
+		\throws std::runtime_error if the system is underdetermined (fewer functions than variables).
+		*/
+		System Randomize() const;
+
+		/**
+		\brief Randomize using a caller-supplied (exact) coefficient matrix R, leaving the functions
+		in their current order.  R has one row per desired randomized function and one column per
+		natural function of this system.  Returns a NEW system; this one is not mutated.
+
+		\throws std::runtime_error if R's column count does not equal this system's natural-function count.
+		*/
+		System Randomize(Mat<mpfr_complex> const& R) const;
+
+		/**
+		\brief The randomization matrix R of a system produced by Randomize() (its first
+		RandomizationBlock's n x N coefficient matrix).
+
+		\throws std::runtime_error if this system carries no randomization block.
+		*/
+		Mat<mpfr_complex> RandomizationMatrix() const;
 
 
 
@@ -1641,6 +1698,11 @@ namespace bertini {
 		*/
 		friend const System operator*(Nd const&  N, System const& s);
 	private:
+
+		/// Shared back end of the Randomize overloads: given the overdetermined operand (already a
+		/// copy, sorted or not) and a finished coefficient matrix, compute the per-row target
+		/// multidegrees, build the RandomizationBlock, and return a new system carrying it.
+		System AssembleRandomized(std::shared_ptr<System> operand, Mat<mpfr_complex> coefficients) const;
 
 		/**
 		\brief Get the sizes according to the FIFO ordering.

--- a/core/include/bertini2/system/system.hpp
+++ b/core/include/bertini2/system/system.hpp
@@ -1503,6 +1503,16 @@ namespace bertini {
 			patch_.RescalePointToFitInPlace(x);
 		}
 		/**
+		\brief Human-facing description of the system, block by block.
+
+		Each block describes the rows it owns (labelled `f_k` in function-vector order).  `verbose ==
+		false` (the default, used by `operator<<` / Python `str`) shows placeholder symbols for the
+		structured blocks' matrices/coefficients; `verbose == true` reveals the actual numbers and the
+		underlying functions of randomization / blend blocks.  This is for reading, not re-parsing.
+		*/
+		void Describe(std::ostream& out, bool verbose = false) const;
+
+		/**
 		 \brief Overloaded operator for printing to an arbirtary out stream.
 		 */
 		friend std::ostream& operator <<(std::ostream& out, const System & s);

--- a/core/src/system/system.cpp
+++ b/core/src/system/system.cpp
@@ -388,6 +388,46 @@ namespace bertini
 	}
 
 
+	void System::Homogenize(VariableGroup const& provided_hom_vars)
+	{
+		// Like Homogenize(), but adopt the supplied homogenizing variables (one per affine variable
+		// group, in group order) instead of minting fresh ones.  Mirrors Homogenize()'s
+		// fresh-system branch exactly; the only difference is where the hom var comes from.
+		for (const auto& curr_var_gp : hom_variable_groups_)
+			for (auto const& b : blocks_)
+				if (!std::visit([&](auto const& blk){ return blk.IsHomogeneous(curr_var_gp); }, b))
+					throw std::runtime_error("inhomogeneous function, with homogeneous variable group");
+
+		if (!IsPolynomial())
+			throw std::runtime_error("trying to homogenize a non-polynomial system.");
+
+		if (NumHomVariables()!=0)
+			throw std::runtime_error("Homogenize(provided homogenizing variables): system is already homogenized.");
+
+		if (provided_hom_vars.size()!=NumVariableGroups())
+			throw std::runtime_error("Homogenize(provided homogenizing variables): need exactly one homogenizing variable per affine variable group.");
+
+		homogenizing_variables_.resize(NumVariableGroups());
+
+		auto group_counter = 0;
+		for (auto curr_var_gp = variable_groups_.begin(); curr_var_gp!=variable_groups_.end(); curr_var_gp++)
+		{
+			Var hom_var = provided_hom_vars[group_counter];
+			homogenizing_variables_[group_counter] = hom_var;
+			for (auto& b : blocks_)
+				std::visit([&](auto& blk){ blk.Homogenize(*curr_var_gp, hom_var); }, b);
+			group_counter++;
+		}
+
+		InvalidateDifferentiation();
+		have_ordering_ = false;
+
+		#ifndef BERTINI_DISABLE_ASSERTS
+		assert(homogenizing_variables_.size() == variable_groups_.size());
+		#endif
+	}
+
+
 
 
 	bool System::IsHomogeneous() const
@@ -999,6 +1039,40 @@ namespace bertini
 					for (auto& f : blended)
 						out.push_back(f ? f : Nd(Integer::Make(0)));
 				}
+				else if constexpr (std::is_same_v<B, blocks::RandomizationBlock<System>>)
+				{
+					// g_i = sum_j c_ij * f_j * prod_g h_g^{(D_{i,g} - d_{j,g})}, the operand functions
+					// expanded recursively and the homogenizing-variable powers folded back in (so the
+					// expansion matches the block's homogenized evaluation).
+					std::vector<Nd> fj = b.Operand()->NaturalFunctionsAsNodes();      // N nodes
+					auto const& R   = b.RandomizationMatrix();                        // n x N
+					auto const& tgt = b.TargetMultidegrees();
+					auto const& omd = b.OperandMultidegrees();
+					auto const& homvars = b.HomVars();
+					const bool hom = b.IsHomogenized();
+					const size_t n = b.NumFunctions();
+					const size_t N = fj.size();
+					for (size_t i = 0; i < n; ++i)
+					{
+						Nd gi = nullptr;
+						for (size_t j = 0; j < N; ++j)
+						{
+							mpfr_complex const& c = R(static_cast<Eigen::Index>(i), static_cast<Eigen::Index>(j));
+							if (c.real() == 0 && c.imag() == 0)
+								continue;
+							Nd term = Float::Make(c) * fj[j];
+							if (hom)
+								for (size_t g = 0; g < homvars.size(); ++g)
+								{
+									const int e = tgt[i][g] - omd[j][g];
+									if (e > 0)
+										term = term * pow(homvars[g], e);
+								}
+							gi = gi ? (gi + term) : term;
+						}
+						out.push_back(gi ? gi : Nd(Integer::Make(0)));
+					}
+				}
 				else // LinearFormsBlock and any future block
 				{
 					throw std::runtime_error("ExpandToFunctionTree: block type not yet supported");
@@ -1023,6 +1097,132 @@ namespace bertini
 			result.AddFunction(f);
 		result.InvalidateDifferentiation();
 		return result;
+	}
+
+
+	//
+	//  Randomize -- square up an overdetermined system (see the header).  Construction (degrees,
+	//  sorting, the coefficient matrix) happens here, on a copy, where System is complete; the
+	//  RandomizationBlock just stores the finished matrix and multidegrees and evaluates.
+	//
+	namespace {
+
+		// operand->Degrees(group_g)[j] gathered into operand_multidegrees[j][g].
+		std::vector<std::vector<int>> OperandMultidegrees(System const& operand)
+		{
+			auto groups = operand.VariableGroups();
+			const size_t G = groups.size();
+			const size_t N = operand.NumNaturalFunctions();
+			std::vector<std::vector<int>> md(N, std::vector<int>(G, 0));
+			for (size_t g = 0; g < G; ++g)
+			{
+				auto dg = operand.Degrees(groups[g]);            // length N: degree of each function in group g
+				for (size_t j = 0; j < N && j < dg.size(); ++j)
+					md[j][g] = dg[j];
+			}
+			return md;
+		}
+
+	} // anonymous namespace
+
+
+	System System::AssembleRandomized(std::shared_ptr<System> operand, Mat<mpfr_complex> coefficients) const
+	{
+		const size_t G = operand->NumVariableGroups();
+		const size_t N = operand->NumNaturalFunctions();
+		const size_t n = static_cast<size_t>(coefficients.rows());
+
+		if (static_cast<size_t>(coefficients.cols()) != N)
+			throw std::runtime_error("Randomize: coefficient matrix column count must equal the number of natural functions.");
+
+		auto operand_md = OperandMultidegrees(*operand);
+
+		// Row i's target multidegree is, per group, the largest degree among the functions actually
+		// combined into it (those with a nonzero coefficient).  This makes every h-power deficit
+		// D_{i,g} - d_{j,g} >= 0, and -- with the descending sort the auto path uses -- equal to the
+		// row's own leading-function degree, so the path count is minimal.
+		std::vector<std::vector<int>> target_md(n, std::vector<int>(G, 0));
+		for (size_t i = 0; i < n; ++i)
+			for (size_t j = 0; j < N; ++j)
+			{
+				mpfr_complex const& c = coefficients(static_cast<Eigen::Index>(i), static_cast<Eigen::Index>(j));
+				if (c.real() == 0 && c.imag() == 0)
+					continue;
+				for (size_t g = 0; g < G; ++g)
+					target_md[i][g] = std::max(target_md[i][g], operand_md[j][g]);
+			}
+
+		blocks::RandomizationBlock<System> block(operand, std::move(coefficients),
+		                                         std::move(target_md), std::move(operand_md), G);
+
+		System result = *this;          // share variables / groups / path variable / ordering
+		result.ClearBlocks();           // drop this system's own functions...
+		result.AddBlock(std::move(block));  // ...the randomized rows come from the block
+		result.InvalidateDifferentiation();
+		return result;
+	}
+
+
+	System System::Randomize() const
+	{
+		const size_t G = NumVariableGroups();
+		const size_t N = NumNaturalFunctions();
+		const size_t n = NumVariables() - NumHomVariableGroups();
+
+		if (N < n)
+			throw std::runtime_error("Randomize: system is underdetermined (fewer functions than variables), so it has no isolated solutions to capture.");
+
+		auto operand = std::make_shared<System>(*this);
+
+		Mat<mpfr_complex> R(static_cast<Eigen::Index>(n), static_cast<Eigen::Index>(N));
+
+		if (G == 1)
+		{
+			// single affine group: sort the operand's functions by descending degree, then R = [I | C].
+			// The identity block makes g_i carry f_i with coefficient 1 (degree d_i); the random tail
+			// C folds the lower-degree functions in, padded by hom-var powers.  deg g_i = d_i, so the
+			// total-degree path count is the product of the n largest degrees -- optimal.
+			operand->ReorderFunctionsByDegreeDecreasing();
+			for (size_t i = 0; i < n; ++i)
+				for (size_t j = 0; j < N; ++j)
+				{
+					if (j < n)
+						R(static_cast<Eigen::Index>(i), static_cast<Eigen::Index>(j)) =
+							(i == j) ? mpfr_complex(1) : mpfr_complex(0);
+					else
+						R(static_cast<Eigen::Index>(i), static_cast<Eigen::Index>(j)) =
+							bertini::multiprecision::RandomComplex(DefaultPrecision());
+				}
+		}
+		else
+		{
+			// several variable groups: multidegrees are only partially ordered, so use a dense random
+			// R with a common (componentwise-max) target multidegree -- correct, and optimal when the
+			// functions share a multidegree.
+			for (Eigen::Index r = 0; r < R.rows(); ++r)
+				for (Eigen::Index c = 0; c < R.cols(); ++c)
+					R(r, c) = bertini::multiprecision::RandomComplex(DefaultPrecision());
+		}
+
+		return AssembleRandomized(operand, std::move(R));
+	}
+
+
+	System System::Randomize(Mat<mpfr_complex> const& R) const
+	{
+		if (static_cast<size_t>(R.cols()) != NumNaturalFunctions())
+			throw std::runtime_error("Randomize: supplied matrix must have one column per natural function of the system.");
+		auto operand = std::make_shared<System>(*this);  // functions kept in their current order
+		return AssembleRandomized(operand, R);
+	}
+
+
+	Mat<mpfr_complex> System::RandomizationMatrix() const
+	{
+		for (auto const& b : blocks_)
+			if (auto const* rb = std::get_if<blocks::RandomizationBlock<System>>(&b))
+				return rb->RandomizationMatrix();
+		throw std::runtime_error("RandomizationMatrix: this system has no randomization block (it was not produced by Randomize()).");
 	}
 
 
@@ -1438,17 +1638,19 @@ namespace bertini
 		               : std::static_pointer_cast<node::Node>(node::Rational::Make(node::Rational::Rand()));
 
 		System homotopy;
-		if (start.HasStructuredBlocks())
+		if (start.HasStructuredBlocks() || target.HasStructuredBlocks())
 		{
-			// A block-backed start system (e.g. a products-of-linears start) cannot be fused
-			// into a node-arithmetic homotopy, so combine the two systems with a blend block:
-			// H = (1-t)*target + gamma*t*start, evaluated by blending whole Systems.  The
-			// homotopy carries target's variable structure and patch; the blend contributes the
-			// natural rows.  ClearFunctions drops target's own polynomial block so its functions
-			// aren't evaluated a second time alongside the blend (the blend already references
-			// target).  Mirrors policy::CloneGiven::FormHomotopy.
+			// A block-backed system (e.g. a products-of-linears start, or a randomized target)
+			// cannot be fused into a node-arithmetic homotopy: operator+ / operator* only combine
+			// the PolynomialBlock functions and silently ignore structured blocks.  So whenever
+			// EITHER side carries a structured block, combine the two systems with a blend block:
+			// H = (1-t)*target + gamma*t*start, evaluated by blending whole Systems.  The homotopy
+			// carries target's variable structure and patch; the blend contributes the natural
+			// rows.  ClearBlocks drops the shell's own function blocks (a structured target's rows
+			// live in a structured block, not a PolynomialBlock, so ClearFunctions would leave them
+			// to be evaluated a second time alongside the blend).  Mirrors policy::CloneGiven::FormHomotopy.
 			homotopy = target;
-			homotopy.ClearFunctions();
+			homotopy.ClearBlocks();
 			homotopy.AddPathVariable(t);
 			std::vector<std::shared_ptr<node::Node>> coeffs{ 1 - t, g * t };
 			std::vector<std::shared_ptr<const System>> operands{

--- a/core/src/system/system.cpp
+++ b/core/src/system/system.cpp
@@ -1073,7 +1073,37 @@ namespace bertini
 						out.push_back(gi ? gi : Nd(Integer::Make(0)));
 					}
 				}
-				else // LinearFormsBlock and any future block
+				else if constexpr (std::is_same_v<B, blocks::LinearFormsBlock>)
+				{
+					// each row is one affine linear form  sum_c M(r,c)*vars[c] (+ constant).  Affine:
+					// the trailing column is the constant.  Homogeneous (post-Homogenize): every column
+					// is a variable column (the old constant is now the homogenizing-variable coeff).
+					auto const& M = b.Coefficients();
+					const size_t n = b.NumVariables();
+					if (static_cast<size_t>(vars.size()) != n)
+						throw std::runtime_error("ExpandToFunctionTree: linear-forms variable count mismatch");
+					for (Eigen::Index r = 0; r < M.rows(); ++r)
+					{
+						if (b.IsHomogenized())
+						{
+							Nd form = nullptr;
+							for (size_t c = 0; c < n; ++c)
+							{
+								mpfr_complex const& coeff = M(r, static_cast<Eigen::Index>(c));
+								if (coeff.real() == 0 && coeff.imag() == 0)
+									continue;
+								Nd term = node::Float::Make(coeff) * vars[c];
+								form = form ? (form + term) : term;
+							}
+							out.push_back(form ? form : Nd(Integer::Make(0)));
+						}
+						else
+						{
+							out.push_back(LinearFormNode(M, r, vars, n));   // augmented: last col is the constant
+						}
+					}
+				}
+				else // any future block
 				{
 					throw std::runtime_error("ExpandToFunctionTree: block type not yet supported");
 				}
@@ -1663,6 +1693,38 @@ namespace bertini
 			homotopy = (1-t)*target + g*t*start;
 			homotopy.AddPathVariable(t);
 		}
+		return homotopy;
+	}
+
+
+	System MakeMovingHomotopy(System const& fixed, System const& start_moving, System const& end_moving,
+	                          std::string const& path_variable_name,
+	                          std::shared_ptr<node::Node> const& gamma)
+	{
+		if (start_moving.NumNaturalFunctions() != end_moving.NumNaturalFunctions())
+			throw std::runtime_error("MakeMovingHomotopy: start_moving and end_moving must have the same number of functions (they are the two endpoints of the moving rows).");
+		if (fixed.NumVariables() != start_moving.NumVariables() || fixed.NumVariables() != end_moving.NumVariables())
+			throw std::runtime_error("MakeMovingHomotopy: fixed, start_moving and end_moving must share the same variable structure.");
+		if (start_moving.HavePathVariable() || end_moving.HavePathVariable() || fixed.HavePathVariable())
+			throw std::runtime_error("MakeMovingHomotopy: the fixed and moving systems must not already have a path variable.");
+
+		auto t = node::Variable::Make(path_variable_name);
+		auto g = gamma ? gamma
+		               : std::static_pointer_cast<node::Node>(node::Rational::Make(node::Rational::Rand()));
+
+		// Keep the fixed system's blocks as sibling blocks (do NOT clear them): they are autonomous,
+		// so they are evaluated once per point and contribute nothing to dH/dt as the moving rows
+		// slide.  Append a single blend block that moves only the moving rows:
+		//   moving = (1-t)*end_moving + gamma*t*start_moving   (t=1 -> gamma*start, t=0 -> end).
+		// Mirrors MakeHomotopy's blend branch, but blends only the moving operands instead of whole
+		// systems, so the fixed equations are never duplicated or scaled.
+		System homotopy = fixed;
+		homotopy.AddPathVariable(t);
+		std::vector<std::shared_ptr<node::Node>> coeffs{ 1 - t, g * t };
+		std::vector<std::shared_ptr<const System>> operands{
+			std::make_shared<System>(end_moving),
+			std::make_shared<System>(start_moving) };
+		homotopy.AddBlock(blocks::BlendBlock<System>(t, std::move(coeffs), std::move(operands)));
 		return homotopy;
 	}
 

--- a/core/src/system/system.cpp
+++ b/core/src/system/system.cpp
@@ -1469,79 +1469,81 @@ namespace bertini
 	//
 	////////////////////
 
+	void System::Describe(std::ostream& out, bool verbose) const
+	{
+		// --- variables ---
+		out << NumVariableGroups() << (NumVariableGroups() == 1 ? " variable group:\n" : " variable groups:\n");
+		{
+			auto counter = 0;
+			for (const auto& grp : variable_groups_)
+			{
+				out << "  group " << counter++ << ": ";
+				for (auto const& v : grp) out << *v << " ";
+				out << "\n";
+			}
+		}
+		if (!hom_variable_groups_.empty())
+		{
+			out << NumHomVariableGroups() << " projective variable groups:\n";
+			auto counter = 0;
+			for (const auto& grp : hom_variable_groups_)
+			{
+				out << "  group " << counter++ << ": ";
+				for (auto const& v : grp) out << *v << " ";
+				out << "\n";
+			}
+		}
+		if (NumHomVariables() != 0)
+		{
+			out << "  homogenizing variables: ";
+			for (const auto& v : homogenizing_variables_) out << *v << " ";
+			out << "\n";
+		}
+		if (!ungrouped_variables_.empty())
+		{
+			out << "  ungrouped variables: ";
+			for (const auto& v : ungrouped_variables_) out << *v << " ";
+			out << "\n";
+		}
+
+		// --- functions, block by block ---
+		out << "\n" << NumNaturalFunctions() << (NumNaturalFunctions() == 1 ? " function:\n" : " functions:\n");
+		VariableGroup vars;
+		try { vars = VariableOrdering(); } catch (...) { /* unordered/malformed: print without var names */ }
+		size_t row = 0;
+		for (auto const& blk : blocks_)
+			std::visit([&](auto const& b){ b.Describe(out, row, vars, verbose); }, blk);
+
+		// --- parameters / constants (only when present) ---
+		if (NumParameters())
+		{
+			out << "\n" << NumParameters() << " explicit parameters:\n";
+			for (const auto& p : explicit_parameters_)
+				out << "  " << p->name() << " = " << p->EntryNode() << "\n";
+		}
+		if (NumConstants())
+		{
+			out << "\n" << NumConstants() << " constants:\n";
+			for (const auto& c : PolyBlockPtr()->ConstantSubfunctions())
+				out << "  " << c->name() << " = " << c->EntryNode() << "\n";
+		}
+
+		// --- path variable / patch (only the informative bits) ---
+		if (path_variable_)
+			out << "\npath variable: " << path_variable_->name() << "\n";
+		if (IsPatched())
+		{
+			if (verbose)
+				out << "\n" << patch_;
+			else
+				out << "\npatched (" << NumPatches() << (NumPatches() == 1 ? " patch)\n" : " patches)\n");
+		}
+	}
+
+
 	std::ostream& operator<<(std::ostream& out, const bertini::System & s)
 	{
-
-
-		out << s.NumVariableGroups() << " variable groups, containing these variables:\n";
-		auto counter = 0;
-		for (const auto& iter : s.variable_groups_)
-		{
-			out << "group " << counter << ": "<< "\n";
-			for (auto jter : iter)
-				out << *jter << " ";
-
-
-			out << "\n";
-			counter++;
-		}
-		out << "\n";
-
-		out << s.NumHomVariables() << " homogenizing variables:\n";
-		for (const auto& iter : s.homogenizing_variables_)
-			out << (*iter) << " ";
-		out << "\n\n";
-
-
-		out << s.ungrouped_variables_.size() << " ungrouped variables:\n";
-		for (const auto& v :s.ungrouped_variables_)
-			out << (*v) << " ";
-		out << "\n\n";
-
-
-		out << s.NumNaturalFunctions() << " functions:\n";
-		for (const auto& iter : s.GetNaturalFunctions()) 
-			out << (iter)->name() << " = " << *iter << "\n";
-		out << "\n";
-
-
-		if (s.NumParameters()) {
-			out << s.NumParameters() << " explicit parameters:\n";
-			for (const auto& iter : s.explicit_parameters_)
-				out << (iter)->name() << " = " << *iter << "\n";
-			out << "\n";
-		}
-
-
-		if (s.NumConstants()) {
-			out << s.NumConstants() << " constants:\n";
-			for (const auto& iter : s.PolyBlockPtr()->ConstantSubfunctions())
-				out << (iter)->name() << " = " << *iter << "\n";
-			out << "\n";
-		}
-
-		if (s.path_variable_)
-			out << "path variable defined.  named " << s.path_variable_->name() << "\n";
-		else 
-			out << "no path variable defined\n";
-
-		if (s.is_differentiated_)
-			out << "system is differentiated.\n";
-		else
-			out << "system not differentiated\n";
-
-		if (s.IsPatched())
-		{
-			out << s.patch_;
-		}
-		else{
-			out << "system not patched\n";
-		}
-
-		out << "\ncurrent variable values:\n";
-		out << std::get< Vec<dbl> > (s.current_variable_values_) << "\n";
-		out << std::get< Vec<mpfr_complex> > (s.current_variable_values_) << "\n";
-
+		s.Describe(out, /*verbose=*/false);
 		return out;
 	}
 

--- a/core/test/classes/moving_homotopy_test.cpp
+++ b/core/test/classes/moving_homotopy_test.cpp
@@ -1,0 +1,228 @@
+//This file is part of Bertini 2.
+//
+//moving_homotopy_test.cpp is free software: you can redistribute it and/or modify
+//it under the terms of the GNU General Public License as published by
+//the Free Software Foundation, either version 3 of the License, or
+//(at your option) any later version.
+//
+//moving_homotopy_test.cpp is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//GNU General Public License for more details.
+//
+//You should have received a copy of the GNU General Public License
+//along with this file.  If not, see <http://www.gnu.org/licenses/>.
+//
+// Copyright(C) Bertini2 Development Team
+
+/**
+\file moving_homotopy_test.cpp
+
+\brief Unit tests for MakeMovingHomotopy: move only the moving rows, keep the fixed system as its
+own blocks (evaluated once, contributing zero to dH/dt).
+*/
+
+#include <boost/test/unit_test.hpp>
+
+#include "bertini2/system/system.hpp"
+#include "bertini2/system/blocks/block.hpp"
+
+BOOST_AUTO_TEST_SUITE(moving_homotopy_suite)
+
+using namespace bertini;
+using bertini::node::Variable;
+
+// gamma fixed off the real axis for reproducibility.
+static std::shared_ptr<node::Node> Gamma()
+{
+	return node::Float::Make(mpfr_complex("0.6", "0.8"));
+}
+
+// A LinearFormsBlock-backed single-form system  c.[x;1]  over variables {x,y}.
+static System LinearFormSystem(std::shared_ptr<node::Variable> x, std::shared_ptr<node::Variable> y,
+                               mpfr_complex cx, mpfr_complex cy, mpfr_complex c1)
+{
+	System s;
+	s.AddVariableGroup(VariableGroup{x, y});
+	Mat<mpfr_complex> M(1, 3);
+	M << cx, cy, c1;
+	s.AddBlock(blocks::LinearFormsBlock(2, M));
+	return s;
+}
+
+// H, its expansion twin, agree on values AND Jacobian at several (point, t), in dbl and mpfr.
+static void AgreesWithExpansionAtTimes(System const& H)
+{
+	System twin = H.ExpandToFunctionTree();
+	BOOST_REQUIRE_EQUAL(H.NumNaturalFunctions(), twin.NumNaturalFunctions());
+	// (no Degrees() comparison: the blend reports space-only degree, while the expanded node tree
+	//  counts the path variable t too, so they legitimately differ for a homotopy.)
+
+	const Eigen::Index nv = static_cast<Eigen::Index>(H.NumVariables());
+	std::vector<dbl> times{dbl(1.0), dbl(0.0), dbl(0.37, -0.21)};
+
+	Vec<dbl> p(nv);
+	for (Eigen::Index k = 0; k < nv; ++k) p(k) = dbl(0.3 + 0.13 * static_cast<double>(k), 0.4 - 0.07 * static_cast<double>(k));
+
+	for (auto t : times)
+	{
+		Vec<dbl> a = H.Eval(p, t),  b = twin.Eval(p, t);
+		for (Eigen::Index i = 0; i < a.size(); ++i)
+			BOOST_CHECK(std::abs(a(i) - b(i)) < 1e-10);
+
+		Mat<dbl> ja = H.Jacobian(p, t), jb = twin.Jacobian(p, t);
+		for (Eigen::Index i = 0; i < ja.rows(); ++i)
+			for (Eigen::Index j = 0; j < ja.cols(); ++j)
+				BOOST_CHECK(std::abs(ja(i, j) - jb(i, j)) < 1e-10);
+
+		Vec<dbl> da = H.TimeDerivative(p, t), db = twin.TimeDerivative(p, t);
+		for (Eigen::Index i = 0; i < da.size(); ++i)
+			BOOST_CHECK(std::abs(da(i) - db(i)) < 1e-10);
+	}
+
+	// one mpfr cross-check
+	DefaultPrecision(40);
+	Vec<mpfr_complex> pm(nv);
+	for (Eigen::Index k = 0; k < nv; ++k) pm(k) = mpfr_complex(p(k).real(), p(k).imag());
+	mpfr_complex tm("0.37", "-0.21");
+	Vec<mpfr_complex> am = H.Eval(pm, tm), bm = twin.Eval(pm, tm);
+	for (Eigen::Index i = 0; i < am.size(); ++i)
+		BOOST_CHECK(abs(am(i) - bm(i)) < mpfr_float("1e-30"));
+	Mat<mpfr_complex> jam = H.Jacobian(pm, tm), jbm = twin.Jacobian(pm, tm);
+	for (Eigen::Index i = 0; i < jam.rows(); ++i)
+		for (Eigen::Index j = 0; j < jam.cols(); ++j)
+			BOOST_CHECK(abs(jam(i, j) - jbm(i, j)) < mpfr_float("1e-30"));
+}
+
+
+// fixed = unit circle (PolynomialBlock); moving slice y (start) -> y-x (end), both polynomial.
+static System CircleMovingSlice()
+{
+	auto x = Variable::Make("x"), y = Variable::Make("y");
+	System fixed; fixed.AddVariableGroup(VariableGroup{x, y});
+	fixed.AddFunction(x*x + y*y - node::Integer::Make(1));
+	System start_moving; start_moving.AddVariableGroup(VariableGroup{x, y}); start_moving.AddFunction(y);
+	System end_moving;   end_moving.AddVariableGroup(VariableGroup{x, y});   end_moving.AddFunction(y - x);
+	return MakeMovingHomotopy(fixed, start_moving, end_moving, "t", Gamma());
+}
+
+
+BOOST_AUTO_TEST_CASE(shape_and_path_variable)
+{
+	DefaultPrecision(30);
+	System H = CircleMovingSlice();
+	BOOST_CHECK_EQUAL(H.NumNaturalFunctions(), 2u);     // 1 fixed (circle) + 1 moving (slice)
+	BOOST_CHECK(H.HavePathVariable());
+}
+
+BOOST_AUTO_TEST_CASE(endpoints_t0_and_t1)
+{
+	DefaultPrecision(40);
+	System H = CircleMovingSlice();
+
+	Vec<dbl> p(2); p << dbl(0.4, 0.2), dbl(-0.3, 0.5);
+	const dbl circle = p(0)*p(0) + p(1)*p(1) - dbl(1);
+
+	// t = 0: moving row = end_moving = y - x ; fixed row = circle.
+	Vec<dbl> at0 = H.Eval(p, dbl(0));
+	BOOST_CHECK(std::abs(at0(0) - circle) < 1e-12);
+	BOOST_CHECK(std::abs(at0(1) - (p(1) - p(0))) < 1e-12);
+
+	// t = 1: moving row = gamma * start_moving = gamma * y ; fixed row still circle.
+	const dbl gamma(0.6, 0.8);
+	Vec<dbl> at1 = H.Eval(p, dbl(1));
+	BOOST_CHECK(std::abs(at1(0) - circle) < 1e-12);
+	BOOST_CHECK(std::abs(at1(1) - gamma * p(1)) < 1e-12);
+}
+
+BOOST_AUTO_TEST_CASE(fixed_row_is_left_out_of_time_derivative)
+{
+	DefaultPrecision(40);
+	System H = CircleMovingSlice();
+
+	Vec<dbl> p(2); p << dbl(0.4, 0.2), dbl(-0.3, 0.5);
+	// dH/dt = [ 0 (circle is t-independent) ; -end + gamma*start = -(y-x) + gamma*y ]
+	Vec<dbl> dt = H.TimeDerivative(p, dbl(0.5));
+	BOOST_CHECK(std::abs(dt(0)) < 1e-14);                                  // fixed row: exactly out
+	const dbl gamma(0.6, 0.8);
+	BOOST_CHECK(std::abs(dt(1) - (-(p(1) - p(0)) + gamma * p(1))) < 1e-12); // moving row
+}
+
+BOOST_AUTO_TEST_CASE(matches_expansion_polynomial_moving)
+{
+	DefaultPrecision(40);
+	AgreesWithExpansionAtTimes(CircleMovingSlice());
+}
+
+BOOST_AUTO_TEST_CASE(static_slice_and_moving_slice_both_fixed)
+{
+	// fixed = circle (poly) + a STATIC linear-forms slice  x ; moving slice y -> y - x.
+	DefaultPrecision(40);
+	auto x = Variable::Make("x"), y = Variable::Make("y");
+	System fixed; fixed.AddVariableGroup(VariableGroup{x, y});
+	fixed.AddFunction(x*x + y*y - node::Integer::Make(1));               // row 0: circle (PolynomialBlock)
+	Mat<mpfr_complex> M(1, 3); M << mpfr_complex(1), mpfr_complex(0), mpfr_complex(0);
+	fixed.AddBlock(blocks::LinearFormsBlock(2, M));                      // row 1: static slice x=0 (LinearFormsBlock)
+
+	System start_moving = LinearFormSystem(x, y, mpfr_complex(0), mpfr_complex(1), mpfr_complex(0));   // y
+	System end_moving;   end_moving.AddVariableGroup(VariableGroup{x, y}); end_moving.AddFunction(y - x);
+
+	System H = MakeMovingHomotopy(fixed, start_moving, end_moving, "t", Gamma());
+	BOOST_CHECK_EQUAL(H.NumNaturalFunctions(), 3u);
+
+	// both fixed rows (circle, static slice) are out of dH/dt; only the moving row survives.
+	Vec<dbl> p(2); p << dbl(0.4, 0.2), dbl(-0.3, 0.5);
+	Vec<dbl> dt = H.TimeDerivative(p, dbl(0.5));
+	BOOST_CHECK(std::abs(dt(0)) < 1e-14);
+	BOOST_CHECK(std::abs(dt(1)) < 1e-14);
+	BOOST_CHECK(std::abs(dt(2)) > 1e-3);
+
+	AgreesWithExpansionAtTimes(H);
+}
+
+BOOST_AUTO_TEST_CASE(deform_products_of_linears_into_polynomial)
+{
+	// regeneration step: deform (x-1)(x+1) (a products-of-linears block) into the circle, with a
+	// static slice y (= the fixed row).
+	DefaultPrecision(40);
+	auto x = Variable::Make("x"), y = Variable::Make("y");
+	System fixed = LinearFormSystem(x, y, mpfr_complex(0), mpfr_complex(1), mpfr_complex(0));  // y (static)
+
+	System start_moving; start_moving.AddVariableGroup(VariableGroup{x, y});
+	Mat<mpfr_complex> f(2, 3);
+	f << mpfr_complex(1), mpfr_complex(0), mpfr_complex(-1),     // (x - 1)
+	     mpfr_complex(1), mpfr_complex(0), mpfr_complex(1);      // (x + 1)
+	start_moving.AddBlock(blocks::ProductsOfLinearsBlock(2, std::vector<Mat<mpfr_complex>>{f}));
+
+	System end_moving; end_moving.AddVariableGroup(VariableGroup{x, y});
+	end_moving.AddFunction(x*x + y*y - node::Integer::Make(1));
+
+	System H = MakeMovingHomotopy(fixed, start_moving, end_moving, "t", Gamma());
+	BOOST_CHECK_EQUAL(H.NumNaturalFunctions(), 2u);
+
+	// at t=1 the moving row is gamma*(x-1)(x+1) = gamma*(x^2-1); at t=0 it is the circle.
+	Vec<dbl> p(2); p << dbl(2.0), dbl(3.0);
+	const dbl gamma(0.6, 0.8);
+	Vec<dbl> at1 = H.Eval(p, dbl(1));
+	BOOST_CHECK(std::abs(at1(1) - gamma * (p(0)*p(0) - dbl(1))) < 1e-10);
+	Vec<dbl> at0 = H.Eval(p, dbl(0));
+	BOOST_CHECK(std::abs(at0(1) - (p(0)*p(0) + p(1)*p(1) - dbl(1))) < 1e-10);
+
+	// fixed (static slice) row out of dH/dt
+	Vec<dbl> dt = H.TimeDerivative(p, dbl(0.5));
+	BOOST_CHECK(std::abs(dt(0)) < 1e-14);
+
+	AgreesWithExpansionAtTimes(H);
+}
+
+BOOST_AUTO_TEST_CASE(rejects_mismatched_endpoints)
+{
+	DefaultPrecision(30);
+	auto x = Variable::Make("x"), y = Variable::Make("y");
+	System fixed; fixed.AddVariableGroup(VariableGroup{x, y}); fixed.AddFunction(x*x + y*y - node::Integer::Make(1));
+	System sm; sm.AddVariableGroup(VariableGroup{x, y}); sm.AddFunction(y);
+	System em; em.AddVariableGroup(VariableGroup{x, y}); em.AddFunction(y - x); em.AddFunction(x);  // 2 != 1
+	BOOST_CHECK_THROW(MakeMovingHomotopy(fixed, sm, em, "t", Gamma()), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/core/test/classes/randomization_block_test.cpp
+++ b/core/test/classes/randomization_block_test.cpp
@@ -1,0 +1,332 @@
+//This file is part of Bertini 2.
+//
+//randomization_block_test.cpp is free software: you can redistribute it and/or modify
+//it under the terms of the GNU General Public License as published by
+//the Free Software Foundation, either version 3 of the License, or
+//(at your option) any later version.
+//
+//randomization_block_test.cpp is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//GNU General Public License for more details.
+//
+//You should have received a copy of the GNU General Public License
+//along with this file.  If not, see <http://www.gnu.org/licenses/>.
+//
+// Copyright(C) Bertini2 Development Team
+
+/**
+\file randomization_block_test.cpp
+
+\brief Unit tests for RandomizationBlock and System::Randomize.
+
+The workhorse oracle is ExpandToFunctionTree(): a randomized system evaluated through its block
+must agree, value-for-value and derivative-for-derivative, with the same system expanded to plain
+function-tree nodes -- in both dbl and mpfr_complex, before AND after homogenization (so the
+homogenizing-variable power deficits are exercised), for single- and multi-projective systems.
+That cross-check is deterministic on every platform, unlike a heap-dirtiness-dependent bug.
+*/
+
+#include <boost/test/unit_test.hpp>
+
+#include "bertini2/system/system.hpp"
+#include "bertini2/system/blocks/block.hpp"
+#include "bertini2/system/blocks/randomization_block.hpp"
+
+BOOST_AUTO_TEST_SUITE(randomization_block_suite)
+
+using namespace bertini;
+using bertini::node::Variable;
+using bertini::blocks::RandomizationBlock;
+using Randomization = RandomizationBlock<System>;
+
+// The contract is checkable here (System is complete), even though block.hpp cannot static_assert
+// it (System is only forward-declared there).
+static_assert(bertini::blocks::is_block_v<Randomization>,
+              "RandomizationBlock<System> must satisfy the block contract");
+
+
+// ---- helpers -------------------------------------------------------------------------------
+
+// An overdetermined single-affine-group system of UNEQUAL degrees (so randomization needs the
+// h-power deficits once homogenized): f0 = x^2 + y^2 - 1 (deg 2), f1 = x - y (deg 1),
+// f2 = 2x^2 - 1 (deg 2).  Common zeros are the two points (+/- 1/sqrt2, +/- 1/sqrt2) with x = y.
+static System OverdeterminedSingleGroup()
+{
+	auto x = Variable::Make("x");
+	auto y = Variable::Make("y");
+	System s;
+	s.AddVariableGroup(VariableGroup{x, y});
+	s.AddFunction(x * x + y * y - node::Integer::Make(1));
+	s.AddFunction(x - y);
+	s.AddFunction(node::Integer::Make(2) * x * x - node::Integer::Make(1));
+	return s;
+}
+
+// An overdetermined two-affine-group system of UNEQUAL multidegrees: with groups {x}, {y},
+// f0 = x*y (md (1,1)), f1 = x*x*y (md (2,1)), f2 = x (md (1,0)), f3 = y (md (0,1)).
+static System OverdeterminedMultiGroup()
+{
+	auto x = Variable::Make("x");
+	auto y = Variable::Make("y");
+	System s;
+	s.AddVariableGroup(VariableGroup{x});
+	s.AddVariableGroup(VariableGroup{y});
+	s.AddFunction(x * y);
+	s.AddFunction(x * x * y);
+	s.AddFunction(x);
+	s.AddFunction(y);
+	return s;
+}
+
+// Compare a block-composed system against its function-tree expansion at a handful of points, in
+// both numeric types.  Covers values AND the Jacobian.
+static void AgreesWithExpansion(System const& sys)
+{
+	System twin = sys.ExpandToFunctionTree();
+
+	BOOST_REQUIRE_EQUAL(sys.NumNaturalFunctions(), twin.NumNaturalFunctions());
+	BOOST_REQUIRE_EQUAL(sys.NumVariables(), twin.NumVariables());
+	// the randomized rows' degrees must survive the expansion
+	BOOST_CHECK(sys.Degrees() == twin.Degrees());
+
+	const Eigen::Index nv = static_cast<Eigen::Index>(sys.NumVariables());
+
+	// a few non-degenerate complex points
+	std::vector<Vec<dbl>> pts;
+	{
+		Vec<dbl> p(nv);
+		for (Eigen::Index k = 0; k < nv; ++k) p(k) = dbl(0.3 + 0.17 * k, 0.5 - 0.11 * k);
+		pts.push_back(p);
+		Vec<dbl> q(nv);
+		for (Eigen::Index k = 0; k < nv; ++k) q(k) = dbl(-0.7 + 0.05 * k, 0.9 + 0.03 * k);
+		pts.push_back(q);
+	}
+
+	for (auto const& p : pts)
+	{
+		// --- dbl ---
+		Vec<dbl> ea = sys.Eval(p);
+		Vec<dbl> eb = twin.Eval(p);
+		BOOST_REQUIRE_EQUAL(ea.size(), eb.size());
+		for (Eigen::Index i = 0; i < ea.size(); ++i)
+			BOOST_CHECK(std::abs(ea(i) - eb(i)) < 1e-10);
+
+		Mat<dbl> ja = sys.Jacobian(p);
+		Mat<dbl> jb = twin.Jacobian(p);
+		BOOST_REQUIRE_EQUAL(ja.rows(), jb.rows());
+		BOOST_REQUIRE_EQUAL(ja.cols(), jb.cols());
+		for (Eigen::Index i = 0; i < ja.rows(); ++i)
+			for (Eigen::Index j = 0; j < ja.cols(); ++j)
+				BOOST_CHECK(std::abs(ja(i, j) - jb(i, j)) < 1e-10);
+
+		// --- mpfr_complex ---
+		DefaultPrecision(40);
+		Vec<mpfr_complex> pm(nv);
+		for (Eigen::Index k = 0; k < nv; ++k)
+			pm(k) = mpfr_complex(p(k).real(), p(k).imag());
+
+		Vec<mpfr_complex> ema = sys.Eval(pm);
+		Vec<mpfr_complex> emb = twin.Eval(pm);
+		for (Eigen::Index i = 0; i < ema.size(); ++i)
+			BOOST_CHECK(abs(ema(i) - emb(i)) < mpfr_float("1e-30"));
+
+		Mat<mpfr_complex> jma = sys.Jacobian(pm);
+		Mat<mpfr_complex> jmb = twin.Jacobian(pm);
+		for (Eigen::Index i = 0; i < jma.rows(); ++i)
+			for (Eigen::Index j = 0; j < jma.cols(); ++j)
+				BOOST_CHECK(abs(jma(i, j) - jmb(i, j)) < mpfr_float("1e-30"));
+	}
+}
+
+
+// ---- shape / construction ------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(randomize_squares_the_system)
+{
+	DefaultPrecision(30);
+	System s = OverdeterminedSingleGroup();
+	BOOST_REQUIRE_EQUAL(s.NumNaturalFunctions(), 3u);
+
+	System r = s.Randomize();
+
+	BOOST_CHECK_EQUAL(r.NumNaturalFunctions(), 2u);   // n = NumVariables - NumHomVariableGroups = 2
+	BOOST_CHECK_EQUAL(r.NumVariables(), 2u);
+	// the original system is NOT mutated
+	BOOST_CHECK_EQUAL(s.NumNaturalFunctions(), 3u);
+}
+
+BOOST_AUTO_TEST_CASE(randomize_does_not_mutate_original_ordering)
+{
+	DefaultPrecision(30);
+	System s = OverdeterminedSingleGroup();
+	auto degs_before = s.Degrees();      // (2,1,2) in author order
+	s.Randomize();
+	auto degs_after = s.Degrees();
+	BOOST_CHECK(degs_before == degs_after);  // the descending sort happened on the copy, not on s
+}
+
+BOOST_AUTO_TEST_CASE(optimal_path_count_is_product_of_top_n_degrees)
+{
+	DefaultPrecision(30);
+	System s = OverdeterminedSingleGroup();   // degrees 2,1,2 -> top two are 2,2
+	System r = s.Randomize();
+	auto d = r.Degrees();
+	BOOST_REQUIRE_EQUAL(d.size(), 2u);
+	int product = 1;
+	for (int e : d) product *= e;
+	BOOST_CHECK_EQUAL(product, 4);            // 2*2, not 2^3 nor (maxdeg)^n with the low one inflated
+}
+
+BOOST_AUTO_TEST_CASE(matrix_getter_round_trips_and_is_I_C)
+{
+	DefaultPrecision(30);
+	System s = OverdeterminedSingleGroup();
+	System r = s.Randomize();
+
+	auto const& block = std::get<Randomization>(r.Blocks().front());
+	auto const& R = block.RandomizationMatrix();
+	BOOST_REQUIRE_EQUAL(R.rows(), 2);
+	BOOST_REQUIRE_EQUAL(R.cols(), 3);
+	// leading 2x2 is the identity (the [I | C] structure after the descending sort)
+	BOOST_CHECK(R(0, 0) == mpfr_complex(1) && R(1, 1) == mpfr_complex(1));
+	BOOST_CHECK(R(0, 1) == mpfr_complex(0) && R(1, 0) == mpfr_complex(0));
+}
+
+BOOST_AUTO_TEST_CASE(underdetermined_throws)
+{
+	DefaultPrecision(30);
+	auto x = Variable::Make("x");
+	auto y = Variable::Make("y");
+	auto z = Variable::Make("z");
+	System s;
+	s.AddVariableGroup(VariableGroup{x, y, z});
+	s.AddFunction(x + y + z);            // 1 function, 3 variables
+	BOOST_CHECK_THROW(s.Randomize(), std::runtime_error);
+}
+
+
+// ---- evaluation correctness via the expansion oracle ---------------------------------------
+
+BOOST_AUTO_TEST_CASE(affine_single_group_matches_expansion)
+{
+	DefaultPrecision(40);
+	System r = OverdeterminedSingleGroup().Randomize();   // affine, not yet homogenized
+	AgreesWithExpansion(r);
+}
+
+BOOST_AUTO_TEST_CASE(homogenized_single_group_matches_expansion)
+{
+	DefaultPrecision(40);
+	System r = OverdeterminedSingleGroup().Randomize();
+	r.Homogenize();                                       // exercises the h-power deficit (deg-1 fn padded by h)
+	AgreesWithExpansion(r);
+}
+
+BOOST_AUTO_TEST_CASE(affine_multi_group_matches_expansion)
+{
+	DefaultPrecision(40);
+	System r = OverdeterminedMultiGroup().Randomize();
+	AgreesWithExpansion(r);
+}
+
+BOOST_AUTO_TEST_CASE(homogenized_multi_group_matches_expansion)
+{
+	DefaultPrecision(40);
+	System r = OverdeterminedMultiGroup().Randomize();
+	r.Homogenize();                                       // per-group hom-var power deficits
+	AgreesWithExpansion(r);
+}
+
+
+// ---- user-supplied matrix ------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(user_supplied_matrix_reproduces_combination)
+{
+	DefaultPrecision(40);
+	System s = OverdeterminedSingleGroup();    // f0=x^2+y^2-1, f1=x-y, f2=2x^2-1 (order preserved)
+
+	// g0 = 1*f0 + 0*f1 + 0*f2 ; g1 = 3*f0 + 0*f1 + 5*f2  (kept in author order: f0 has max degree)
+	Mat<mpfr_complex> R(2, 3);
+	R << mpfr_complex(1), mpfr_complex(0), mpfr_complex(0),
+	     mpfr_complex(3), mpfr_complex(0), mpfr_complex(5);
+	System r = s.Randomize(R);
+
+	BOOST_CHECK_EQUAL(r.NumNaturalFunctions(), 2u);
+
+	// at (x,y) = (2,3):  f0 = 4+9-1 = 12, f2 = 8-1 = 7.  g0 = 12, g1 = 3*12 + 5*7 = 71.
+	Vec<dbl> p(2); p << dbl(2), dbl(3);
+	Vec<dbl> g = r.Eval(p);
+	BOOST_CHECK(std::abs(g(0) - dbl(12)) < 1e-10);
+	BOOST_CHECK(std::abs(g(1) - dbl(71)) < 1e-10);
+
+	// and it agrees with its own expansion, affine and homogenized
+	AgreesWithExpansion(r);
+	r.Homogenize();
+	AgreesWithExpansion(r);
+}
+
+BOOST_AUTO_TEST_CASE(user_supplied_matrix_wrong_columns_throws)
+{
+	DefaultPrecision(30);
+	System s = OverdeterminedSingleGroup();   // 3 natural functions
+	Mat<mpfr_complex> R(2, 2);                // 2 columns != 3
+	R << mpfr_complex(1), mpfr_complex(0), mpfr_complex(0), mpfr_complex(1);
+	BOOST_CHECK_THROW(s.Randomize(R), std::runtime_error);
+}
+
+
+// ---- ADR-0021: a block fully defines its own rows into a dirty buffer ----------------------
+
+BOOST_AUTO_TEST_CASE(eval_and_jacobian_fully_define_rows_in_a_dirty_buffer)
+{
+	DefaultPrecision(40);
+	System r = OverdeterminedSingleGroup().Randomize();
+	r.Homogenize();
+
+	auto const& block = std::get<Randomization>(r.Blocks().front());
+	const Eigen::Index n  = static_cast<Eigen::Index>(r.NumNaturalFunctions());
+	const Eigen::Index nv = static_cast<Eigen::Index>(r.NumVariables());
+
+	Vec<dbl> p(nv);
+	for (Eigen::Index k = 0; k < nv; ++k) p(k) = dbl(0.4 + 0.1 * k, 0.2 - 0.05 * k);
+
+	// poison the output buffers with a huge value; the block must overwrite every owned entry.
+	Vec<dbl> seg(n);   seg.setConstant(dbl(1e300, 1e300));
+	Mat<dbl> jac(n, nv); jac.setConstant(dbl(1e300, 1e300));
+
+	block.EvalInPlace<dbl>(seg, p, dbl(0));
+	block.JacobianInPlace<dbl>(jac, p, dbl(0));
+
+	// reference: the function-tree expansion of just the block's rows
+	System twin = r.ExpandToFunctionTree();
+	Vec<dbl> seg_ref = twin.Eval(p);
+	Mat<dbl> jac_ref = twin.Jacobian(p);
+
+	for (Eigen::Index i = 0; i < n; ++i)
+		BOOST_CHECK(std::abs(seg(i) - seg_ref(i)) < 1e-10);
+	for (Eigen::Index i = 0; i < n; ++i)
+		for (Eigen::Index j = 0; j < nv; ++j)
+			BOOST_CHECK(std::abs(jac(i, j) - jac_ref(i, j)) < 1e-10);
+}
+
+
+// ---- metadata ------------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(metadata)
+{
+	DefaultPrecision(30);
+	System r = OverdeterminedSingleGroup().Randomize();
+	auto const& block = std::get<Randomization>(r.Blocks().front());
+	BOOST_CHECK_EQUAL(block.NumFunctions(), 2u);
+	BOOST_CHECK(!block.DependsOnPathVariable());     // autonomous operand
+	BOOST_CHECK(!block.HasConstantJacobian());
+
+	// time-derivative is identically zero
+	Vec<dbl> p(2); p << dbl(1), dbl(1);
+	Vec<dbl> dt(2); dt.setConstant(dbl(7));
+	block.TimeDerivInPlace<dbl>(dt, p, dbl(0));
+	BOOST_CHECK(std::abs(dt(0)) < 1e-14 && std::abs(dt(1)) < 1e-14);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/core/test/classes/system_printing_test.cpp
+++ b/core/test/classes/system_printing_test.cpp
@@ -1,0 +1,122 @@
+//This file is part of Bertini 2.
+//
+//system_printing_test.cpp is free software: you can redistribute it and/or modify
+//it under the terms of the GNU General Public License as published by
+//the Free Software Foundation, either version 3 of the License, or
+//(at your option) any later version.
+//
+//system_printing_test.cpp is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//GNU General Public License for more details.
+//
+//You should have received a copy of the GNU General Public License
+//along with this file.  If not, see <http://www.gnu.org/licenses/>.
+//
+// Copyright(C) Bertini2 Development Team
+
+/**
+\file system_printing_test.cpp
+
+\brief Human-facing printing of block-composed systems (System::Describe / operator<<): terse
+placeholders by default, actual numbers + underlying functions when verbose, and none of the old
+debugging noise.
+*/
+
+#include <sstream>
+#include <boost/test/unit_test.hpp>
+
+#include "bertini2/system/system.hpp"
+#include "bertini2/system/blocks/block.hpp"
+
+BOOST_AUTO_TEST_SUITE(system_printing_suite)
+
+using namespace bertini;
+using bertini::node::Variable;
+
+static std::string Terse(System const& s)   { std::ostringstream ss; s.Describe(ss, false); return ss.str(); }
+static std::string Verbose(System const& s) { std::ostringstream ss; s.Describe(ss, true);  return ss.str(); }
+static bool Has(std::string const& hay, std::string const& needle) { return hay.find(needle) != std::string::npos; }
+
+// none of the old debugging leftovers should appear.
+static void NoNoise(std::string const& t)
+{
+	BOOST_CHECK(!Has(t, "current variable values"));
+	BOOST_CHECK(!Has(t, "differentiated"));
+	BOOST_CHECK(!Has(t, "unnamed_function"));
+}
+
+
+BOOST_AUTO_TEST_CASE(plain_polynomial)
+{
+	DefaultPrecision(30);
+	auto x = Variable::Make("x"), y = Variable::Make("y");
+	System s; s.AddVariableGroup(VariableGroup{x, y});
+	s.AddFunction(x*x + y*y - node::Integer::Make(1));
+	s.AddFunction(x - y);
+
+	std::string t = Terse(s);
+	BOOST_CHECK(Has(t, "f_0 = "));
+	BOOST_CHECK(Has(t, "f_1 = "));
+	NoNoise(t);
+}
+
+BOOST_AUTO_TEST_CASE(randomization_placeholder_and_underlying)
+{
+	DefaultPrecision(30);
+	auto x = Variable::Make("x"), y = Variable::Make("y");
+	System o; o.AddVariableGroup(VariableGroup{x, y});
+	o.AddFunction(x*x + y*y - node::Integer::Make(1));
+	o.AddFunction(x*y);
+	o.AddFunction(x*x + y*y - x - y);
+	System r = o.Randomize();
+
+	std::string t = Terse(r);
+	BOOST_CHECK(Has(t, "R . g"));
+	BOOST_CHECK(Has(t, "(R: 2x3 randomization matrix)"));
+	BOOST_CHECK(Has(t, "g_0 = "));
+	BOOST_CHECK(Has(t, "g_2 = "));
+	BOOST_CHECK(!Has(t, "R =\n"));               // the matrix is not in the terse form
+	NoNoise(t);
+
+	std::string v = Verbose(r);
+	BOOST_CHECK(Has(v, "R ="));                  // ... but it is in verbose
+}
+
+BOOST_AUTO_TEST_CASE(linear_forms_placeholder_vs_actual)
+{
+	DefaultPrecision(30);
+	auto x = Variable::Make("x"), y = Variable::Make("y");
+	System m; m.AddVariableGroup(VariableGroup{x, y});
+	m.AddFunction(x*x + y*y - node::Integer::Make(1));        // row 0: polynomial
+	Mat<mpfr_complex> M(1, 3); M << mpfr_complex(2), mpfr_complex(1), mpfr_complex(-1);
+	m.AddBlock(blocks::LinearFormsBlock(2, M));               // row 1: 2x + y - 1
+
+	std::string t = Terse(m);
+	BOOST_CHECK(Has(t, "f_0 = "));
+	BOOST_CHECK(Has(t, "f_1 = c.[x, y, 1]"));    // both rows visible; structured row is a placeholder
+
+	std::string v = Verbose(m);
+	BOOST_CHECK(Has(v, "*x") && Has(v, "*y"));   // actual coefficients shown
+}
+
+BOOST_AUTO_TEST_CASE(moving_homotopy_blend)
+{
+	DefaultPrecision(30);
+	auto x = Variable::Make("x"), y = Variable::Make("y");
+	System fixed; fixed.AddVariableGroup(VariableGroup{x, y}); fixed.AddFunction(x*x + y*y - node::Integer::Make(1));
+	System sm; sm.AddVariableGroup(VariableGroup{x, y}); sm.AddFunction(y);
+	System em; em.AddVariableGroup(VariableGroup{x, y}); em.AddFunction(y - x);
+	System H = MakeMovingHomotopy(fixed, sm, em, "t", node::Float::Make(mpfr_complex("0.6", "0.8")));
+
+	std::string t = Terse(H);
+	BOOST_CHECK(Has(t, "f_0 = "));               // the fixed polynomial row
+	BOOST_CHECK(Has(t, "blend of 2 systems"));
+	BOOST_CHECK(Has(t, "path variable: t"));
+	BOOST_CHECK(!Has(t, "f_1..f_1"));            // single moving row reads f_1
+
+	std::string v = Verbose(H);
+	BOOST_CHECK(Has(v, "A_0 = ") && Has(v, "B_0 = "));   // operand functions listed
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/docs/adr/0022-randomization-block.md
+++ b/docs/adr/0022-randomization-block.md
@@ -1,0 +1,81 @@
+# ADR-0022: Randomization of overdetermined systems is a first-class block
+
+**Status:** Accepted
+**Date:** 2026-06-17
+
+## Context
+
+An overdetermined system (N functions, n variables, N > n) with isolated solutions cannot be fed
+to a total-degree start system, which requires a square target (`system/start/total_degree.hpp`
+throws otherwise). The standard fix is **randomization**: replace the N functions with n generic
+combinations `G = R·F` whose isolated solutions still contain the target's; solve the square
+system and discard the extraneous solutions. This is the squaring-up the regeneration roadmap
+needs, and ADR-0021 already names a future `RandomizationBlock`.
+
+We implement it as a first-class, multidegree-native evaluation block rather than by inflating the
+combinations into function-tree nodes ("everything is a block").
+
+## Decision
+
+### The block wraps a System and applies a constant matrix with homogenizing-variable powers
+
+`RandomizationBlock<System>` (templated like `BlendBlock<System>` so `System` stays a dependent
+name and the `Block` variant closes) holds the overdetermined system as a `shared_ptr<System>`
+operand plus a constant coefficient matrix, and emits
+
+    g_i(x) = sum_j  c_ij · f_j(x) · prod_g  h_g^{(D_{i,g} − d_{j,g})}
+
+where `f_j` is the operand's j-th natural function (homogenized to its own multidegree `d_j`), `D_i`
+is row i's target multidegree, and `h_g` is group g's homogenizing variable. The h-power factors
+are what let a **constant** combination of functions of *differing* degree homogenize correctly:
+before homogenization every `h_g = 1` and it collapses to `g_i = Σ c_ij f_j`. The block is
+multidegree-native, so single-affine-group and multihomogeneous randomization share one evaluator,
+and (per ADR-0021) it fully defines its own rows.
+
+### Construction (`System::Randomize`)
+
+- **Single affine group → optimal.** Sort the functions by descending degree and use `R = [I | C]`
+  with random `C`. Then `deg g_i = d_i` and the total-degree path count is the product of the n
+  largest degrees — the minimum. The sort is *required*, not cosmetic: it makes every deficit
+  `D_{i,g} − d_{j,g} ≥ 0` (a negative deficit has no h-power representation).
+- **Several variable groups → correct.** Multidegrees are only partially ordered, so use a dense
+  random `R` with a common (componentwise-max) target multidegree. Correct, and optimal when the
+  functions share a multidegree (e.g. a bilinear system).
+- **User-supplied matrix.** `Randomize(R)` uses `R` verbatim, functions in their given order.
+
+`Randomize` returns a **new** system and never mutates the caller's (the descending sort happens
+on an internal copy). The matrix is retrievable via `RandomizationMatrix()` (toward future
+`R · [f]` block stringification).
+
+### Same homogenizing variables across the operand boundary
+
+The h-power factors must reference the *actual* homogenizing-variable nodes, not coincidentally
+aligned ordering positions. `RandomizationBlock::Homogenize` threads the owning system's hom var
+into the operand by homogenizing it through the new `System::Homogenize(VariableGroup const&)`
+overload, which reuses supplied hom vars instead of minting fresh ones. Operand evaluation and the
+block's deficit padding then live in one coordinate system.
+
+### Load-bearing fix: `MakeHomotopy` must blend whenever EITHER side is structured
+
+`MakeHomotopy` previously chose the blend-block path only when the **start** system carried a
+structured block, falling back to node arithmetic otherwise. But `operator+` / `operator*` on
+Systems only combine the `PolynomialBlock` functions and **silently ignore structured blocks** — so
+a structured-block *target* (exactly what a randomized system is) was dropped from the homotopy,
+which then tracked from the start system to nothing (empty / singular endpoints). `MakeHomotopy`
+now blends whenever **either** target or start has a structured block, and the homotopy shell uses
+`ClearBlocks()` (not `ClearFunctions()`, which only removes a `PolynomialBlock`) so a structured
+target's rows are not double-counted alongside the blend. This generalizes the MHom case (ADR-0020)
+to a structured target.
+
+## Consequences
+
+- Overdetermined systems solve end to end: randomize → solve the square system → filter extraneous
+  solutions by re-evaluating the original. Covered by `randomization_block_test.cpp` (eval/Jacobian
+  vs the function-tree expansion oracle, affine and homogenized, single- and multi-group, plus an
+  ADR-0021 dirty-buffer check) and `python/test/zero_dim/randomize_test.py` (solve + filter).
+- A merged tutorial (`tutorials/randomize.rst`) drives it, written as executable `.. testcode::`
+  blocks; the docs CI now runs `sphinx-build -b doctest` so the tutorials are verified code.
+- **Deferred:** provably-minimal target-multidegree *selection* for unequal multidegrees across
+  several groups (the partial-order optimization, no clean `[I|C]` analog); the constant-`C` common
+  target is correct meanwhile. Also deferred: deep-cloning a block operand for per-thread tracking
+  (shared with `BlendBlock`), and `R · [f]` stringification.

--- a/docs/adr/0023-moving-homotopy-blend-moving-rows-only.md
+++ b/docs/adr/0023-moving-homotopy-blend-moving-rows-only.md
@@ -1,0 +1,61 @@
+# ADR-0023: Moving homotopies blend only the moving rows; fixed equations stay sibling blocks
+
+**Status:** Accepted
+**Date:** 2026-06-17
+
+## Context
+
+Regeneration and moving-slice continuation need a homotopy in which most equations are **fixed** (the
+polynomial system, plus "below" linear slices that cut dimension) and only a small part **moves** with
+the path variable `t`. The fixed equations must be evaluated **once** per step — never duplicated,
+never scaled by the path coefficient, never differentiated in `t`. Two operations are wanted:
+
+1. move one or several linear slices (slide hyperplanes), and
+2. deform a product-of-linears into a polynomial — the regeneration "add a degree" step
+   `(1−t)·f + γ·t·∏Lᵢ` for one row.
+
+The existing whole-system homotopy (`MakeHomotopy` → `BlendBlock`) blends *whole* systems
+`(1−t)·target + γt·start`. If the polynomial part is shared between the operands it is evaluated in
+**both** and comes out as `((1−t)+γt)·f ≠ f` — both wrong and wasteful for the moving-rows case.
+
+## Decision
+
+**No new block types.** `BlendBlock<System>` already linearly combines operand systems with shared
+path-variable coefficient nodes — it *is* a "moving wrapper". The fix is the construction: blend only
+the **moving** rows, and keep every fixed equation as its own sibling block in the homotopy.
+
+`MakeMovingHomotopy(fixed, start_moving, end_moving, t, gamma)` (`system.cpp`; Python
+`nag_algorithm.moving_homotopy`, plus the `make_moving_homotopy` binding) builds
+
+    H = [ fixed's blocks (unchanged) ;  BlendBlock( end_moving, start_moving ; (1−t), γ·t ) ]
+
+- `fixed`'s blocks are kept (not `ClearBlocks`); being autonomous, the block loop
+  (`system.hpp` `EvalBlocksInPlace`/`TimeDerivBlocksInPlace`) evaluates them once and their
+  `TimeDerivInPlace` writes zeros — the fixed rows are exactly zero in `dH/dt`.
+- only the moving operands enter the blend, so the fixed equations are never duplicated or scaled.
+- at `t=1` the moving rows are `γ·start_moving` (start points = roots of `fixed` ∧ `start_moving`);
+  at `t=0` they are `end_moving`. Row order is fixed rows then moving rows; the matching target is
+  `concatenate(fixed, end_moving)`.
+
+Both wanted operations are **output-level** blends and need nothing more: a moving linear slice is a
+blend of linear-forms operands (= interpolating their coefficients = sliding hyperplanes), and a
+∏L→polynomial deformation is a blend of a products-of-linears operand and a polynomial operand. The
+tracked homotopy is affine, matching the existing user-homotopy pipeline (whose `SystemSetup` is a
+no-op — it tracks the supplied homotopy as-is).
+
+Supporting changes: bound `System::TimeDerivative` to Python as `eval_time_derivative` (so the
+`dH/dt`-is-zero-on-fixed-rows invariant is checkable, and shown in the tutorial); taught
+`System::NaturalFunctionsAsNodes` to expand a `LinearFormsBlock` (affine and homogeneous), so the
+`ExpandToFunctionTree` oracle covers slice-bearing homotopies.
+
+## Consequences
+
+- The fixed system is provably evaluated once: `dH/dt` is exactly zero on every fixed-block row,
+  asserted in `moving_homotopy_test.cpp` (also: `t=0`/`t=1` endpoints, expansion-oracle agreement in
+  `dbl`/`mpfr`, a static linear slice + a moving slice both fixed, and a products-of-linears→polynomial
+  deform) and in `python/test/zero_dim/moving_homotopy_test.py` (three hand-checkable demos).
+- Tutorial `tutorials/moving_slice.rst` drives it (doctested), framed as regeneration.
+- **"Factor-sliding" a product-of-linears** (each factor's hyperplane moving independently) is a
+  *different*, deliberately out-of-scope semantics; the regeneration need is the output-level blend.
+- Deferred: the higher-level regeneration cascade driver that sequences these moving homotopies, and
+  a projective/patched variant if affine tracking proves insufficient for some target.

--- a/docs/adr/0025-randomization-block.md
+++ b/docs/adr/0025-randomization-block.md
@@ -1,4 +1,4 @@
-# ADR-0022: Randomization of overdetermined systems is a first-class block
+# ADR-0025: Randomization of overdetermined systems is a first-class block
 
 **Status:** Accepted
 **Date:** 2026-06-17

--- a/docs/adr/0026-moving-homotopy-blend-moving-rows-only.md
+++ b/docs/adr/0026-moving-homotopy-blend-moving-rows-only.md
@@ -1,4 +1,4 @@
-# ADR-0023: Moving homotopies blend only the moving rows; fixed equations stay sibling blocks
+# ADR-0026: Moving homotopies blend only the moving rows; fixed equations stay sibling blocks
 
 **Status:** Accepted
 **Date:** 2026-06-17

--- a/python/bertini/config.py
+++ b/python/bertini/config.py
@@ -176,6 +176,24 @@ def _make_reduce():
     return __reduce__
 
 
+def _make_copy():
+    # copy.copy / copy.deepcopy rebuild through the same to_dict/from_dict round-trip as pickle.
+    # Defining __deepcopy__ explicitly is load-bearing: the generic copy.deepcopy fallback would
+    # deep-copy the to_dict() mapping's *values* (the multiprecision scalars), which aliases/corrupts
+    # them on some interpreters (observed: Python 3.10 collapses the mpq_rational fields).  The field
+    # values are immutable scalars re-fetched from the getters, so rebuilding from them -- without
+    # deep-copying the scalars at all -- is both correct and portable.
+    def __copy__(self):
+        return type(self).from_dict(self.to_dict())
+
+    def __deepcopy__(self, memo):
+        new = type(self).from_dict(self.to_dict())
+        memo[id(self)] = new
+        return new
+
+    return __copy__, __deepcopy__
+
+
 def _enhance_config_class(cls):
     """Add update/to_dict/from_dict/repr/eq/pickle to a bound config class (idempotent)."""
     if getattr(cls, "_b2_config_enhanced", False):
@@ -191,6 +209,7 @@ def _enhance_config_class(cls):
         # Make the class picklable (copy.copy/deepcopy too) via to_dict/from_dict, overriding the
         # Boost.Python "pickling not enabled" default.
         cls.__reduce__ = _make_reduce()
+        cls.__copy__, cls.__deepcopy__ = _make_copy()
     except (TypeError, AttributeError):
         # some bound types may refuse dunder assignment; the rest still apply
         pass

--- a/python/bertini/linalg.py
+++ b/python/bertini/linalg.py
@@ -68,7 +68,8 @@ _MP_VALUE_TYPES = tuple(
 )
 
 __all__ = ['variable_vector', 'variable_matrix', 'coefficient', 'as_coefficients',
-           'add_functions', 'add_linear_forms', 'add_linear', 'add_products_of_linears']
+           'add_functions', 'add_linear_forms', 'add_linear', 'add_products_of_linears',
+           'randomize']
 
 
 def variable_vector(name, n, start=0):
@@ -395,3 +396,61 @@ def add_products_of_linears(system, factors):
         raise ValueError("factors must contain at least one function")
     system.add_products_of_linears_block(ncol - 1, mats)
     return system
+
+
+def randomize(system, matrix=None):
+    """Randomize an overdetermined ``System`` down to a square one, returning a NEW system.
+
+    An overdetermined system (N functions, n variables, N > n) cannot be fed to a total-degree
+    start system, which needs a square system.  Randomization replaces the N functions with n
+    generic combinations whose isolated solutions still contain the original's; you then solve
+    the square result and discard the extraneous solutions by re-evaluating the original system.
+
+    The original ``system`` is **not** mutated.
+
+    Parameters
+    ----------
+    system : the overdetermined System to randomize.
+    matrix : optional exact coefficient matrix R (array/list of lists), one row per randomized
+        function and one column per natural function of ``system``.  When ``None`` (the default)
+        bertini builds a generic R for you -- for a single affine variable group it sorts the
+        functions by descending degree and uses ``R = [I | C]`` (random ``C``), giving the optimal
+        total-degree path count (the product of the n largest degrees); for several variable groups
+        it uses a dense random R.  When supplied, R is used verbatim and the functions are kept in
+        their current order.  Coefficients must be exact (see :func:`coefficient`); Python floats
+        are refused.
+
+    Returns
+    -------
+    A new square ``System`` carrying a single randomization block.
+
+    Examples
+    --------
+    Three quadrics in two variables (overdetermined), squared up to two functions::
+
+        >>> import bertini
+        >>> from bertini import linalg
+        >>> x, y = bertini.Variable('x'), bertini.Variable('y')
+        >>> S = bertini.System()
+        >>> S.add_variable_group(bertini.VariableGroup([x, y]))
+        >>> S.add_function(x*x + y*y - 1)
+        >>> S.add_function(x*y)
+        >>> S.add_function(x*x + y*y - x - y)
+        >>> R = linalg.randomize(S)
+        >>> R.num_functions(), S.num_functions()
+        (2, 3)
+    """
+    if matrix is None:
+        return system.randomize()
+
+    rows = [list(r) for r in matrix]
+    if not rows:
+        raise ValueError("randomization matrix must have at least one row")
+    ncol = len(rows[0])
+    M = np.empty((len(rows), ncol), dtype=_mp.Complex)
+    for i, row in enumerate(rows):
+        if len(row) != ncol:
+            raise ValueError("randomization matrix is ragged (rows of differing length)")
+        for j, entry in enumerate(row):
+            M[i, j] = _exact_to_mpfr(entry)
+    return system.randomize(M)

--- a/python/bertini/nag_algorithm/__init__.py
+++ b/python/bertini/nag_algorithm/__init__.py
@@ -279,10 +279,38 @@ def blend_homotopy(target, start, *, path_variable='t', gamma=None):
     return _system.make_homotopy(target, start, path_variable, gamma)
 
 
+def moving_homotopy(fixed, start_moving, end_moving, *, path_variable='t', gamma=None):
+    """Form a homotopy that moves ONLY the moving rows, leaving the fixed system evaluated once.
+
+    The regeneration / moving-slice homotopy:
+
+        H = [ fixed's blocks ;  (1-t)*end_moving + gamma*t*start_moving ]
+
+    ``fixed`` holds the equations that do not move -- the polynomial system and any *static* linear
+    slices -- and stays as its own evaluation block(s); ``start_moving`` and ``end_moving`` hold just
+    the rows that move (a linear slice that slides, or a products-of-linears that deforms into a
+    polynomial), agreeing in function count and sharing ``fixed``'s variable structure.  Only the
+    moving rows carry the path variable: the fixed blocks are evaluated once per point and contribute
+    zero to ``dH/dt`` as the moving rows slide -- the fixed system is never re-evaluated or scaled by
+    the path coefficient.
+
+    At t=1 the moving rows are ``gamma*start_moving`` (so the start points are the roots of ``fixed``
+    together with ``start_moving``); at t=0 they are ``end_moving``.  The fixed rows come first, then
+    the moving rows; build the matching ``target`` for :func:`user_homotopy` as ``fixed`` concatenated
+    with ``end_moving`` (e.g. via ``bertini.system.concatenate``).  ``gamma=None`` draws a random
+    rational gamma.
+
+    Returns the homotopy System; pair it with :func:`user_homotopy` and your start points to solve.
+    """
+    from bertini._pybertini import system as _system
+    return _system.make_moving_homotopy(fixed, start_moving, end_moving, path_variable, gamma)
+
+
 __all__ = dir(_pybnalag)
 __all__.append('ZeroDim')
 __all__.append('user_homotopy')
 __all__.append('coefficient_parameter_homotopy')
+__all__.append('moving_homotopy')
 __all__.append('blend_homotopy')
 
 

--- a/python/docs/source/tutorials/moving_slice.rst
+++ b/python/docs/source/tutorials/moving_slice.rst
@@ -1,0 +1,155 @@
+🛷 Move a slice, hold the system fixed (regeneration)
+*********************************************************
+
+.. testsetup:: *
+
+   import numpy as np
+   import bertini
+   from bertini import linalg, nag_algorithm
+
+Regeneration and witness-set work share a shape: most equations are **fixed** -- the polynomial
+system, plus "below" linear slices that cut the dimension -- and only a small part **moves** along
+the path variable. The fixed equations should be evaluated **once** per step: never duplicated,
+never scaled by the path coefficient, never differentiated in :math:`t`.
+
+:func:`~bertini.nag_algorithm.moving_homotopy` builds exactly that. You hand it the **fixed** system
+and the two endpoints of the **moving** rows, and it returns
+
+.. math::
+
+   H \;=\; \bigl[\; \text{fixed's blocks} \;;\; (1-t)\,\text{end} + \gamma\,t\,\text{start} \;\bigr],
+
+keeping the fixed equations as their own evaluation blocks and moving only the rest. Pair it with
+:func:`~bertini.nag_algorithm.user_homotopy` and the start points you already know.
+
+Move one slice
+==============
+
+A fixed unit circle, sliced by a line that slides from the x-axis (:math:`y=0`) to the diagonal
+(:math:`y-x=0`). At :math:`t=1` the slice is the x-axis, so the start points are the circle's
+intersections with it, :math:`(\pm 1, 0)`; at :math:`t=0` the slice is the diagonal:
+
+.. testcode::
+
+    x, y = bertini.Variable('x'), bertini.Variable('y')
+
+    fixed = bertini.System()
+    fixed.add_variable_group(bertini.VariableGroup([x, y]))
+    fixed.add_function(x*x + y*y - 1)                 # the fixed unit circle
+
+    start_moving = bertini.System()                   # the slice at t=1: the x-axis y = 0
+    start_moving.add_variable_group(bertini.VariableGroup([x, y]))
+    start_moving.add_function(y)
+
+    end_moving = bertini.System()                     # the slice at t=0: the diagonal y - x = 0
+    end_moving.add_variable_group(bertini.VariableGroup([x, y]))
+    end_moving.add_function(y - x)
+
+.. testcode::
+
+    gamma = linalg.coefficient(bertini.multiprec.Complex('0.6', '0.8'))   # off the real axis
+    H = nag_algorithm.moving_homotopy(fixed, start_moving, end_moving, gamma=gamma)
+
+    target = bertini.system.concatenate(fixed, end_moving)   # the t=0 system: circle + diagonal
+    start_points = [np.array([bertini.multiprec.Complex('1'),  bertini.multiprec.Complex('0')]),
+                    np.array([bertini.multiprec.Complex('-1'), bertini.multiprec.Complex('0')])]
+
+    solver = nag_algorithm.user_homotopy(H, start_points, target)
+    solver.solve()
+    roots = sorted((round(complex(s[0]).real, 4), round(complex(s[1]).real, 4))
+                   for s in solver.solutions())
+
+    r = round(1 / np.sqrt(2), 4)
+    assert roots == sorted([(r, r), (-r, -r)])        # circle ∩ diagonal = (±1/√2, ±1/√2)
+
+The circle never moved; only the slice did. The two start points slid along the circle to the two
+diagonal intersections.
+
+A static slice and a moving slice (the regeneration shape)
+==========================================================
+
+Now in three variables, the genuinely regeneration-flavored case: a fixed unit **sphere** (a
+surface) cut to dimension zero by **two** slices -- a **static** one ``z = 0`` and a **moving** one
+that slides ``y = 0`` :math:`\to` ``y - x = 0``. Two blocks are fixed (the sphere and the static
+slice); only the moving slice carries :math:`t`:
+
+.. testcode::
+
+    x, y, z = bertini.Variable('x'), bertini.Variable('y'), bertini.Variable('z')
+
+    fixed = bertini.System()
+    fixed.add_variable_group(bertini.VariableGroup([x, y, z]))
+    fixed.add_function(x*x + y*y + z*z - 1)                                # the sphere
+    linalg.add_linear(fixed, np.array([[0, 0, 1]]), np.array([x, y, z]))   # static slice z = 0
+
+    start_moving = bertini.System(); start_moving.add_variable_group(bertini.VariableGroup([x, y, z]))
+    start_moving.add_function(y)                                           # moving slice at t=1
+    end_moving = bertini.System(); end_moving.add_variable_group(bertini.VariableGroup([x, y, z]))
+    end_moving.add_function(y - x)                                         # moving slice at t=0
+
+.. testcode::
+
+    H = nag_algorithm.moving_homotopy(fixed, start_moving, end_moving, gamma=gamma)
+    target = bertini.system.concatenate(fixed, end_moving)
+    start_points = [np.array([bertini.multiprec.Complex(str(a)), bertini.multiprec.Complex('0'),
+                              bertini.multiprec.Complex('0')]) for a in (1, -1)]
+
+    solver = nag_algorithm.user_homotopy(H, start_points, target)
+    solver.solve()
+    roots = sorted((round(complex(s[0]).real, 4), round(complex(s[1]).real, 4), round(complex(s[2]).real, 4))
+                   for s in solver.solutions())
+    r = round(1 / np.sqrt(2), 4)
+    assert roots == sorted([(r, r, 0.0), (-r, -r, 0.0)])
+
+**The fixed system is left out of the motion.** Ask the homotopy for :math:`dH/dt`: the rows of the
+two fixed blocks (the sphere and the static slice) are exactly zero -- they are evaluated once and
+never differentiated as the slice moves -- while only the moving row is nonzero:
+
+.. testcode::
+
+    dHdt = H.eval_time_derivative(np.array([bertini.multiprec.Complex('0.3'),
+                                            bertini.multiprec.Complex('0.4'),
+                                            bertini.multiprec.Complex('0.5')]),
+                                  bertini.multiprec.Complex('0.5'))
+    assert abs(complex(dHdt[0])) == 0.0      # sphere row: out of dH/dt
+    assert abs(complex(dHdt[1])) == 0.0      # static slice row: out of dH/dt
+    assert abs(complex(dHdt[2])) > 0.0       # only the moving slice carries t
+
+Deform a product of linears into a polynomial
+=============================================
+
+The regeneration "add a degree" step itself is the same construction with a different moving pair:
+deform a **product of linears** into the actual polynomial, holding a slice fixed. Here the product
+:math:`(x-1)(x+1)` deforms into the circle, with the slice ``y = 1/2`` static. At :math:`t=1` the
+moving row is :math:`\gamma\,(x-1)(x+1)`, whose roots on the slice are :math:`(\pm 1, 1/2)`:
+
+.. testcode::
+
+    x, y = bertini.Variable('x'), bertini.Variable('y')
+
+    fixed = bertini.System(); fixed.add_variable_group(bertini.VariableGroup([x, y]))
+    linalg.add_linear(fixed, np.array([[0, 1]]), np.array([x, y]), ['-1/2'])    # static slice y = 1/2
+
+    start_moving = bertini.System(); start_moving.add_variable_group(bertini.VariableGroup([x, y]))
+    linalg.add_products_of_linears(start_moving, [[[1, 0, -1], [1, 0, 1]]])      # (x-1)(x+1), a structured block
+
+    end_moving = bertini.System(); end_moving.add_variable_group(bertini.VariableGroup([x, y]))
+    end_moving.add_function(x*x + y*y - 1)                                       # the polynomial
+
+.. testcode::
+
+    H = nag_algorithm.moving_homotopy(fixed, start_moving, end_moving, gamma=gamma)
+    target = bertini.system.concatenate(fixed, end_moving)
+    start_points = [np.array([bertini.multiprec.Complex(str(a)), bertini.multiprec.Complex('0.5')])
+                    for a in (1, -1)]
+
+    solver = nag_algorithm.user_homotopy(H, start_points, target)
+    solver.solve()
+    roots = sorted((round(complex(s[0]).real, 4), round(complex(s[1]).real, 4))
+                   for s in solver.solutions())
+    s3 = round(np.sqrt(3) / 2, 4)
+    assert roots == sorted([(s3, 0.5), (-s3, 0.5)])     # circle ∩ {y = 1/2}
+
+The product-of-linears is a first-class structured block (it is never expanded into nodes), the
+static slice stays put, and only the one regenerating row carries :math:`t`. That is the unit of
+work a regeneration cascade repeats -- and at every step the fixed equations are evaluated once.

--- a/python/docs/source/tutorials/randomize.rst
+++ b/python/docs/source/tutorials/randomize.rst
@@ -1,0 +1,141 @@
+🎲 Randomize an overdetermined system
+*************************************************
+
+.. testsetup:: *
+
+   import numpy as np
+   import bertini
+   from bertini import linalg
+
+Most tutorials solve a **square** system -- as many equations as unknowns. But polynomial models
+are often **overdetermined**: more equations than unknowns. The common zeros are still (at most)
+isolated points, but you cannot hand such a system to a total-degree start system, which needs a
+square target.
+
+The fix is **randomization**: replace the :math:`N` functions with :math:`n` generic combinations
+(:math:`n` = the number of unknowns). Every common zero of the original system is a zero of each
+combination, so the genuine solutions survive -- but the square randomized system has *extra*
+solutions too. The workflow is always: **randomize, solve the square system, then keep only the
+points that also satisfy the original system.**
+
+This tutorial does that twice, to show two different things: first an ordinary system in one block
+of variables, then a system whose variables split into groups -- where the grouping cuts the path
+count.
+
+Part 1 -- one block of variables
+=================================
+
+Three curves in the plane: the unit circle, the line :math:`x = y`, and the vertical lines
+:math:`2x^2 = 1`. Along :math:`x = y` the circle gives :math:`2x^2 = 1`, which is the third
+equation, so all three meet at :math:`(\pm\tfrac{1}{\sqrt2}, \pm\tfrac{1}{\sqrt2})` -- two real
+points you can read off by hand.
+
+.. testcode::
+
+   x, y = bertini.Variable('x'), bertini.Variable('y')
+
+   original = bertini.System()
+   original.add_variable_group(bertini.VariableGroup([x, y]))
+   original.add_function(x*x + y*y - 1)      # the unit circle      (degree 2)
+   original.add_function(x - y)              # the line x = y       (degree 1)
+   original.add_function(2*x*x - 1)          # the lines x = ±1/√2  (degree 2)
+
+   assert list(original.degrees()) == [2, 1, 2]   # three equations, two unknowns: overdetermined
+
+:func:`~bertini.linalg.randomize` returns a **new** square system; the original is left untouched.
+For a single variable group it sorts the functions by descending degree and forms :math:`R = [\,I
+\mid C\,]` with a random block :math:`C`, so the randomized degrees are the :math:`n` **largest**
+original degrees and the total-degree path count is their product -- here :math:`2 \times 2 = 4`,
+the minimum a randomization can achieve.
+
+.. testcode::
+
+   randomized = linalg.randomize(original)
+
+   assert randomized.num_functions() == 2          # squared up
+   assert original.num_functions() == 3            # original unchanged
+   assert sorted(randomized.degrees()) == [2, 2]
+
+.. note::
+
+   The descending sort is what keeps the count minimal: the degree-1 line is folded into the
+   degree-2 rows rather than becoming a degree-1 target that a folded degree-2 function would
+   inflate. The payoff grows with the degree spread -- for degrees :math:`(3, 2, 2)` randomization
+   tracks :math:`3 \times 2 = 6` paths, where a degree-blind squaring (every row pushed to the
+   maximum degree 3) would track :math:`3^2 = 9`. You may also pass your own exact matrix,
+   ``linalg.randomize(original, R)``, in which case the functions are kept in their given order.
+
+Solve the square system, then filter: evaluate the **original** system at each computed point and
+keep the ones with a tiny residual.
+
+.. testcode::
+
+   bertini.random.set_random_seed(1)               # reproducible generic coefficients + gamma
+   zd = bertini.nag_algorithm.ZeroDimCauchyAdaptivePrecisionTotalDegree(randomized)
+   zd.solve()
+   solutions = zd.solutions()
+   assert len(solutions) == 4                       # the two we want, plus two extraneous
+
+   def satisfies_original(point):
+       coords = np.array([complex(c) for c in point])
+       return max(abs(complex(v)) for v in original.eval(coords)) < 1e-7
+
+   true_solutions = [np.array([complex(c) for c in s]) for s in solutions if satisfies_original(s)]
+
+   r = 1.0 / np.sqrt(2.0)
+   found = sorted((round(p[0].real, 4), round(p[1].real, 4)) for p in true_solutions)
+   assert found == sorted([(round(r, 4), round(r, 4)), (round(-r, 4), round(-r, 4))])
+
+Two of the four points survive the filter: :math:`(\tfrac{1}{\sqrt2}, \tfrac{1}{\sqrt2})` and
+:math:`(-\tfrac{1}{\sqrt2}, -\tfrac{1}{\sqrt2})` -- exactly where all three curves meet. The other
+two solve the random combination but not the original equations, so the filter drops them.
+
+Part 2 -- variables in separate groups
+=======================================
+
+Now something different: when the unknowns split into separate **variable groups**, randomization
+works group by group and the *multihomogeneous* start system tracks far fewer paths.
+
+The vehicle is a **bilinear** system -- each function is degree 1 in :math:`x` and degree 1 in
+:math:`y` -- with :math:`x` and :math:`y` in their own groups. Three equations whose only common
+solution is :math:`(1, 1)`: from :math:`x = y` and :math:`x + y = 2` we get :math:`x = y = 1`, and
+indeed :math:`xy = 1`.
+
+.. testcode::
+
+   x, y = bertini.Variable('x'), bertini.Variable('y')
+
+   original = bertini.System()
+   original.add_variable_group(bertini.VariableGroup([x]))    # x is its own group
+   original.add_variable_group(bertini.VariableGroup([y]))    # y is its own group
+   original.add_function(x*y - 1)        # xy = 1
+   original.add_function(x + y - 2)      # x + y = 2
+   original.add_function(x - y)          # x = y
+
+   randomized = linalg.randomize(original)
+   assert randomized.num_functions() == 2
+
+Solve with the **multihomogeneous** start system, which exploits the grouping. Two bilinear
+equations on :math:`\mathbb{P}^1 \times \mathbb{P}^1` meet in the multihomogeneous Bézout number
+of paths -- here :math:`2` (the coefficient of :math:`z_x z_y` in :math:`(z_x + z_y)^2`) -- whereas
+a total-degree start would track :math:`2^2 = 4`. Same answer, half the work.
+
+.. testcode::
+
+   bertini.random.set_random_seed(3)
+   zd = bertini.nag_algorithm.ZeroDimCauchyAdaptivePrecisionMHomogeneous(randomized)
+   zd.solve()
+
+   def satisfies(point):
+       coords = np.array([complex(c) for c in point])
+       return max(abs(complex(v)) for v in original.eval(coords)) < 1e-7
+
+   true_solutions = [np.array([complex(c) for c in s]) for s in zd.solutions() if satisfies(s)]
+
+   assert len(true_solutions) == 1
+   p = true_solutions[0]
+   assert abs(p[0] - 1) < 1e-7 and abs(p[1] - 1) < 1e-7
+
+One solution survives: :math:`(1, 1)`, exactly as read off by hand. The difference from Part 1 is
+the **grouping** -- declaring ``x`` and ``y`` as separate variable groups let the multihomogeneous
+start system see the bilinear structure and track fewer paths to the same answer.

--- a/python/docs/source/tutorials/tutorials.rst
+++ b/python/docs/source/tutorials/tutorials.rst
@@ -17,6 +17,7 @@
    parameter_homotopy
    user_product_of_linears
    randomize
+   moving_slice
    real_points
    solving_at_scale
 

--- a/python/docs/source/tutorials/tutorials.rst
+++ b/python/docs/source/tutorials/tutorials.rst
@@ -16,6 +16,7 @@
    eigenvalues_by_homotopy
    parameter_homotopy
    user_product_of_linears
+   randomize
    real_points
    solving_at_scale
 

--- a/python/test/classes/system_printing_test.py
+++ b/python/test/classes/system_printing_test.py
@@ -1,0 +1,95 @@
+"""Human-facing printing of block-composed systems.
+
+print(system) / str(system) describes the system block by block, with placeholder symbols for the
+structured blocks' coefficients (terse, the default) or the actual numbers and underlying functions
+(system.describe(verbose=True)).  The old debugging leftovers -- the working-vector dump, the
+differentiated flag, the 'unnamed_function' names -- are gone, and structured-block rows are no
+longer invisible.
+"""
+
+import numpy as np
+import pytest
+
+import bertini as pb
+from bertini import linalg, nag_algorithm as na
+
+NOISE = ('current variable values', 'not differentiated', 'is differentiated', 'unnamed_function')
+
+
+def _vg(*vs):
+    return pb.VariableGroup(list(vs))
+
+
+def test_plain_polynomial_is_clean():
+    x, y = pb.Variable('x'), pb.Variable('y')
+    s = pb.System(); s.add_variable_group(_vg(x, y))
+    s.add_function(x*x + y*y - 1); s.add_function(x - y)
+    text = str(s)
+
+    assert 'f_0 = x*x+y*y-1' in text
+    assert 'f_1 = x-y' in text
+    for n in NOISE:
+        assert n not in text          # debugging leftovers are gone
+    assert text.count('= ') == 2      # exactly two functions printed (no extras, none missing)
+
+
+def test_randomization_shows_placeholder_and_underlying_functions():
+    x, y = pb.Variable('x'), pb.Variable('y')
+    o = pb.System(); o.add_variable_group(_vg(x, y))
+    o.add_function(x*x + y*y - 1); o.add_function(x*y); o.add_function(x*x + y*y - x - y)
+    r = linalg.randomize(o)
+
+    terse = str(r)
+    assert 'R . g' in terse                       # placeholder, not the matrix
+    assert '(R: 2x3 randomization matrix)' in terse
+    assert 'g_0 = x*x+y*y-1' in terse              # the underlying functions, indented and shown
+    assert 'g_1 = x*y' in terse
+    assert 'g_2 = x*x+y*y-x-y' in terse
+    assert 'R =' not in terse                      # the actual matrix is NOT in the terse form
+
+    verbose = r.describe(verbose=True)
+    assert 'R =' in verbose                        # ... but it is in verbose
+    assert verbose.count('[') >= 2                 # the two matrix rows
+    for n in NOISE:
+        assert n not in verbose
+
+
+def test_linear_forms_block_placeholder_vs_actual():
+    x, y = pb.Variable('x'), pb.Variable('y')
+    m = pb.System(); m.add_variable_group(_vg(x, y))
+    m.add_function(x*x + y*y - 1)
+    linalg.add_linear(m, np.array([[2, 1]]), np.array([x, y]), [-1])   # 2x + y - 1, a LinearFormsBlock
+
+    terse = str(m)
+    assert 'f_0 = x*x+y*y-1' in terse              # poly row
+    assert 'f_1 = c.[x, y, 1]' in terse            # linear-forms row: placeholder, both rows visible
+
+    verbose = m.describe(verbose=True)
+    assert '(2)*x' in verbose and '(1)*y' in verbose and '(-1)' in verbose   # actual coefficients
+
+
+def test_products_of_linears_block():
+    x, y = pb.Variable('x'), pb.Variable('y')
+    s = pb.System(); s.add_variable_group(_vg(x, y))
+    linalg.add_products_of_linears(s, [[[1, 0, -1], [1, 0, 1]]])    # (x-1)(x+1)
+
+    assert 'prod of 2 linear forms' in str(s)                       # terse placeholder
+    verbose = s.describe(verbose=True)
+    assert '*' in verbose and 'x' in verbose                        # actual product of factors
+
+
+def test_moving_homotopy_blend_and_path_variable():
+    x, y = pb.Variable('x'), pb.Variable('y')
+    fx = pb.System(); fx.add_variable_group(_vg(x, y)); fx.add_function(x*x + y*y - 1)
+    sm = pb.System(); sm.add_variable_group(_vg(x, y)); sm.add_function(y)
+    em = pb.System(); em.add_variable_group(_vg(x, y)); em.add_function(y - x)
+    H = na.moving_homotopy(fx, sm, em, gamma=linalg.coefficient(pb.multiprec.Complex('0.6', '0.8')))
+
+    terse = str(H)
+    assert 'f_0 = x*x+y*y-1' in terse              # the fixed row is a plain polynomial, shown
+    assert '(1-t)*A' in terse and 'blend of 2 systems' in terse
+    assert 'path variable: t' in terse
+    assert 'f_1..f_1' not in terse                 # a single moving row reads 'f_1', not 'f_1..f_1'
+
+    verbose = H.describe(verbose=True)
+    assert 'A_0 = y-x' in verbose and 'B_0 = y' in verbose          # operand functions, indented

--- a/python/test/zero_dim/crossed_paths_test.py
+++ b/python/test/zero_dim/crossed_paths_test.py
@@ -78,7 +78,10 @@ def _find_crossing_seed():
                 "the detection/resolve logic is still covered by the deterministic C++ tests")
 
 
-@pytest.mark.timeout(360)  # several cyclic-5 Euler solves; loose Euler tracking is slow
+@pytest.mark.timeout(900)  # several cyclic-5 Euler solves; loose Euler tracking is slow, and the
+                           # manylinux test container is markedly slower per-core than 360s allowed
+                           # (it timed out there while passing on macOS) -- this is a safety net
+                           # against a true hang, not a performance assertion.
 def test_crossing_is_detected_then_resolved():
     """Report-only loses a solution to the crossing; re-tracking recovers it."""
     seed, report_only, distinct_unresolved = _find_crossing_seed()

--- a/python/test/zero_dim/crossed_paths_test.py
+++ b/python/test/zero_dim/crossed_paths_test.py
@@ -5,55 +5,89 @@ it is a path crossing (under-resolved tracking), which the zero-dim solver is su
 and re-track.  Mirrors the C++ tests in ``core/test/nag_algorithms/zero_dim.cpp``; here we exercise
 the whole pipeline and the ``endgame_boundary_metadata`` report.
 
-To *provoke* a crossing we deliberately use the low-order Euler predictor with a loose pre-endgame
-tolerance on the cyclic-5 system -- the regime documented in ADR-0017.  The fixed seed only makes
-the bad behaviour reproducible; the *fix* is the solver's re-tracking (and, in real use, the better
-default predictor / tighter tolerance), never the seed (see ADR-0017).  Because exactly which seed
-crosses depends on platform numerics, the test searches a small range for one rather than hard-coding
-it.
+Rather than fish for a crossing inside a big *random* system (slow, and *which* seed crosses depends
+on platform floating point), we **construct** a tiny homotopy whose crossing is a deterministic,
+portable geometric fact -- a cubic with three solution paths:
+
+    H(x, t) = (x - A(t)) * (x - B) * (x - C),   A(t) = B + delta + kappa*(t - t0)^2,  B=1, C=-2
+
+* ``B`` (flat) and ``C`` (far) are constant paths; ``A(t)`` is a *curved* path that near-misses
+  ``B`` from above at ``t0 = 0.9`` (closest gap ``delta``).
+* Tracked from ``t=1`` to ``t=0`` with the low-order **Euler** predictor and a *coarse* step, the
+  first step lands at ``t=0.9``.  Euler is exact on straight lines but *errs* on a curve, so its
+  straight-line prediction of ``A`` overshoots downward, *past* ``B``, into ``B``'s basin.  The
+  corrector then lands on ``B`` **exactly** -- a clean root, so the step is *accepted* and adaptive
+  step-size control does **not** rescue it -- while ``B`` itself barely moves.
+
+So two paths funnel onto ``B`` and ``A``'s true endpoint ``A(0)`` is lost: a *detectable* crossing.
+Finer re-tracking (the solver's resolve step) follows ``A``'s curve correctly and recovers it.  The
+overshoot is macroscopic and the coefficients are exact rationals, so the result is identical on
+every platform -- no randomness, no seed search, no platform-dependent numerics.  The *fix* is the
+solver's re-tracking (and, in real use, a better predictor / tighter tolerance), never tuning; the
+detection/resolve logic is also covered by the deterministic C++ tests.
 """
 
 import numpy as np
 import pytest
 
 import bertini as pb
-from bertini.nag_algorithm import ZeroDimCauchyDoublePrecisionTotalDegree
+from bertini.function_tree.symbol import Rational
 
 OK = int(pb.tracking.SuccessCode.Success)
 
-CYCLIC_N = 5
-KNOWN_FINITE = 70           # distinct finite solutions of cyclic-5
-LOOSE_TOL = 1e-4            # loose enough (with Euler) to occasionally cross a pair of paths
-SEEDS_TO_TRY = range(1, 13)
+_CDT = pb.multiprec.Vector(1).dtype     # the numpy dtype of a multiprecision complex vector
+
+# Geometry of the planted near-miss (see module docstring).  Exact rationals -> portable.
+B_ROOT, C_ROOT = 1, -2                   # the flat path and the far spectator path
+T0_NUM, T0_DEN = 9, 10                   # near-miss time t0 = 0.9 = where the first Euler step lands
+DELTA_NUM, DELTA_DEN = 1, 10             # closest gap A - B at t0
+KAPPA = 10                               # curvature of A: big enough that one Euler step overshoots B
+LOST_ROOT = round(B_ROOT + DELTA_NUM / DELTA_DEN + KAPPA * (T0_NUM / T0_DEN) ** 2, 3)  # A(0) = 9.2
+KNOWN_DISTINCT = 3                        # A(0), B, C are three distinct solutions at t=0
+
+COARSE_STEP = '0.1'                       # one step from t=1 lands exactly on the near-miss at t=0.9
+LOOSE_TOL = 1e-3
 
 
-def cyclic_system(n):
-    """The cyclic-n system: the n-1 cyclic sums of products, plus (prod - 1)."""
-    x = [pb.Variable('x{}'.format(i)) for i in range(n)]
-    w = x + x
-    sys = pb.System()
-    for length in range(1, n):
-        sys.add_function(np.sum([np.prod(w[start:start + length]) for start in range(n)]))
-    sys.add_function(np.prod(x) - 1)
-    sys.add_variable_group(pb.VariableGroup(x))
-    return sys
+def _R(n, d=1):
+    return Rational(n, d, 0, 1)
 
 
-def _solve(seed, resolve_attempts):
-    """Solve cyclic-5 with Euler + loose tolerance at a fixed seed.
+def cubic_crossing_homotopy():
+    """Build (homotopy, target, start_points) for the planted cubic crossing."""
+    x, t = pb.Variable('x'), pb.Variable('t')
+    t0 = _R(T0_NUM, T0_DEN)
+    a_of_t = _R(B_ROOT) + _R(DELTA_NUM, DELTA_DEN) + _R(KAPPA) * (t - t0) * (t - t0)
 
-    Returns (report, distinct_finite_count).
-    """
-    pb.random.set_random_seed(seed)
-    solver = ZeroDimCauchyDoublePrecisionTotalDegree(cyclic_system(CYCLIC_N))
+    H = pb.System()
+    H.add_variable_group(pb.VariableGroup([x]))
+    H.add_function((x - a_of_t) * (x - _R(B_ROOT)) * (x - _R(C_ROOT)))
+    H.add_path_variable(t)
 
-    # Euler (order 1) is the root cause of the crossing we want to provoke.
-    solver.get_tracker().predictor(pb.tracking.Predictor.Euler)
+    a_at_0 = _R(B_ROOT) + _R(DELTA_NUM, DELTA_DEN) + _R(KAPPA) * (_R(0) - t0) * (_R(0) - t0)
+    target = pb.System()
+    target.add_variable_group(pb.VariableGroup([x]))
+    target.add_function((x - a_at_0) * (x - _R(B_ROOT)) * (x - _R(C_ROOT)))
 
-    tol = solver.get_config(pb.nag_algorithm.TolerancesConfig)
-    tol.newton_before_endgame = LOOSE_TOL
-    tol.newton_during_endgame = LOOSE_TOL / 10
-    solver.set_config(tol)
+    a_at_1 = B_ROOT + DELTA_NUM / DELTA_DEN + KAPPA * (1 - T0_NUM / T0_DEN) ** 2
+    start_points = [np.array([pb.multiprec.Complex(repr(v))], dtype=_CDT)
+                    for v in (a_at_1, float(B_ROOT), float(C_ROOT))]
+    return H, target, start_points
+
+
+def _solve(resolve_attempts, predictor=pb.tracking.Predictor.Euler, step=COARSE_STEP, tol=LOOSE_TOL):
+    """Track the planted cubic and return (report, sorted distinct real roots)."""
+    H, target, start_points = cubic_crossing_homotopy()
+    solver = pb.nag_algorithm.user_homotopy(H, start_points, target, precision='double')
+
+    solver.get_tracker().predictor(predictor)
+    solver.get_tracker().get_stepping().update(initial_step_size=step, max_step_size=step)
+    solver.get_tracker().reinitialize_initial_step_size(True)
+
+    tol_cfg = solver.get_config(pb.nag_algorithm.TolerancesConfig)
+    tol_cfg.newton_before_endgame = tol
+    tol_cfg.newton_during_endgame = tol / 10
+    solver.set_config(tol_cfg)
 
     zd = solver.get_config(pb.nag_algorithm.ZeroDimConfigDoublePrec)
     zd.max_num_crossed_path_resolve_attempts = resolve_attempts
@@ -62,58 +96,37 @@ def _solve(seed, resolve_attempts):
     solver.solve()
 
     report = solver.endgame_boundary_metadata()
-    finite = [m for m in solver.solution_metadata()
-              if int(m.endgame_success) == OK and m.is_finite]
-    distinct = round(sum(1.0 / m.multiplicity for m in finite))
-    return report, distinct
+    roots = sorted({round(complex(v[0]).real, 3)
+                    for v in solver.solutions() if len(v) > 0})
+    return report, roots
 
 
-def _find_crossing_seed():
-    """Find a seed whose report-only solve detects an (unresolved) crossing; skip if none."""
-    for seed in SEEDS_TO_TRY:
-        report, distinct = _solve(seed, resolve_attempts=0)
-        if report.num_crossings_detected > 0:
-            return seed, report, distinct
-    pytest.skip("no path crossing provoked in the searched seed range on this platform; "
-                "the detection/resolve logic is still covered by the deterministic C++ tests")
-
-
-@pytest.mark.timeout(900)  # several cyclic-5 Euler solves; loose Euler tracking is slow, and the
-                           # manylinux test container is markedly slower per-core than 360s allowed
-                           # (it timed out there while passing on macOS) -- this is a safety net
-                           # against a true hang, not a performance assertion.
 def test_crossing_is_detected_then_resolved():
     """Report-only loses a solution to the crossing; re-tracking recovers it."""
-    seed, report_only, distinct_unresolved = _find_crossing_seed()
-
-    # With re-tracking disabled the crossing is detected but left unresolved, and the two merged
-    # paths cost us a solution: the distinct finite count comes up short.
+    # With re-tracking disabled the crossing is detected but left unresolved: two paths funnel onto
+    # B=1, so the curved path's true endpoint (A(0)) is lost and the distinct count comes up short.
+    report_only, roots_unresolved = _solve(resolve_attempts=0)
     assert not report_only.passed
     assert report_only.num_resolve_attempts == 0
+    assert report_only.num_crossings_detected > 0
     assert len(report_only.crossed_path_indices) == report_only.num_crossings_detected
-    assert distinct_unresolved < KNOWN_FINITE
+    assert len(roots_unresolved) < KNOWN_DISTINCT
+    assert LOST_ROOT not in roots_unresolved          # 9.2 was swallowed by the crossing
 
-    # Re-enable the default re-tracking: the same crossing is detected, then resolved, and the lost
-    # solution is recovered -- the count is now exactly right.
-    resolved, distinct_resolved = _solve(seed, resolve_attempts=2)
+    # Re-enable re-tracking: the same crossing is detected, then resolved, and the lost solution is
+    # recovered -- the count is now exactly right and A(0) is back.
+    resolved, roots_resolved = _solve(resolve_attempts=2)
     assert resolved.num_crossings_detected > 0
     assert resolved.num_resolve_attempts >= 1
     assert resolved.passed
-    assert distinct_resolved == KNOWN_FINITE
+    assert len(roots_resolved) == KNOWN_DISTINCT
+    assert roots_resolved == sorted([float(C_ROOT), float(B_ROOT), LOST_ROOT])
 
 
 def test_clean_solve_reports_no_crossings():
-    """With the good default predictor and a sane tolerance, no crossing is detected."""
-    pb.random.set_random_seed(1)
-    solver = ZeroDimCauchyDoublePrecisionTotalDegree(cyclic_system(CYCLIC_N))
-    tol = solver.get_config(pb.nag_algorithm.TolerancesConfig)
-    tol.newton_before_endgame = 1e-6
-    tol.newton_during_endgame = 1e-7
-    solver.set_config(tol)
-    solver.solve()
-
-    report = solver.endgame_boundary_metadata()
+    """With a good (higher-order) predictor the curve is tracked correctly: no crossing at all."""
+    report, roots = _solve(resolve_attempts=0, predictor=pb.tracking.Predictor.RK4)
     assert report.passed
     assert report.num_crossings_detected == 0
     assert report.num_resolve_attempts == 0
-    assert len(solver.endgame_boundary_solutions()) > 0
+    assert roots == sorted([float(C_ROOT), float(B_ROOT), LOST_ROOT])

--- a/python/test/zero_dim/moving_homotopy_test.py
+++ b/python/test/zero_dim/moving_homotopy_test.py
@@ -1,0 +1,103 @@
+"""Moving-row homotopies: move only the slices/regenerated rows, evaluate the fixed system once.
+
+A regeneration / moving-slice homotopy keeps the polynomial system and any static linear slices
+FIXED -- they are their own evaluation blocks, evaluated once per point and contributing zero to
+dH/dt -- while only the moving rows (a sliding linear slice, or a products-of-linears deforming into
+a polynomial) carry the path variable.  nag_algorithm.moving_homotopy builds it; this verifies the
+solutions land where hand computation says, and that the fixed rows really are left out of dH/dt.
+"""
+
+import numpy as np
+import pytest
+
+import bertini as pb
+from bertini import linalg, nag_algorithm as na
+
+C = pb.multiprec.Complex
+GAMMA = C('0.6', '0.8')   # exact, off the real axis -> reproducible path
+
+
+def _vg(*vs):
+    return pb.VariableGroup(list(vs))
+
+
+def _roots(solutions, n):
+    return sorted(tuple(round(complex(s[i]).real, 4) for i in range(n)) for s in solutions)
+
+
+def _solve(fixed, start_moving, end_moving, start_points, nvars):
+    H = na.moving_homotopy(fixed, start_moving, end_moving, gamma=linalg.coefficient(GAMMA))
+    target = pb.system.concatenate(fixed, end_moving)
+    solver = na.user_homotopy(H, start_points, target)
+    solver.solve()
+    return H, _roots(solver.solutions(), nvars)
+
+
+def _fixed_rows_have_zero_dHdt(H, num_fixed_rows, num_vars):
+    """dH/dt must be exactly zero on every fixed (leading) row -- the fixed system is left out."""
+    p = np.array([C(str(0.3 + 0.1 * k)) for k in range(num_vars)])
+    dhdt = H.eval_time_derivative(p, C('0.5'))
+    return all(abs(complex(dhdt[i])) == 0.0 for i in range(num_fixed_rows))
+
+
+def test_move_one_slice_2var():
+    # fixed unit circle; slice moves from the x-axis (y=0) to the diagonal (y-x=0).
+    x, y = pb.Variable('x'), pb.Variable('y')
+    fixed = pb.System(); fixed.add_variable_group(_vg(x, y)); fixed.add_function(x*x + y*y - 1)
+    start_moving = pb.System(); start_moving.add_variable_group(_vg(x, y)); start_moving.add_function(y)
+    end_moving = pb.System(); end_moving.add_variable_group(_vg(x, y)); end_moving.add_function(y - x)
+
+    sp = [np.array([C('1'), C('0')]), np.array([C('-1'), C('0')])]   # circle ∩ x-axis
+    H, got = _solve(fixed, start_moving, end_moving, sp, 2)
+
+    r = round(1 / np.sqrt(2), 4)
+    assert got == sorted([(r, r), (-r, -r)])           # circle ∩ diagonal
+    assert H.num_functions() == 2
+    assert _fixed_rows_have_zero_dHdt(H, num_fixed_rows=1, num_vars=2)   # circle row out of dH/dt
+
+
+def test_static_and_moving_slice_3var():
+    # fixed unit sphere + a STATIC slice z=0; a second slice moves y=0 -> y-x=0.  Two fixed blocks.
+    x, y, z = pb.Variable('x'), pb.Variable('y'), pb.Variable('z')
+    fixed = pb.System(); fixed.add_variable_group(_vg(x, y, z))
+    fixed.add_function(x*x + y*y + z*z - 1)                                  # sphere (PolynomialBlock)
+    linalg.add_linear(fixed, np.array([[0, 0, 1]]), np.array([x, y, z]))    # static slice z=0 (LinearFormsBlock)
+    start_moving = pb.System(); start_moving.add_variable_group(_vg(x, y, z)); start_moving.add_function(y)
+    end_moving = pb.System(); end_moving.add_variable_group(_vg(x, y, z)); end_moving.add_function(y - x)
+
+    sp = [np.array([C('1'), C('0'), C('0')]), np.array([C('-1'), C('0'), C('0')])]
+    H, got = _solve(fixed, start_moving, end_moving, sp, 3)
+
+    r = round(1 / np.sqrt(2), 4)
+    assert got == sorted([(r, r, 0.0), (-r, -r, 0.0)])
+    assert H.num_functions() == 3
+    # BOTH fixed rows (sphere AND static slice) are left out of dH/dt
+    assert _fixed_rows_have_zero_dHdt(H, num_fixed_rows=2, num_vars=3)
+
+
+def test_deform_products_of_linears_into_polynomial():
+    # the regeneration "add a degree" step: deform the product (x-1)(x+1) into the circle, while a
+    # static slice y=1/2 stays put.  start points are the product's roots on the slice: (±1, 1/2).
+    x, y = pb.Variable('x'), pb.Variable('y')
+    fixed = pb.System(); fixed.add_variable_group(_vg(x, y))
+    linalg.add_linear(fixed, np.array([[0, 1]]), np.array([x, y]), ['-1/2'])     # static slice y=1/2
+    start_moving = pb.System(); start_moving.add_variable_group(_vg(x, y))
+    linalg.add_products_of_linears(start_moving, [[[1, 0, -1], [1, 0, 1]]])      # (x-1)(x+1) as a block
+    end_moving = pb.System(); end_moving.add_variable_group(_vg(x, y)); end_moving.add_function(x*x + y*y - 1)
+
+    sp = [np.array([C('1'), C('0.5')]), np.array([C('-1'), C('0.5')])]
+    H, got = _solve(fixed, start_moving, end_moving, sp, 2)
+
+    s3 = round(np.sqrt(3) / 2, 4)
+    assert got == sorted([(s3, 0.5), (-s3, 0.5)])      # circle ∩ {y=1/2}
+    assert H.num_functions() == 2
+    assert _fixed_rows_have_zero_dHdt(H, num_fixed_rows=1, num_vars=2)   # static slice row out of dH/dt
+
+
+def test_moving_homotopy_rejects_mismatched_endpoints():
+    x, y = pb.Variable('x'), pb.Variable('y')
+    fixed = pb.System(); fixed.add_variable_group(_vg(x, y)); fixed.add_function(x*x + y*y - 1)
+    sm = pb.System(); sm.add_variable_group(_vg(x, y)); sm.add_function(y)
+    em = pb.System(); em.add_variable_group(_vg(x, y)); em.add_function(y - x); em.add_function(x)  # 2 != 1
+    with pytest.raises(RuntimeError):
+        na.moving_homotopy(fixed, sm, em)

--- a/python/test/zero_dim/randomize_test.py
+++ b/python/test/zero_dim/randomize_test.py
@@ -1,0 +1,165 @@
+"""Randomizing an overdetermined system, solving the square result, and filtering.
+
+An overdetermined system (more functions than variables) cannot be solved directly -- a
+total-degree start system needs a square system.  bertini.linalg.randomize (System.Randomize)
+squares it up with a generic combination R*F whose isolated solutions still contain the
+original's; we solve the square system, then keep only the computed solutions that also satisfy
+the original (overdetermined) system, discarding the extraneous ones the randomization introduces.
+
+Covers: the single-affine-group path (with the descending-degree sort + [I|C] and its
+homogenizing-variable power deficits exercised through the real solver), the multihomogeneous
+path, no-mutation of the original, the matrix getter, the user-supplied matrix, and the
+exact-coefficient discipline.
+"""
+
+import numpy as np
+import pytest
+
+import bertini as pb
+from bertini import linalg
+
+
+def _to_complex(solution, num_vars):
+    """A solution point (in user coordinates) as a length-num_vars list of Python complex."""
+    return [complex(solution[k]) for k in range(num_vars)]
+
+
+def _residuals(system, point):
+    """Max-abs residual of the (overdetermined) system at an affine point in user coordinates."""
+    vals = system.eval(np.array(point, dtype=complex))   # double-precision eval
+    return max(abs(complex(vals[i])) for i in range(system.num_functions()))
+
+
+def _true_solutions(original, solutions, num_vars=2, tol=1e-7):
+    """Computed solutions of the randomized system that also satisfy the original system."""
+    out = []
+    for s in solutions:
+        p = _to_complex(s, num_vars)
+        if _residuals(original, p) < tol:
+            out.append(p)
+    return out
+
+
+def _round_pairs(points, ndig=4):
+    return sorted((round(p[0].real, ndig), round(p[1].real, ndig)) for p in points)
+
+
+def test_unequal_degree_single_group_solves_and_filters():
+    # Overdetermined, UNEQUAL degrees (2, 1, 2): the circle, the line x=y, and 2x^2-1.
+    # Common zeros are exactly (+/- 1/sqrt2, +/- 1/sqrt2) along x=y -- two real points.
+    # Randomization keeps target degrees (2, 2) [the two largest], so the degree-1 function is
+    # folded in with a homogenizing-variable power: this drives the h-power path through the solver.
+    x, y = pb.Variable('x'), pb.Variable('y')
+    original = pb.System()
+    original.add_variable_group(pb.VariableGroup([x, y]))
+    original.add_function(x * x + y * y - 1)
+    original.add_function(x - y)
+    original.add_function(2 * x * x - 1)
+
+    pb.random.set_random_seed(1)
+    randomized = linalg.randomize(original)
+    assert randomized.num_functions() == 2
+    assert sorted(randomized.degrees()) == [2, 2]          # product 4 = the path count
+    assert original.num_functions() == 3                    # original untouched
+
+    zd = pb.nag_algorithm.ZeroDimCauchyAdaptivePrecisionTotalDegree(randomized)
+    zd.solve()
+    sols = zd.solutions()
+    assert len(sols) == 4                                   # Bezout 2*2: two true + two extraneous
+
+    true = _true_solutions(original, sols)
+    r = 1.0 / np.sqrt(2.0)
+    assert _round_pairs(true) == sorted([(round(r, 4), round(r, 4)),
+                                         (round(-r, 4), round(-r, 4))])
+
+
+def test_equal_degree_conics_solves_and_filters():
+    # Three conics through exactly (1, 0) and (0, 1): circle, xy, and x^2+y^2-x-y.
+    x, y = pb.Variable('x'), pb.Variable('y')
+    original = pb.System()
+    original.add_variable_group(pb.VariableGroup([x, y]))
+    original.add_function(x * x + y * y - 1)
+    original.add_function(x * y)
+    original.add_function(x * x + y * y - x - y)
+
+    pb.random.set_random_seed(2)
+    randomized = linalg.randomize(original)
+    assert randomized.num_functions() == 2
+
+    zd = pb.nag_algorithm.ZeroDimCauchyAdaptivePrecisionTotalDegree(randomized)
+    zd.solve()
+    sols = zd.solutions()
+    assert len(sols) == 4
+
+    true = _true_solutions(original, sols)
+    assert _round_pairs(true) == sorted([(1.0, 0.0), (0.0, 1.0)])
+
+
+def test_multihomogeneous_bilinear_solves_and_filters():
+    # Two affine variable groups {x}, {y}; three bilinear (multidegree (1,1)) functions sharing
+    # the single common solution (1, 1).  Randomize to two; the multihomogeneous start tracks
+    # the bilinear Bezout (2 paths) rather than the total degree (4).
+    x, y = pb.Variable('x'), pb.Variable('y')
+    original = pb.System()
+    original.add_variable_group(pb.VariableGroup([x]))
+    original.add_variable_group(pb.VariableGroup([y]))
+    original.add_function(x * y - 1)
+    original.add_function(x + y - 2)
+    original.add_function(x - y)
+
+    pb.random.set_random_seed(3)
+    randomized = linalg.randomize(original)
+    assert randomized.num_functions() == 2
+
+    zd = pb.nag_algorithm.ZeroDimCauchyAdaptivePrecisionMHomogeneous(randomized)
+    zd.solve()
+    sols = zd.solutions()
+    assert len(sols) >= 1
+
+    true = _true_solutions(original, sols)
+    assert _round_pairs(true) == [(1.0, 1.0)]
+
+
+def test_user_supplied_matrix_combination():
+    # g0 = f0 ; g1 = 3 f0 + 5 f2, with f0=x^2+y^2-1 (deg 2) and f2=2x^2-1 (deg 2) in author order.
+    x, y = pb.Variable('x'), pb.Variable('y')
+    original = pb.System()
+    original.add_variable_group(pb.VariableGroup([x, y]))
+    original.add_function(x * x + y * y - 1)
+    original.add_function(x - y)
+    original.add_function(2 * x * x - 1)
+
+    randomized = linalg.randomize(original, [[1, 0, 0], [3, 0, 5]])
+    assert randomized.num_functions() == 2
+
+    # at (x, y) = (2, 3): f0 = 12, f2 = 7 -> g0 = 12, g1 = 3*12 + 5*7 = 71.
+    g = randomized.eval(np.array([pb.multiprec.Complex('2'), pb.multiprec.Complex('3')]))
+    g = [complex(v) for v in g]
+    assert abs(g[0] - 12) < 1e-9
+    assert abs(g[1] - 71) < 1e-9
+
+
+def test_randomization_matrix_round_trips():
+    x, y = pb.Variable('x'), pb.Variable('y')
+    original = pb.System()
+    original.add_variable_group(pb.VariableGroup([x, y]))
+    original.add_function(x * x + y * y - 1)
+    original.add_function(x - y)
+    original.add_function(2 * x * x - 1)
+
+    R = linalg.randomize(original, [[1, 0, 0], [3, 0, 5]]).randomization_matrix()
+    assert R.shape == (2, 3)
+    assert abs(complex(R[0, 0]) - 1) < 1e-12
+    assert abs(complex(R[1, 0]) - 3) < 1e-12
+    assert abs(complex(R[1, 2]) - 5) < 1e-12
+
+
+def test_float_coefficient_refused():
+    x, y = pb.Variable('x'), pb.Variable('y')
+    original = pb.System()
+    original.add_variable_group(pb.VariableGroup([x, y]))
+    original.add_function(x * x + y * y - 1)
+    original.add_function(x - y)
+    original.add_function(2 * x * x - 1)
+    with pytest.raises(TypeError):
+        linalg.randomize(original, [[1.5, 0, 0], [0, 1, 0]])   # Python float -> refused

--- a/python_bindings/src/containers.cpp
+++ b/python_bindings/src/containers.cpp
@@ -35,6 +35,8 @@
 
 #include "containers_export.hpp"
 
+#include <boost/python/iterator.hpp>
+
 namespace bertini{
 	namespace python{
 
@@ -47,6 +49,11 @@ void ListVisitor<T>::visit(PyClass& cl) const
 	.def(vector_indexing_suite< T , true >())
 	// By default indexed elements are returned by proxy. This can be
     // disabled by supplying *true* in the NoProxy template parameter.
+
+	// vector_indexing_suite only provides the __getitem__/__len__ sequence protocol; add a real
+	// __iter__ so `for s in solver.solutions(): ...` (and any other list container) iterates
+	// directly rather than relying on the index-fallback.
+	.def("__iter__", boost::python::iterator<T>())
 
 	.def("__str__", &ListVisitor::__str__)
 	.def("__repr__", &ListVisitor::__repr__)

--- a/python_bindings/src/system_export.cpp
+++ b/python_bindings/src/system_export.cpp
@@ -86,6 +86,13 @@ namespace bertini{
 			.def("eval_jacobian", return_Jac2_ptr<dbl>(), (arg("self")) , "Evaluate the Jacobian (martix of partial derivatives) of the system, using time and space values passed into this function.  Throws if doesn't use a time variable")
 			.def("eval_jacobian", return_Jac2_ptr<mpfr>(), (arg("self")) , "Evaluate the Jacobian (martix of partial derivatives) of the system, using time and space values passed into this function.  Throws if doesn't use a time variable")
 
+			.def("eval_time_derivative",
+				+[](SystemBaseT const& self, bertini::Vec<mpfr> const& v, mpfr const& t) { return self.TimeDerivative(v, t); },
+				(arg("self"), arg("space"), arg("time")), "Evaluate dH/dt (the time derivative) in multiple precision at the given space and time values.  Rows of t-independent blocks are zero.")
+			.def("eval_time_derivative",
+				+[](SystemBaseT const& self, bertini::Vec<dbl> const& v, dbl const& t) { return self.TimeDerivative(v, t); },
+				(arg("self"), arg("space"), arg("time")), "Evaluate dH/dt (the time derivative) in double precision at the given space and time values.  Rows of t-independent blocks are zero.")
+
 			.def("homogenize", static_cast<void (SystemBaseT::*)()>(&SystemBaseT::Homogenize), (arg("self")),"Homogenize the system, adding new homogenizing variables if necessary.  This may change your polynomials; that is, it has side effects.")
 			.def("is_homogeneous", &SystemBaseT::IsHomogeneous, (arg("self")), "Determines whether all polynomials in the system have the same degree.  Non-polynomial functions are not homogeneous.")
 			.def("is_polynomial", &SystemBaseT::IsPolynomial, (arg("self")), "Determines whether all polynomials are polynomial.  Transcendental functions, e.g., are non-polynomial.  Returns a bool.")
@@ -253,6 +260,9 @@ namespace bertini{
 			def("make_homotopy", &MakeHomotopy,
 				(arg("target"), arg("start"), arg("path_variable")="t", arg("gamma")=std::shared_ptr<node::Node>()),
 				"Form the gamma-trick straight-line homotopy H = (1-t)*target + gamma*t*start, with the path variable added.  At t=1 the homotopy is gamma*start (so start's solutions are its roots) and at t=0 it is target.  When start carries a structured block (e.g. a products-of-linears start system) the two systems are combined with a blend block; otherwise node arithmetic is used.  gamma=None generates a random rational gamma.  Pair with nag_algorithm.user_homotopy to solve.");
+			def("make_moving_homotopy", &MakeMovingHomotopy,
+				(arg("fixed"), arg("start_moving"), arg("end_moving"), arg("path_variable")="t", arg("gamma")=std::shared_ptr<node::Node>()),
+				"Form a homotopy that moves ONLY the moving rows, leaving the fixed system evaluated once.  H = [ fixed's blocks ; (1-t)*end_moving + gamma*t*start_moving ]: the fixed equations (polynomial system + any static slices) stay as their own blocks (evaluated once, contributing zero to dH/dt) while only the moving rows slide.  At t=1 the moving rows are gamma*start_moving, at t=0 they are end_moving.  start_moving and end_moving hold just the moving rows and share fixed's variable structure.  The fixed rows come first, then the moving rows; build the matching target as fixed concatenated with end_moving.  gamma=None generates a random rational gamma.  Pair with nag_algorithm.user_homotopy to solve.");
 
 			
 

--- a/python_bindings/src/system_export.cpp
+++ b/python_bindings/src/system_export.cpp
@@ -196,8 +196,12 @@ namespace bertini{
 
 			.def("variable_ordering",&SystemBaseT::VariableOrdering,(arg("self")), "The ordering of variables saying what each coordinate of a point in THIS system's coordinates means.  On your original system these are your variables; on a solver's target_system() the homogenizing variables appear too.")
 
-			.def(self_ns::str(self_ns::self))//, "String representation of the system"
-			.def(self_ns::repr(self_ns::self))//, "Round-trippable representation of the system.  Probably not functional"
+			.def("describe",
+				+[](SystemBaseT const& self, bool verbose) { std::ostringstream ss; self.Describe(ss, verbose); return ss.str(); },
+				(arg("self"), arg("verbose") = false),
+				"A human-facing description of the system, block by block (the same as str(system) when verbose=False).  verbose=True reveals the actual coefficients/matrices and the underlying functions of randomization / blend blocks.  For reading, not re-parsing.")
+			.def(self_ns::str(self_ns::self))//, "String representation of the system (terse; structured blocks shown with placeholder symbols)
+			.def(self_ns::repr(self_ns::self))//, "String representation of the system
 			.def(self += self)
 			.def(self + self) 
 			.def(self *= std::shared_ptr<node::Node>())//, "'Scalar-multiply' a system"

--- a/python_bindings/src/system_export.cpp
+++ b/python_bindings/src/system_export.cpp
@@ -86,7 +86,7 @@ namespace bertini{
 			.def("eval_jacobian", return_Jac2_ptr<dbl>(), (arg("self")) , "Evaluate the Jacobian (martix of partial derivatives) of the system, using time and space values passed into this function.  Throws if doesn't use a time variable")
 			.def("eval_jacobian", return_Jac2_ptr<mpfr>(), (arg("self")) , "Evaluate the Jacobian (martix of partial derivatives) of the system, using time and space values passed into this function.  Throws if doesn't use a time variable")
 
-			.def("homogenize", &SystemBaseT::Homogenize, (arg("self")),"Homogenize the system, adding new homogenizing variables if necessary.  This may change your polynomials; that is, it has side effects.")
+			.def("homogenize", static_cast<void (SystemBaseT::*)()>(&SystemBaseT::Homogenize), (arg("self")),"Homogenize the system, adding new homogenizing variables if necessary.  This may change your polynomials; that is, it has side effects.")
 			.def("is_homogeneous", &SystemBaseT::IsHomogeneous, (arg("self")), "Determines whether all polynomials in the system have the same degree.  Non-polynomial functions are not homogeneous.")
 			.def("is_polynomial", &SystemBaseT::IsPolynomial, (arg("self")), "Determines whether all polynomials are polynomial.  Transcendental functions, e.g., are non-polynomial.  Returns a bool.")
 			
@@ -148,6 +148,18 @@ namespace bertini{
 			.def("hom_variable_groups", &SystemBaseT::HomVariableGroups, (arg("self")), "Get the list of projective / homogeneous variable_groups from the system")
 			.def("degrees", sysDeg1, (arg("self")), "Get a list of the degrees of the functions in the system, with respect to all variables in all groups (and in fact overall)")
 			.def("degrees", sysDeg2, (arg("self"), arg("group")), "Get a list of the degrees of the functions in the system, with respect to a variable_group passed in to this function.  Negative numbers indicate non-polynomial")
+			.def("randomize",
+				+[](SystemBaseT const& self) { return self.Randomize(); },
+				(arg("self")),
+				"Randomize an overdetermined system (N functions, n variables, N>n) down to a square one, returning a NEW system; this one is left untouched.  The square result has n generic combinations of the original functions, whose isolated solutions still contain this system's -- solve it, then discard the extraneous solutions by re-evaluating this system.  For a single affine variable group the functions are sorted by descending degree and R=[I|C], giving the optimal total-degree path count.")
+			.def("randomize",
+				+[](SystemBaseT const& self, bertini::Mat<mpfr> const& R) { return self.Randomize(R); },
+				(arg("self"), arg("matrix")),
+				"Randomize using a supplied coefficient matrix R (one row per randomized function, one column per natural function of this system); the functions are kept in their current order.  Returns a NEW system.")
+			.def("randomization_matrix",
+				+[](SystemBaseT const& self) { return self.RandomizationMatrix(); },
+				(arg("self")),
+				"The randomization matrix R (n x N, mpfr_complex) of a system produced by randomize().  Raises if the system has no randomization block.")
 			.def("reorder_functions_by_degree_decreasing", &SystemBaseT::ReorderFunctionsByDegreeDecreasing, (arg("self")),"Change the order of the functions to be in decreasing order")
 			.def("reorder_functions_by_degree_increasing", &SystemBaseT::ReorderFunctionsByDegreeIncreasing, (arg("self")),"Change the order of the functions to be in decreasing order")
 			.def("clear_variables", &SystemBaseT::ClearVariables, (arg("self")), "Remove the variable structure from the system")


### PR DESCRIPTION
## Overview

Three related pieces of work on the block-composed `System`, building toward regeneration:

1. **Randomize overdetermined systems** — a first-class `RandomizationBlock` that squares an
   overdetermined system (N functions, n variables, N > n) to a solvable one, so its isolated
   solutions can be found and the extraneous ones filtered.
2. **Moving-row homotopies** — `MakeMovingHomotopy`: keep the polynomial system and any static
   slices FIXED (evaluated once, `dH/dt = 0` on them) while only the moving rows carry `t`. Covers
   sliding linear slices and the regeneration "add a degree" step (deform a product-of-linears into
   a polynomial). No new block types — reuse `BlendBlock`, blending only the moving rows.
3. **Human-facing printing** — each block describes its own rows; terse placeholders by default
   (`R · g`, `c·[x,y,1]`, `(1-t)·A + γt·B`), actual numbers + underlying functions with
   `system.describe(verbose=True)`.

## Features

- `System::Randomize()` / `Randomize(R)` (`[I|C]` + descending-degree sort for one group → optimal
  path count; dense + common multidegree for several groups), `randomization_matrix()`, Python
  `linalg.randomize`.
- `MakeMovingHomotopy(fixed, start_moving, end_moving, t, gamma)` / `nag_algorithm.moving_homotopy`;
  the three hand-checkable demos (circle + moving slice; sphere + static + moving slice; deform
  `(x-1)(x+1)` into the circle) in the tests and the doctested `moving_slice.rst` tutorial.
- Per-block `Describe`; `system.describe(verbose=...)`; `eval_time_derivative` bound to Python (so
  the "fixed rows are out of `dH/dt`" invariant is checkable).
- Tutorials: `randomize.rst`, `moving_slice.rst` (both doctested; `build_docs.yml` now runs
  `sphinx -b doctest`). ADRs 0025, 0026 (renumbered after #21).

## Bugs / latent issues fixed along the way

- **`MakeHomotopy` silently dropped a structured-block target.** It chose the blend path only when
  the *start* carried a structured block, falling back to node arithmetic otherwise — but
  `operator+`/`operator*` on Systems only combine the `PolynomialBlock` functions and **silently
  ignore structured blocks**. So a structured-block *target* (a randomized system) was dropped from
  the homotopy, which then tracked to empty / singular endpoints. Now it blends whenever *either*
  side is structured, and clears all shell blocks (`ClearBlocks`, not `ClearFunctions`). This was a
  genuine latent correctness bug. (ADR-0025.)
- **`System` printing was broken for block systems.** `operator<<` listed only the `PolynomialBlock`
  rows, so structured-block rows were **invisible** (a randomized system printed `2 functions:` then
  nothing; a poly+slice system dropped the slice row); polynomial rows were double-named with
  `unnamed_function`; and debugging leftovers (the differentiated flag, a dump of the working
  dbl/mpfr variable vectors) leaked into the output. Replaced with per-block `Describe`.
- **`ExpandToFunctionTree` didn't support `LinearFormsBlock`** — it threw `block type not yet
  supported`, so the verification oracle couldn't cover slice-bearing systems. Added the expansion
  case (affine and homogeneous).
- **Solution / list containers had no real iterator.** They iterated only via the `__getitem__`
  fallback; added a proper `__iter__` (boost `iterator<T>`) to the shared list-container visitor, so
  `for s in solver.solutions()` (and every list container) iterates directly.

## Getting CI green

Two pre-existing problems (inherited from the #21 merge) blocked CI and took real work to resolve:

- **Path-crossing test timed out in the manylinux container.** The Python path-crossing test
  *searched* a range of RNG seeds, running up to a dozen full cyclic-5 (120-path) Euler solves until
  one happened to produce a detected crossing — because *which* seed crosses depends on platform
  floating point. In the `manylinux_2_34_x86_64` container this ran >15 min and timed out (it passed
  on macOS), and a timeout bump didn't help. **Replaced the seed search with an explicit,
  hand-constructed path-crossing example** whose crossing is a portable geometric fact rather than a
  platform-FP coincidence: a cubic with three paths — `A(t)` curved, `B` flat, `C` far. Under the
  low-order Euler predictor with a coarse step, the straight-line prediction of the curved path
  overshoots *past* the flat path into its basin; the corrector lands on the flat root exactly (so
  the step is accepted and adaptive step-size control does not rescue it), two paths funnel onto it,
  and the curved path's true endpoint is lost — a **detectable crossing**, which the solver's
  re-tracking then **resolves and recovers**. Exact rational coefficients + a macroscopic overshoot
  make it identical on every platform; it runs in ~0.02 s with no randomness, no seed search, and no
  timeout band-aid.
- **Config `deepcopy` corrupted multiprecision fields on Python 3.10.** The enhanced config classes
  pickled via a `to_dict`/`from_dict` `__reduce__` and let `copy.deepcopy` fall through to that
  generic path, which then deep-copied the mapping's multiprecision *values* — these alias and
  corrupt on Python 3.10 (the `SteppingConfig` `mpq_rational` fields collapsed to `0.5`, failing the
  config round-trip test on the 3.10 wheels while 3.11–3.14 passed; pickle itself was fine). Gave the
  enhanced classes an explicit `__deepcopy__`/`__copy__` that rebuild through
  `from_dict(to_dict(self))` — re-fetching the immutable scalar fields from the getters instead of
  deep-copying them. Removes the corrupting operation entirely; portable across interpreters.

## Verification

- C++: full class suite (incl. randomization, moving-homotopy, and printing tests) + blackbox +
  nag-algorithms, all green.
- Python: full suite green (411 tests).
- Docs: `sphinx -b doctest` 0 failures (randomize + moving-slice tutorials are executed); warning-clean
  `-b html -W`.
- CI: all jobs green across Linux / macOS / Windows × CPython 3.10–3.14 (the path-crossing example
  runs fast in the manylinux container; the 3.10 config round-trip passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
