### PR TITLE
ZeroDim: crossed-path resolution, speculative-full-path parallelism, reproducibility & MPI-portability fixes

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -456,7 +456,13 @@ target_link_libraries(bertini2 PUBLIC Eigen3::Eigen)
 target_link_libraries(bertini2 PUBLIC ${Boost_LIBRARIES})
 
 if(ENABLE_MPI)
-    target_compile_definitions(bertini2 PUBLIC BERTINI2_HAVE_MPI)
+    # We use only the MPI C API.  Including <mpi.h> from C++ otherwise pulls in the deprecated
+    # MPI C++ bindings (the MPI:: namespace / mpicxx.h), which MPICH compiles in by default and
+    # which fail to build under modern C++ (clang especially) -- so the project compiled with
+    # OpenMPI but not MPICH.  These macros tell both implementations to skip the C++ bindings.
+    # PUBLIC + on the compile command line, so they are defined before any <mpi.h> include, and
+    # propagate to everything linking bertini2 (python bindings, blackbox).
+    target_compile_definitions(bertini2 PUBLIC BERTINI2_HAVE_MPI MPICH_SKIP_MPICXX OMPI_SKIP_MPICXX)
     target_link_libraries(bertini2 PUBLIC MPI::MPI_CXX)
     message(STATUS "bertini2 built with plain C MPI support (no Boost.MPI)")
 endif()

--- a/core/include/bertini2/io/splash.hpp
+++ b/core/include/bertini2/io/splash.hpp
@@ -39,7 +39,7 @@
 #include "boost/version.hpp"
 
 #ifdef BERTINI2_HAVE_MPI
-#include <mpi.h>
+#include "bertini2/parallel/mpi_include.hpp"
 #endif
 
 #include <sstream>

--- a/core/include/bertini2/nag_algorithms/common/policies.hpp
+++ b/core/include/bertini2/nag_algorithms/common/policies.hpp
@@ -145,7 +145,12 @@ public:
 
 			using SystemT = SystemType;
 			using StartSystemT = StartSystemType;
-			
+
+			// This policy owns (deep-copies) its systems, so in a distributed solve rank 0's
+			// systems can be broadcast and installed authoritatively on every rank.  RefToGiven,
+			// which only holds references to user-managed systems, sets this false.
+			static constexpr bool OwnsSystems = true;
+
 private:
 			StoredSystemT target_system_;
 			StoredStartSystemT start_system_;
@@ -275,6 +280,10 @@ public:
 			using SMP::TargetSystem;
 			using SMP::StartSystem;
 			using SMP::Homotopy;
+
+			// The user owns these systems (we only hold references); a distributed solve must not
+			// overwrite them, so it does not broadcast/install rank 0's systems here.  See CloneGiven.
+			static constexpr bool OwnsSystems = false;
 
 
 private:

--- a/core/include/bertini2/nag_algorithms/midpath_check.hpp
+++ b/core/include/bertini2/nag_algorithms/midpath_check.hpp
@@ -134,6 +134,16 @@ namespace bertini{
 			template <typename StartSystemT>
 			bool Check(BoundaryData const& boundary_data, StartSystemT const& start_system)
 			{
+				// Each Check is independent: the algorithm calls this repeatedly (once before any
+				// resolve, then again after each MidpathResolve).  Reset the accumulated state so a
+				// later call reports *this* call's crossings, not the union with prior calls.
+				// Without this, passed_ (only ever set false below) would stay false forever once
+				// any crossing was seen, and crossed_paths_ would grow without bound -- the resolve
+				// loop in EGBoundaryAction would then never see a clean pass and would re-track
+				// stale indices.
+				passed_ = true;
+				crossed_paths_.clear();
+
 				for (PathIndT ii = 0; ii < boundary_data.size(); ++ii)
 				{
 					if ( boundary_data[ii].success_code != SuccessCode::Success)
@@ -158,7 +168,15 @@ namespace bertini{
 							
 							const auto start_jj = start_system.template StartPoint<ComplexT>(jj);
 							auto diff_start = start_ii - start_jj;
-							bool same_start = (diff_start.template lpNorm<Eigen::Infinity>() > SamePointTol());
+							// same_start is true when the two paths *began at the same start point*
+							// (their start points differ by less than the tolerance).  That governs
+							// whether this coincidence is a genuine path crossing worth re-tracking:
+							// CrossedPath sets rerun_ = !same_start, so two *distinct* starts that
+							// have collided (same_start == false) get re-tracked, while two paths
+							// that legitimately share a start point do not.  NOTE: this comparison
+							// was historically inverted (>), which flipped rerun and meant genuine
+							// crossings were never re-tracked.
+							bool same_start = (diff_start.template lpNorm<Eigen::Infinity>() < SamePointTol());
 							
 							
 							// Check if path has already been stored in crossed_paths_

--- a/core/include/bertini2/nag_algorithms/zero_dim_solve.hpp
+++ b/core/include/bertini2/nag_algorithms/zero_dim_solve.hpp
@@ -46,6 +46,7 @@
 #include "bertini2/parallel.hpp"
 #include <chrono>
 #include <mutex>
+#include <iostream>
 
 
 namespace bertini {
@@ -244,6 +245,38 @@ std::ostream& operator<<(std::ostream & out, const EGBoundaryMetaData<NumT> & me
 	out << "success_code = " << meta.success_code << std::endl;
 	out << "last_used_stepsize = " << meta.last_used_stepsize << std::endl;
 	out << "precision = " << meta.precision << std::endl;
+	return out;
+}
+
+/**
+\brief Summary of what the midpath (path-crossing) check found at the endgame boundary, and what the
+algorithm did about it.
+
+Two distinct paths landing on the same point at the endgame boundary is a probability-0 event: it
+signals a path crossing (under-resolved tracking), not a benign coincidence.  The zero-dim algorithm
+detects these at the boundary using a relaxed same-point tolerance and re-tracks the offending paths
+with tightened settings (see ZeroDim::EGBoundaryAction).  This struct records the outcome so a caller
+can tell whether a solve hit crossings and whether they were resolved.
+
+\see ZeroDim::EndgameBoundaryMetadata
+*/
+struct MidpathCheckReport
+{
+	bool passed = true;                                    ///< Did the final midpath check pass (no crossings remained)?
+	unsigned num_crossings_detected = 0;                   ///< Number of crossed paths found on the *first* check, before any re-tracking.
+	unsigned num_resolve_attempts = 0;                     ///< How many re-track attempts were actually performed.
+	std::vector<unsigned long long> crossed_path_indices;  ///< Indices of the paths flagged as crossed on the first check.
+};
+
+inline
+std::ostream& operator<<(std::ostream & out, const MidpathCheckReport & r){
+	out << "passed = " << std::boolalpha << r.passed << std::endl;
+	out << "num_crossings_detected = " << r.num_crossings_detected << std::endl;
+	out << "num_resolve_attempts = " << r.num_resolve_attempts << std::endl;
+	out << "crossed_path_indices = [";
+	for (size_t i = 0; i < r.crossed_path_indices.size(); ++i)
+		out << (i ? ", " : "") << r.crossed_path_indices[i];
+	out << "]" << std::endl;
 	return out;
 }
 
@@ -846,9 +879,21 @@ std::ostream& operator<<(std::ostream & out, const EGBoundaryMetaData<NumT> & me
 			/**
 			\brief Get the solutions as computed at the endgame boundary
 			*/
-			const auto& EndgameBoundaryData() const
+			const auto& EndgameBoundarySolutions() const
 			{
 				return solutions_at_endgame_boundary_;
+			}
+
+			/**
+			\brief Get the report from the midpath (path-crossing) check performed at the endgame
+			boundary: how many crossings were detected, which paths, how many re-track attempts were
+			made, and whether the check ultimately passed.
+
+			\see MidpathCheckReport
+			*/
+			const MidpathCheckReport& EndgameBoundaryMetadata() const
+			{
+				return midpath_report_;
 			}
 
 		private:
@@ -1161,21 +1206,51 @@ std::ostream& operator<<(std::ostream & out, const EGBoundaryMetaData<NumT> & me
 
 			void EGBoundaryAction()
 			{
+				// Detect path crossings: two distinct paths landing on the same point at the endgame
+				// boundary is a probability-0 event, so it signals under-resolved tracking.
 				auto midcheckpassed = midpath_.Check(solutions_at_endgame_boundary_, StartSystem());
 
+				// Record the *first*-check findings (before any re-tracking) into the report.
+				midpath_report_ = MidpathCheckReport{};
+				midpath_report_.passed = midcheckpassed;
+				for (auto const& v : midpath_.GetCrossedPaths())
+					midpath_report_.crossed_path_indices.push_back(v.index());
+				midpath_report_.num_crossings_detected =
+					static_cast<unsigned>(midpath_report_.crossed_path_indices.size());
+
+				// max_num_crossed_path_resolve_attempts == 0 means "detect and report, but do not
+				// re-track" -- the conservative, give-up-after-detection mode.  The loop below
+				// naturally performs zero iterations in that case (and is bounded in all cases, so
+				// it always terminates).
+				const auto max_attempts = this->template Get<ZeroDimConf>().max_num_crossed_path_resolve_attempts;
 				unsigned num_resolve_attempts = 0;
-				while (!midcheckpassed && num_resolve_attempts < this->template Get<ZeroDimConf>().max_num_crossed_path_resolve_attempts)
+				while (!midcheckpassed && num_resolve_attempts < max_attempts)
 				{
 					MidpathResolve();
 					midcheckpassed = midpath_.Check(solutions_at_endgame_boundary_, StartSystem());
 					num_resolve_attempts++;
 				}
+
+				midpath_report_.num_resolve_attempts = num_resolve_attempts;
+				midpath_report_.passed = midcheckpassed;
+
+				// Unresolved crossings are kept tracking (they still go through the endgame, so we
+				// never lose more answers than Bertini 1 would) but are made observable: the report
+				// carries passed==false and the offending indices, and we warn here.  A caller can
+				// inspect EndgameBoundaryMetadata() and re-solve with a better predictor / tighter
+				// tolerance (the defaults are tuned precisely so this does not happen).
+				if (!midcheckpassed)
+					std::cerr << "warning: " << midpath_report_.num_crossings_detected
+					          << " path crossing(s) detected at the endgame boundary remained unresolved "
+					          << "after " << num_resolve_attempts << " re-track attempt(s); "
+					          << "the affected solutions may be wrong.  Consider a higher-order predictor "
+					          << "or a tighter tracking tolerance.  See EndgameBoundaryMetadata()." << std::endl;
 			}
 
 
 			void MidpathResolve()
 			{
-				ShrinkMidpathTolerance();
+				EscalateRetrackSettings();
 
 				for(auto const& v : midpath_.GetCrossedPaths())
 				{
@@ -1190,10 +1265,31 @@ std::ostream& operator<<(std::ostream & out, const EGBoundaryMetaData<NumT> & me
 			}
 
 
-			void ShrinkMidpathTolerance()
+			/**
+			\brief Apply one step of escalation to the tracker before re-tracking crossed paths.
+
+			Two remedies are applied: (1) tighten the tracking tolerance, and (2) raise the ODE
+			predictor to the default (RKF45) if a low-order predictor is in use -- a too-low-order
+			predictor (notably Euler) is the most common cause of spurious boundary crossings, and
+			no amount of tolerance-tightening on a first-order predictor is as effective as moving to
+			a higher-order one.  The predictor bump is idempotent (once at RKF45's order it is a
+			no-op).
+
+			\note Future work: this single step wants to become a *configurable, ordered remedy list*
+			(tighten tolerance, more Newton iterations, bump predictor, shrink min step size, ...),
+			applied in sequence until exhausted.  That strategy abstraction is intentionally deferred;
+			for now the escalation is a fixed, minimal two-remedy step.  Termination is guaranteed
+			regardless, because EGBoundaryAction bounds the number of attempts.
+			*/
+			void EscalateRetrackSettings()
 			{
 				midpath_retrack_tolerance_ *= this->template Get<AutoRetrack>().midpath_decrease_tolerance_factor;
 				GetTracker().SetTrackingTolerance(midpath_retrack_tolerance_);
+
+				const auto default_predictor = tracking::predict::DefaultPredictor();
+				if (tracking::predict::Order(GetTracker().GetPredictor())
+				    < tracking::predict::Order(default_predictor))
+					GetTracker().SetPredictor(default_predictor);
 			}
 
 
@@ -1508,6 +1604,7 @@ std::ostream& operator<<(std::ostream & out, const EGBoundaryMetaData<NumT> & me
 
 			unsigned long long num_start_points_;
 			NumErrorT midpath_retrack_tolerance_;
+			MidpathCheckReport midpath_report_; ///< populated by EGBoundaryAction; exposed via EndgameBoundaryMetadata()
 
 
 			/// observers used during tracking

--- a/core/include/bertini2/nag_algorithms/zero_dim_solve.hpp
+++ b/core/include/bertini2/nag_algorithms/zero_dim_solve.hpp
@@ -807,11 +807,14 @@ std::ostream& operator<<(std::ostream & out, const MidpathCheckReport & r){
 
 				PreSolveSetup();
 
-				TrackBeforeEG();
+				// Speculative-full-path model: carry every path all the way through (pre-endgame +
+				// endgame) as one unit, then detect crossings from the collected boundary points and
+				// re-run any crossed path in full.  This is the same shape the distributed solve uses
+				// (one worker per whole path), so serial and distributed share the per-path primitive.
+				for (decltype(num_start_points_) ii{0}; ii < num_start_points_; ++ii)
+					ExecuteOnePath(MemberDuringEGContext(), static_cast<SolnIndT>(ii));
 
-				EGBoundaryAction();
-
-				TrackDuringEG();
+				RunMidpathResolution([this](SolnIndT idx){ ExecuteOnePath(MemberDuringEGContext(), idx); });
 
 				PostEGAction();
 			}
@@ -1011,6 +1014,13 @@ std::ostream& operator<<(std::ostream & out, const MidpathCheckReport & r){
 					std::lock_guard<std::mutex> lock(start_point_mutex);
 					start_point = StartSystem().template StartPoint<BaseComplexT>(soln_ind);
 				}
+
+				// Reset to the configured initial step size for this fresh path.  In the
+				// speculative-full-path model a path's endgame runs immediately before the next
+				// path's pre-endgame tracking on the same tracker, and the endgame leaves
+				// ReinitializeInitialStepSize(false) with a tiny step; without restoring it here the
+				// next path would crawl from the start time with that tiny step (effectively a hang).
+				ctx.tracker.ReinitializeInitialStepSize(true);
 
 				// Begin tracking at the intended ambient precision rather than the start point's
 				// incidental precision.  Total-degree start points are generated at
@@ -1218,6 +1228,74 @@ std::ostream& operator<<(std::ostream & out, const MidpathCheckReport & r){
 
 					TrackSinglePathDuringEG(soln_ind);
 				}
+			}
+
+
+			/**
+			\brief Execute one whole path: start -> endgame boundary -> target, against `ctx`.
+
+			The unit of work in the speculative-full-path model: a single worker/thread carries a
+			path through both the pre-endgame tracking and the endgame, so the boundary state never
+			leaves the executing context (no serialize-the-handoff, hence no precision-transfer gap).
+			The pre-endgame tracking tolerance is `midpath_retrack_tolerance_` (== newton_before_endgame
+			on the first pass, tightened on re-track passes by EscalateRetrackSettings); the endgame
+			uses newton_during_endgame.
+			*/
+			void ExecuteOnePath(DuringEGContext ctx, SolnIndT soln_ind)
+			{
+				ctx.tracker.SetTrackingTolerance(midpath_retrack_tolerance_);
+				ExecuteBeforeEG(BeforeEGContext{ ctx.tracker, ctx.first_prec_rec, ctx.min_max_prec }, soln_ind);
+
+				if (solution_final_metadata_[soln_ind].pre_endgame_success != SuccessCode::Success)
+					return;
+
+				ctx.tracker.SetTrackingTolerance(this->template Get<Tolerances>().newton_during_endgame);
+				ExecuteDuringEG(ctx, soln_ind);
+			}
+
+
+			/**
+			\brief Detect path crossings from the collected boundary points and, for each crossed
+			path, re-run it via `redo_one` (a full-path redo) with escalated settings.
+
+			Shared by the serial flow and the distributed manager.  Populates midpath_report_.
+			Bounded by max_num_crossed_path_resolve_attempts (0 = detect-and-report only), so it always
+			terminates.  Unresolved crossings stay tracked but observable (report.passed == false +
+			warning).
+			*/
+			template<typename RedoOne>
+			void RunMidpathResolution(RedoOne&& redo_one)
+			{
+				auto passed = midpath_.Check(solutions_at_endgame_boundary_, StartSystem());
+
+				midpath_report_ = MidpathCheckReport{};
+				midpath_report_.passed = passed;
+				for (auto const& v : midpath_.GetCrossedPaths())
+					midpath_report_.crossed_path_indices.push_back(v.index());
+				midpath_report_.num_crossings_detected =
+					static_cast<unsigned>(midpath_report_.crossed_path_indices.size());
+
+				const auto max_attempts = this->template Get<ZeroDimConf>().max_num_crossed_path_resolve_attempts;
+				unsigned num_resolve_attempts = 0;
+				while (!passed && num_resolve_attempts < max_attempts)
+				{
+					EscalateRetrackSettings();
+					for (auto const& v : midpath_.GetCrossedPaths())
+						if (v.rerun())
+							redo_one(static_cast<SolnIndT>(v.index()));
+					passed = midpath_.Check(solutions_at_endgame_boundary_, StartSystem());
+					++num_resolve_attempts;
+				}
+
+				midpath_report_.num_resolve_attempts = num_resolve_attempts;
+				midpath_report_.passed = passed;
+
+				if (!passed)
+					std::cerr << "warning: " << midpath_report_.num_crossings_detected
+					          << " path crossing(s) detected at the endgame boundary remained unresolved "
+					          << "after " << num_resolve_attempts << " re-track attempt(s); "
+					          << "the affected solutions may be wrong.  Consider a higher-order predictor "
+					          << "or a tighter tracking tolerance.  See EndgameBoundaryMetadata()." << std::endl;
 			}
 
 

--- a/core/include/bertini2/nag_algorithms/zero_dim_solve.hpp
+++ b/core/include/bertini2/nag_algorithms/zero_dim_solve.hpp
@@ -393,6 +393,7 @@ std::ostream& operator<<(std::ostream & out, const MidpathCheckReport & r){
 			void RunParallel(MPI_Comm comm)
 			{
 				using Result = parallel::FullPathResult<BaseComplexT>;
+				using Task   = parallel::StartPointTask<BaseComplexT>;
 
 				mpfr_free_cache(); // reproducibility: clear this rank's mpfr constant cache (see Solve())
 
@@ -439,15 +440,21 @@ std::ostream& operator<<(std::ostream & out, const MidpathCheckReport & r){
 				// so it rides the same demand-driven worker pool (no idle-manager bottleneck).
 				if (parallel::IsManager())
 				{
-					auto run_round = [&](std::queue<SolnIndT>& q)
+					// Rank 0 computes every start point once, authoritatively, and ships each to the
+					// worker that tracks it.  Cached so re-track rounds reuse the identical points.
+					std::vector<Vec<BaseComplexT>> start_points(num_start_points_);
+					for (decltype(num_start_points_) ii{0}; ii < num_start_points_; ++ii)
+						start_points[ii] = ComputeStartPoint(static_cast<SolnIndT>(ii));
+
+					auto run_round = [&](std::queue<Task>& q)
 					{
-						parallel::RunManagerLoop<SolnIndT, Result>(comm, q,
+						parallel::RunManagerLoop<Task, Result>(comm, q,
 							[this](Result const& r){ StoreFullPathResult(r); });
 					};
 
-					std::queue<SolnIndT> queue;
+					std::queue<Task> queue;
 					for (decltype(num_start_points_) ii{0}; ii < num_start_points_; ++ii)
-						queue.push(static_cast<SolnIndT>(ii));
+						queue.push(Task{ static_cast<SolnIndT>(ii), start_points[ii] });
 					run_round(queue);
 
 					// Midpath/crossing check on the collected boundary points, then bounded parallel
@@ -470,10 +477,13 @@ std::ostream& operator<<(std::ostream & out, const MidpathCheckReport & r){
 						if (!keep_going)
 							break;
 
-						std::queue<SolnIndT> redo;
+						std::queue<Task> redo;
 						for (auto const& v : midpath_.GetCrossedPaths())
 							if (v.rerun())
-								redo.push(static_cast<SolnIndT>(v.index()));
+							{
+								auto idx = static_cast<SolnIndT>(v.index());
+								redo.push(Task{ idx, start_points[idx] });
+							}
 						run_round(redo);
 
 						passed = midpath_.Check(solutions_at_endgame_boundary_, StartSystem());
@@ -497,10 +507,10 @@ std::ostream& operator<<(std::ostream & out, const MidpathCheckReport & r){
 						if (n_threads <= 1)
 						{
 							// Single-threaded worker: execute whole paths on the rank's member
-							// tracker/endgame directly.
-							parallel::RunWorkerLoop<SolnIndT, Result>(comm,
-								[this](SolnIndT const& idx){ ExecuteOnePath(MemberDuringEGContext(), idx); },
-								[this](SolnIndT const& idx) -> Result { return PackFullPathResult(idx); });
+							// tracker/endgame directly, from rank 0's authoritative start point.
+							parallel::RunWorkerLoop<Task, Result>(comm,
+								[this](Task const& task){ ExecuteOnePath(MemberDuringEGContext(), static_cast<SolnIndT>(task.path_index), task.start_point); },
+								[this](Task const& task) -> Result { return PackFullPathResult(static_cast<SolnIndT>(task.path_index)); });
 						}
 						else
 						{
@@ -522,13 +532,14 @@ std::ostream& operator<<(std::ostream & out, const MidpathCheckReport & r){
 								return s;
 							};
 
-							auto track_fn = [this](std::unique_ptr<PathThreadState>& state, SolnIndT const& idx) -> Result
+							auto track_fn = [this](std::unique_ptr<PathThreadState>& state, Task const& task) -> Result
 							{
-								ExecuteOnePath(state->Context(), idx);
+								auto idx = static_cast<SolnIndT>(task.path_index);
+								ExecuteOnePath(state->Context(), idx, task.start_point);
 								return PackFullPathResult(idx);
 							};
 
-							parallel::RunWorkerLoopThreaded<SolnIndT, Result>(
+							parallel::RunWorkerLoopThreaded<Task, Result>(
 								comm, state_factory, track_fn, n_threads);
 						}
 					}; // run_worker_round
@@ -633,6 +644,23 @@ std::ostream& operator<<(std::ostream & out, const MidpathCheckReport & r){
 			const auto& MidpathRetrackTol() const
 			{
 				return midpath_retrack_tolerance_;
+			}
+
+			/**
+			\brief Set the precision at which start points are computed.
+
+			Defaults to the initial ambient precision.  Set this to carry a higher precision forward
+			(e.g. when one solve's output seeds the next).  Once set, PreSolveSetup will not override it.
+			*/
+			void SetStartPointPrecision(unsigned p)
+			{
+				start_point_precision_ = p;
+				start_point_precision_set_by_user_ = true;
+			}
+
+			unsigned StartPointPrecision() const
+			{
+				return start_point_precision_;
 			}
 
 
@@ -788,11 +816,15 @@ std::ostream& operator<<(std::ostream & out, const MidpathCheckReport & r){
 				// Speculative-full-path model: carry every path all the way through (pre-endgame +
 				// endgame) as one unit, then detect crossings from the collected boundary points and
 				// re-run any crossed path in full.  This is the same shape the distributed solve uses
-				// (one worker per whole path), so serial and distributed share the per-path primitive.
+				// (one worker per whole path), so serial and distributed share the per-path primitive
+				// -- including computing the start point via the same ComputeStartPoint.
 				for (decltype(num_start_points_) ii{0}; ii < num_start_points_; ++ii)
-					ExecuteOnePath(MemberDuringEGContext(), static_cast<SolnIndT>(ii));
+				{
+					auto idx = static_cast<SolnIndT>(ii);
+					ExecuteOnePath(MemberDuringEGContext(), idx, ComputeStartPoint(idx));
+				}
 
-				RunMidpathResolution([this](SolnIndT idx){ ExecuteOnePath(MemberDuringEGContext(), idx); });
+				RunMidpathResolution([this](SolnIndT idx){ ExecuteOnePath(MemberDuringEGContext(), idx, ComputeStartPoint(idx)); });
 
 				PostEGAction();
 			}
@@ -898,6 +930,12 @@ std::ostream& operator<<(std::ostream & out, const MidpathCheckReport & r){
 				solutions_post_endgame_.resize(num_as_size_t);
 
 				SetMidpathRetrackTol(this->template Get<Tolerances>().newton_before_endgame);
+
+				// Default the start-point precision to the initial ambient precision.  A caller can
+				// override it via SetStartPointPrecision (e.g. to carry a higher precision forward
+				// from a previous solve whose output feeds this one).
+				if (!start_point_precision_set_by_user_)
+					start_point_precision_ = this->template Get<ZeroDimConf>().initial_ambient_precision;
 			}
 
 			/**
@@ -934,6 +972,24 @@ std::ostream& operator<<(std::ostream & out, const MidpathCheckReport & r){
 			}
 
 			/**
+			\brief Compute the start point for one path, authoritatively.
+
+			The single source of a start point.  The serial flow calls this directly; in a distributed
+			solve rank 0 calls it and ships the result to the worker (the worker never derives its own),
+			so start points are identical across serial and distributed runs.  Computed at
+			start_point_precision_ (defaults to the initial ambient precision; settable so a chained
+			solve can carry precision forward).  StartPoint() mutates the shared start system's
+			expression-tree value caches, so generation is serialized.
+			*/
+			Vec<BaseComplexT> ComputeStartPoint(SolnIndT soln_ind)
+			{
+				SetThreadPrecision(start_point_precision_);
+				static std::mutex start_point_mutex;
+				std::lock_guard<std::mutex> lock(start_point_mutex);
+				return StartSystem().template StartPoint<BaseComplexT>(soln_ind);
+			}
+
+			/**
 			\brief Track one path from the start time to the endgame boundary, against `ctx`.
 
 			The single before-endgame body, shared by the serial flow and the distributed worker.
@@ -941,7 +997,7 @@ std::ostream& operator<<(std::ostream & out, const MidpathCheckReport & r){
 			and concurrently on worker threads alike.  Writes the boundary point + the pre-endgame
 			portion of the metadata.
 			*/
-			void ExecuteBeforeEG(BeforeEGContext ctx, SolnIndT soln_ind)
+			void ExecuteBeforeEG(BeforeEGContext ctx, SolnIndT soln_ind, Vec<BaseComplexT> const& start_point)
 			{
 				ReseedThisThread(static_cast<uint64_t>(soln_ind));
 
@@ -962,15 +1018,11 @@ std::ostream& operator<<(std::ostream & out, const MidpathCheckReport & r){
 				auto t_start            = this->template Get<ZeroDimConf>().start_time;
 				auto t_endgame_boundary = this->template Get<ZeroDimConf>().endgame_boundary;
 
-				// The start system is shared; StartPoint() mutates expression-tree value caches, so
-				// generation is serialized.  Trivial cost next to tracking.  Generated AFTER
-				// SetThreadPrecision so the point has the precision a serial run would give it.
-				Vec<BaseComplexT> start_point;
-				{
-					static std::mutex start_point_mutex;
-					std::lock_guard<std::mutex> lock(start_point_mutex);
-					start_point = StartSystem().template StartPoint<BaseComplexT>(soln_ind);
-				}
+				// The start point is supplied by the caller (computed once, authoritatively, via
+				// ComputeStartPoint) rather than regenerated here.  In a distributed solve rank 0
+				// computes it and sends it with the task, so a worker never derives its own -- that,
+				// plus authoritative pi (issue #156), is what makes the start point identical across
+				// serial and distributed runs.
 
 				// Reset to the configured initial step size for this fresh path.  In the
 				// speculative-full-path model a path's endgame runs immediately before the next
@@ -1079,10 +1131,10 @@ std::ostream& operator<<(std::ostream & out, const MidpathCheckReport & r){
 			on the first pass, tightened on re-track passes by EscalateRetrackSettings); the endgame
 			uses newton_during_endgame.
 			*/
-			void ExecuteOnePath(DuringEGContext ctx, SolnIndT soln_ind)
+			void ExecuteOnePath(DuringEGContext ctx, SolnIndT soln_ind, Vec<BaseComplexT> const& start_point)
 			{
 				ctx.tracker.SetTrackingTolerance(midpath_retrack_tolerance_);
-				ExecuteBeforeEG(BeforeEGContext{ ctx.tracker, ctx.first_prec_rec, ctx.min_max_prec }, soln_ind);
+				ExecuteBeforeEG(BeforeEGContext{ ctx.tracker, ctx.first_prec_rec, ctx.min_max_prec }, soln_ind, start_point);
 
 				if (solution_final_metadata_[soln_ind].pre_endgame_success != SuccessCode::Success)
 					return;
@@ -1420,6 +1472,8 @@ std::ostream& operator<<(std::ostream & out, const MidpathCheckReport & r){
 			unsigned long long num_start_points_;
 			NumErrorT midpath_retrack_tolerance_;
 			MidpathCheckReport midpath_report_; ///< populated by EGBoundaryAction; exposed via EndgameBoundaryMetadata()
+			unsigned start_point_precision_ = DoublePrecision(); ///< precision at which start points are computed; defaults to initial ambient precision (see PreSolveSetup)
+			bool start_point_precision_set_by_user_ = false;
 
 
 			/// observers used during tracking

--- a/core/include/bertini2/nag_algorithms/zero_dim_solve.hpp
+++ b/core/include/bertini2/nag_algorithms/zero_dim_solve.hpp
@@ -392,9 +392,7 @@ std::ostream& operator<<(std::ostream & out, const MidpathCheckReport & r){
 			*/
 			void RunParallel(MPI_Comm comm)
 			{
-				using BeforeResult = parallel::PathBeforeEGResult<BaseComplexT>;
-				using Phase2T      = parallel::Phase2Task<BaseComplexT>;
-				using DuringResult = parallel::PathDuringEGResult<BaseComplexT>;
+				using Result = parallel::FullPathResult<BaseComplexT>;
 
 				mpfr_free_cache(); // reproducibility: clear this rank's mpfr constant cache (see Solve())
 
@@ -420,155 +418,122 @@ std::ostream& operator<<(std::ostream & out, const MidpathCheckReport & r){
 				PreSolveChecks();
 				PreSolveSetup();
 
+				const int n_threads = parallel::WorkerThreadCount();
+
+				// One round = dispatch a set of path indices, each executed as a WHOLE path
+				// (pre-endgame + endgame) by a worker.  Round 0 is every path; later rounds re-run
+				// only the crossed paths with escalated settings -- the re-track is path-independent,
+				// so it rides the same demand-driven worker pool (no idle-manager bottleneck).
 				if (parallel::IsManager())
 				{
-					// ---- Phase 1: before endgame ----
-					std::queue<SolnIndT> phase1_queue;
-					for (decltype(num_start_points_) ii{0}; ii < num_start_points_; ++ii)
-						phase1_queue.push(static_cast<SolnIndT>(ii));
-
-					parallel::RunManagerLoop<SolnIndT, BeforeResult>(comm, phase1_queue,
-						[this](BeforeResult const& r){ StoreBeforeEGResult(r); });
-
-					// Midpath check + possible re-tracks run locally on rank 0.
-					// Workers are idle here. This is acceptable for Phase 1 since
-					// midpath crossings are rare; a future optimization could
-					// redistribute re-track work.
-					EGBoundaryAction();
-
-					// ---- Phase 2: during endgame (successful paths only) ----
-					std::queue<Phase2T> phase2_queue;
-					for (decltype(num_start_points_) ii{0}; ii < num_start_points_; ++ii)
+					auto run_round = [&](std::queue<SolnIndT>& q)
 					{
-						if (solution_final_metadata_[ii].pre_endgame_success == SuccessCode::Success)
-						{
-							auto idx = static_cast<SolnIndT>(ii);
-							Phase2T task;
-							task.path_index        = idx;
-							task.boundary_point    = solutions_at_endgame_boundary_[idx].path_point;
-							task.boundary_stepsize = solutions_at_endgame_boundary_[idx].last_used_stepsize;
-							phase2_queue.push(std::move(task));
-						}
-					}
+						parallel::RunManagerLoop<SolnIndT, Result>(comm, q,
+							[this](Result const& r){ StoreFullPathResult(r); });
+					};
 
-					parallel::RunManagerLoop<Phase2T, DuringResult>(comm, phase2_queue,
-						[this](DuringResult const& r){ StoreDuringEGResult(r); });
+					std::queue<SolnIndT> queue;
+					for (decltype(num_start_points_) ii{0}; ii < num_start_points_; ++ii)
+						queue.push(static_cast<SolnIndT>(ii));
+					run_round(queue);
+
+					// Midpath/crossing check on the collected boundary points, then bounded parallel
+					// resolve rounds.  A continue/stop flag is broadcast to the workers each round so
+					// they know whether to run again (and escalate their settings first).
+					auto passed = midpath_.Check(solutions_at_endgame_boundary_, StartSystem());
+					midpath_report_ = MidpathCheckReport{};
+					midpath_report_.passed = passed;
+					for (auto const& v : midpath_.GetCrossedPaths())
+						midpath_report_.crossed_path_indices.push_back(v.index());
+					midpath_report_.num_crossings_detected =
+						static_cast<unsigned>(midpath_report_.crossed_path_indices.size());
+
+					const auto max_attempts = this->template Get<ZeroDimConf>().max_num_crossed_path_resolve_attempts;
+					unsigned num_resolve_attempts = 0;
+					while (true)
+					{
+						int keep_going = (!passed && num_resolve_attempts < max_attempts) ? 1 : 0;
+						MPI_Bcast(&keep_going, 1, MPI_INT, 0, comm);
+						if (!keep_going)
+							break;
+
+						std::queue<SolnIndT> redo;
+						for (auto const& v : midpath_.GetCrossedPaths())
+							if (v.rerun())
+								redo.push(static_cast<SolnIndT>(v.index()));
+						run_round(redo);
+
+						passed = midpath_.Check(solutions_at_endgame_boundary_, StartSystem());
+						++num_resolve_attempts;
+					}
+					midpath_report_.num_resolve_attempts = num_resolve_attempts;
+					midpath_report_.passed = passed;
+					if (!passed)
+						std::cerr << "warning: " << midpath_report_.num_crossings_detected
+						          << " path crossing(s) detected at the endgame boundary remained unresolved "
+						          << "after " << num_resolve_attempts << " re-track attempt(s); "
+						          << "the affected solutions may be wrong.  Consider a higher-order predictor "
+						          << "or a tighter tracking tolerance.  See EndgameBoundaryMetadata()." << std::endl;
 
 					PostEGAction();
 				}
-				else
+				else // worker
 				{
-					const int n_threads = parallel::WorkerThreadCount();
-
-					// ---- Phase 1 worker ----
-					if (n_threads <= 1)
+					auto run_worker_round = [&]()
 					{
-						parallel::RunWorkerLoop<SolnIndT, BeforeResult>(comm,
-							[this](SolnIndT const& idx)
+						if (n_threads <= 1)
+						{
+							// Single-threaded worker: execute whole paths on the rank's member
+							// tracker/endgame directly.
+							parallel::RunWorkerLoop<SolnIndT, Result>(comm,
+								[this](SolnIndT const& idx){ ExecuteOnePath(MemberDuringEGContext(), idx); },
+								[this](SolnIndT const& idx) -> Result { return PackFullPathResult(idx); });
+						}
+						else
+						{
+							// Threaded worker: each thread owns a self-contained PathThreadState clone
+							// so concurrent whole-path execution shares no mutable state.  Cloned per
+							// round so it inherits any escalation (predictor bump) applied to the rank's
+							// member tracker between rounds.
+							auto state_factory = [this]() -> std::unique_ptr<PathThreadState>
 							{
-								TrackSinglePathBeforeEG(idx);
-							},
-							[this](SolnIndT const& idx) -> BeforeResult
+								// Clone(), not copy: System copies are SHALLOW (shared expression-tree
+								// nodes whose value caches mutate on Eval); Clone() deep-copies the tree.
+								// Trackers/Endgames have no default ctor, so aggregate-init via new.
+								std::unique_ptr<PathThreadState> s(
+									new PathThreadState{ Clone(GetTracker().GetSystem()), Clone(TargetSystem()),
+									                     GetTracker(), GetEndgame(), {}, {} });
+								s->tracker.SetSystem(s->sys);
+								s->endgame.SetTracker(s->tracker);
+								SetThreadPrecision(this->template Get<ZeroDimConf>().initial_ambient_precision);
+								return s;
+							};
+
+							auto track_fn = [this](std::unique_ptr<PathThreadState>& state, SolnIndT const& idx) -> Result
 							{
-								return PackBeforeEGResult(idx);
-							});
-					}
-					else
+								ExecuteOnePath(state->Context(), idx);
+								return PackFullPathResult(idx);
+							};
+
+							parallel::RunWorkerLoopThreaded<SolnIndT, Result>(
+								comm, state_factory, track_fn, n_threads);
+						}
+					}; // run_worker_round
+
+					while (true)
 					{
-						// Thread-safe Phase 1: each thread owns a System copy, a Tracker
-						// copy pointed at that System, and its own pair of precision
-						// observers (so observer-derived metadata matches serial runs).
-						// The state is heap-allocated (unique_ptr) so the System address
-						// is stable after the factory returns — the tracker's
-						// reference_wrapper never dangles.
-						auto state_factory = [this]() -> std::unique_ptr<Phase1ThreadState>
-						{
-							// Clone(), not the copy constructor: System copies are SHALLOW
-							// (shared_ptr expression-tree nodes), and node value caches are
-							// mutated on every Eval.  Clone() deep-copies the whole tree, so
-							// each thread evaluates its own.
-							//
-							// Trackers have no default constructor (require a System at
-							// construction), so aggregate-initialize via new rather than
-							// make_unique.
-							std::unique_ptr<Phase1ThreadState> s(
-								new Phase1ThreadState{ Clone(GetTracker().GetSystem()), GetTracker(), {}, {} });
-							// Tracker copies are fully independent (value-semantic predictor,
-							// corrector, and an empty observer list); just repoint the copy
-							// at its own System clone.
-							s->tracker.SetSystem(s->sys);
-							// Same precision the serial flow sets via DefaultPrecision()
-							// in TrackBeforeEG — but thread-local, from the config (the
-							// global default is not reliable on worker ranks).
-							SetThreadPrecision(this->template Get<ZeroDimConf>().initial_ambient_precision);
-							return s;
-						};
+						run_worker_round();
 
-						auto track_fn = [this](std::unique_ptr<Phase1ThreadState>& state, SolnIndT const& idx) -> BeforeResult
-						{
-							TrackSinglePathBeforeEGWith(*state, idx);
-							return PackBeforeEGResult(idx);
-						};
+						int keep_going = 0;
+						MPI_Bcast(&keep_going, 1, MPI_INT, 0, comm);
+						if (!keep_going)
+							break;
 
-						parallel::RunWorkerLoopThreaded<SolnIndT, BeforeResult>(
-							comm, state_factory, track_fn, n_threads);
-					}
-
-					// ---- Phase 2 worker (endgame) ----
-					if (n_threads <= 1)
-					{
-						// Serial flow sets this before its endgame loop (TrackDuringEG);
-						// mirror it here so worker tolerances match serial runs.
-						GetTracker().SetTrackingTolerance(this->template Get<Tolerances>().newton_during_endgame);
-
-						parallel::RunWorkerLoop<Phase2T, DuringResult>(comm,
-							[this](Phase2T const& task)
-							{
-								auto idx = static_cast<SolnIndT>(task.path_index);
-								// Install boundary data so TrackSinglePathDuringEG can read it.
-								solutions_at_endgame_boundary_[idx].path_point         = task.boundary_point;
-								solutions_at_endgame_boundary_[idx].last_used_stepsize = task.boundary_stepsize;
-								solutions_at_endgame_boundary_[idx].success_code       = SuccessCode::Success;
-								TrackSinglePathDuringEG(idx);
-							},
-							[this](Phase2T const& task) -> DuringResult
-							{
-								return PackDuringEGResult(static_cast<SolnIndT>(task.path_index));
-							});
-					}
-					else
-					{
-						// Thread-safe Phase 2: each thread owns copies of the homotopy
-						// (for its tracker), the target system (for residual evaluation,
-						// which mutates System precision state), the tracker, the endgame
-						// (rebound to the thread's tracker), and precision observers.
-						auto state_factory = [this]() -> std::unique_ptr<Phase2ThreadState>
-						{
-							// Clone(), not copy: see the Phase 1 factory above.
-							std::unique_ptr<Phase2ThreadState> s(
-								new Phase2ThreadState{ Clone(GetTracker().GetSystem()), Clone(TargetSystem()),
-								                       GetTracker(), GetEndgame(), {}, {} });
-							s->tracker.SetSystem(s->sys);
-							s->tracker.SetTrackingTolerance(this->template Get<Tolerances>().newton_during_endgame);
-							s->endgame.SetTracker(s->tracker);
-							SetThreadPrecision(this->template Get<ZeroDimConf>().initial_ambient_precision);
-							return s;
-						};
-
-						auto track_fn = [this](std::unique_ptr<Phase2ThreadState>& state, Phase2T const& task) -> DuringResult
-						{
-							auto idx = static_cast<SolnIndT>(task.path_index);
-							// Each idx is assigned to exactly one thread — element-wise
-							// writes into these pre-sized vectors race with nobody.
-							solutions_at_endgame_boundary_[idx].path_point         = task.boundary_point;
-							solutions_at_endgame_boundary_[idx].last_used_stepsize = task.boundary_stepsize;
-							solutions_at_endgame_boundary_[idx].success_code       = SuccessCode::Success;
-							TrackSinglePathDuringEGWith(*state, idx);
-							return PackDuringEGResult(idx);
-						};
-
-						parallel::RunWorkerLoopThreaded<Phase2T, DuringResult>(
-							comm, state_factory, track_fn, n_threads);
+						// Match the escalation the serial RunMidpathResolution applies between
+						// re-track passes: tighten midpath_retrack_tolerance_ (read by ExecuteOnePath)
+						// and bump a low-order predictor on this rank's member tracker, so the next
+						// round's thread clones inherit it.
+						EscalateRetrackSettings();
 					}
 				}
 			}
@@ -923,27 +888,6 @@ std::ostream& operator<<(std::ostream & out, const MidpathCheckReport & r){
 			}
 
 			/**
-			\brief Track from the start point in time, from each start point of the start system, to the endgame boundary.
-
-			Results are accumulated into an internally stored variable, solutions_at_endgame_boundary_.
-
-			The point at the endgame boundary, as well as the success flag, and the stepsize, are all stored.
-			*/
-			void TrackBeforeEG()
-			{
-				DefaultPrecision(this->template Get<ZeroDimConf>().initial_ambient_precision);
-
-				GetTracker().SetTrackingTolerance(this->template Get<Tolerances>().newton_before_endgame);
-
-				for (decltype(num_start_points_) ii{0}; ii < num_start_points_; ++ii)
-				{
-					TrackSinglePathBeforeEG(static_cast<SolnIndT>(ii));
-				}
-			}
-
-
-
-			/**
 			Reference-bundle over the tracker/endgame/systems/observers a single path needs.
 			Lets one set of per-path execution bodies (ExecuteBeforeEG / ExecuteDuringEG) serve
 			both the serial flow (members) and the distributed worker (thread-owned clones), so
@@ -1059,131 +1003,29 @@ std::ostream& operator<<(std::ostream & out, const MidpathCheckReport & r){
 				}
 			}
 
-			/**
-			 /brief Track a single path before we reach the endgame boundary (serial flow).
-			*/
-			void TrackSinglePathBeforeEG(SolnIndT soln_ind)
-			{
-				ExecuteBeforeEG(MemberBeforeEGContext(), soln_ind);
-			}
-
 #ifdef BERTINI2_HAVE_MPI
 			/**
-			Self-contained per-thread tracking state for Phase 1 (before-EG) work on a
-			threaded MPI worker rank.  Each std::thread owns one of these: a System copy,
-			a Tracker copy repointed at that System, and its own precision observers so
-			observer-derived metadata is collected exactly as in serial runs.
+			Self-contained per-thread state for executing one WHOLE path on a threaded MPI worker.
+			Each std::thread owns one: a homotopy copy (tracked by `tracker`), a target-system copy
+			(residual evaluation mutates System precision state), a Tracker and Endgame, and its own
+			precision observers so observer-derived metadata matches serial runs.  Build a
+			DuringEGContext from it to drive ExecuteOnePath.
 			*/
-			struct Phase1ThreadState
-			{
-				System          sys;
-				TrackerType     tracker;
-				tracking::FirstPrecisionRecorder<TrackerType>  first_prec_rec;
-				tracking::MinMaxPrecisionRecorder<TrackerType> min_max_prec;
-			};
-
-			/**
-			Per-thread state for Phase 2 (endgame).  Additionally owns a target-system
-			copy (residual evaluation mutates System precision state) and an Endgame copy
-			rebound to the thread's tracker.
-			*/
-			struct Phase2ThreadState
+			struct PathThreadState
 			{
 				System          sys;         // homotopy, tracked by `tracker`
 				System          target_sys;  // for function residuals / dehomogenization
 				TrackerType     tracker;
-				EndgameT        endgame;
+				EndgameType     endgame;
 				tracking::FirstPrecisionRecorder<TrackerType>  first_prec_rec;
 				tracking::MinMaxPrecisionRecorder<TrackerType> min_max_prec;
+
+				DuringEGContext Context()
+				{
+					return DuringEGContext{ target_sys, tracker, endgame, first_prec_rec, min_max_prec };
+				}
 			};
-
-			/**
-			\brief Track one path to the endgame boundary using thread-owned state.
-
-			Like TrackSinglePathBeforeEG but uses the caller's tracker and observers
-			(from a Phase1ThreadState) instead of the shared members.  Intended for use
-			from std::thread workers.  Precision changes are thread-local only.
-			*/
-			void TrackSinglePathBeforeEGWith(
-				Phase1ThreadState& state,
-				SolnIndT soln_ind)
-			{
-				ExecuteBeforeEG(BeforeEGContext{ state.tracker, state.first_prec_rec, state.min_max_prec }, soln_ind);
-			}
-
-			/**
-			\brief Run the endgame on one path using thread-owned state.
-
-			Like TrackSinglePathDuringEG but uses the caller's tracker, endgame, target
-			system, and observers (from a Phase2ThreadState) instead of the shared
-			members.  Precision changes are thread-local only.
-			*/
-			void TrackSinglePathDuringEGWith(Phase2ThreadState& state, SolnIndT soln_ind)
-			{
-				ExecuteDuringEG(DuringEGContext{ state.target_sys, state.tracker, state.endgame, state.first_prec_rec, state.min_max_prec }, soln_ind);
-			}
 #endif // BERTINI2_HAVE_MPI
-
-			void EGBoundaryAction()
-			{
-				// Detect path crossings: two distinct paths landing on the same point at the endgame
-				// boundary is a probability-0 event, so it signals under-resolved tracking.
-				auto midcheckpassed = midpath_.Check(solutions_at_endgame_boundary_, StartSystem());
-
-				// Record the *first*-check findings (before any re-tracking) into the report.
-				midpath_report_ = MidpathCheckReport{};
-				midpath_report_.passed = midcheckpassed;
-				for (auto const& v : midpath_.GetCrossedPaths())
-					midpath_report_.crossed_path_indices.push_back(v.index());
-				midpath_report_.num_crossings_detected =
-					static_cast<unsigned>(midpath_report_.crossed_path_indices.size());
-
-				// max_num_crossed_path_resolve_attempts == 0 means "detect and report, but do not
-				// re-track" -- the conservative, give-up-after-detection mode.  The loop below
-				// naturally performs zero iterations in that case (and is bounded in all cases, so
-				// it always terminates).
-				const auto max_attempts = this->template Get<ZeroDimConf>().max_num_crossed_path_resolve_attempts;
-				unsigned num_resolve_attempts = 0;
-				while (!midcheckpassed && num_resolve_attempts < max_attempts)
-				{
-					MidpathResolve();
-					midcheckpassed = midpath_.Check(solutions_at_endgame_boundary_, StartSystem());
-					num_resolve_attempts++;
-				}
-
-				midpath_report_.num_resolve_attempts = num_resolve_attempts;
-				midpath_report_.passed = midcheckpassed;
-
-				// Unresolved crossings are kept tracking (they still go through the endgame, so we
-				// never lose more answers than Bertini 1 would) but are made observable: the report
-				// carries passed==false and the offending indices, and we warn here.  A caller can
-				// inspect EndgameBoundaryMetadata() and re-solve with a better predictor / tighter
-				// tolerance (the defaults are tuned precisely so this does not happen).
-				if (!midcheckpassed)
-					std::cerr << "warning: " << midpath_report_.num_crossings_detected
-					          << " path crossing(s) detected at the endgame boundary remained unresolved "
-					          << "after " << num_resolve_attempts << " re-track attempt(s); "
-					          << "the affected solutions may be wrong.  Consider a higher-order predictor "
-					          << "or a tighter tracking tolerance.  See EndgameBoundaryMetadata()." << std::endl;
-			}
-
-
-			void MidpathResolve()
-			{
-				EscalateRetrackSettings();
-
-				for(auto const& v : midpath_.GetCrossedPaths())
-				{
-					if(v.rerun())
-					{
-						unsigned long long index = v.index();
-						auto soln_ind = static_cast<SolnIndT>(index);
-						TrackSinglePathBeforeEG(soln_ind);
-					}
-				}
-
-			}
-
 
 			/**
 			\brief Apply one step of escalation to the tracker before re-tracking crossed paths.
@@ -1212,23 +1054,6 @@ std::ostream& operator<<(std::ostream & out, const MidpathCheckReport & r){
 					GetTracker().SetPredictor(default_predictor);
 			}
 
-
-
-			void TrackDuringEG()
-			{
-
-				GetTracker().SetTrackingTolerance(this->template Get<Tolerances>().newton_during_endgame);
-
-				for (decltype(num_start_points_) ii{0}; ii < num_start_points_; ++ii)
-				{
-					auto soln_ind = static_cast<SolnIndT>(ii);
-
-					if (solution_final_metadata_[soln_ind].pre_endgame_success != SuccessCode::Success)
-						continue;
-
-					TrackSinglePathDuringEG(soln_ind);
-				}
-			}
 
 
 			/**
@@ -1384,12 +1209,6 @@ std::ostream& operator<<(std::ostream & out, const MidpathCheckReport & r){
 				smd.cycle_num = ctx.endgame.CycleNumber();
 			}
 
-			void TrackSinglePathDuringEG(SolnIndT soln_ind)
-			{
-				ExecuteDuringEG(MemberDuringEGContext(), soln_ind);
-			}
-
-
 
 			void PostEGAction()
 			{
@@ -1527,41 +1346,19 @@ std::ostream& operator<<(std::ostream & out, const MidpathCheckReport & r){
 		///////
 
 #ifdef BERTINI2_HAVE_MPI
-			parallel::PathBeforeEGResult<BaseComplexT> PackBeforeEGResult(SolnIndT idx) const
+			// Pack everything a worker computed for one whole path into the single result message.
+			parallel::FullPathResult<BaseComplexT> PackFullPathResult(SolnIndT idx) const
 			{
-				parallel::PathBeforeEGResult<BaseComplexT> r;
-				r.path_index           = idx;
-				r.pre_endgame_success  = solutions_at_endgame_boundary_[idx].success_code;
-				r.boundary_point       = solutions_at_endgame_boundary_[idx].path_point;
-				r.boundary_stepsize    = solutions_at_endgame_boundary_[idx].last_used_stepsize;
-				r.boundary_precision   = solutions_at_endgame_boundary_[idx].precision;
-				r.precision_changed    = solution_final_metadata_[idx].precision_changed;
-				r.time_of_first_prec_increase = solution_final_metadata_[idx].time_of_first_prec_increase;
-				r.max_precision_used   = solution_final_metadata_[idx].max_precision_used;
-				return r;
-			}
+				parallel::FullPathResult<BaseComplexT> r;
+				r.path_index          = idx;
+				r.pre_endgame_success = solutions_at_endgame_boundary_[idx].success_code;
+				r.boundary_point      = solutions_at_endgame_boundary_[idx].path_point;
+				r.boundary_stepsize   = solutions_at_endgame_boundary_[idx].last_used_stepsize;
+				r.boundary_precision  = solutions_at_endgame_boundary_[idx].precision;
 
-			void StoreBeforeEGResult(parallel::PathBeforeEGResult<BaseComplexT> const& r)
-			{
-				auto idx = static_cast<SolnIndT>(r.path_index);
-				solutions_at_endgame_boundary_[idx] =
-					EGBoundaryMetaDataT{r.boundary_point, r.pre_endgame_success, r.boundary_stepsize, r.boundary_precision};
-				auto& smd = solution_final_metadata_[idx];
-				smd.path_index             = idx;
-				smd.solution_index         = idx;
-				smd.pre_endgame_success    = r.pre_endgame_success;
-				smd.precision_changed      = r.precision_changed;
-				smd.time_of_first_prec_increase = r.time_of_first_prec_increase;
-				smd.max_precision_used     = r.max_precision_used;
-			}
-
-			parallel::PathDuringEGResult<BaseComplexT> PackDuringEGResult(SolnIndT idx) const
-			{
-				parallel::PathDuringEGResult<BaseComplexT> r;
-				r.path_index        = idx;
-				r.final_solution    = solutions_post_endgame_[idx];
-				auto const& smd     = solution_final_metadata_[idx];
+				auto const& smd = solution_final_metadata_[idx];
 				r.endgame_success   = smd.endgame_success;
+				r.final_solution    = solutions_post_endgame_[idx];
 				r.function_residual = smd.function_residual;
 				r.condition_number  = smd.condition_number;
 				r.newton_residual   = smd.newton_residual;
@@ -1575,27 +1372,30 @@ std::ostream& operator<<(std::ostream & out, const MidpathCheckReport & r){
 				return r;
 			}
 
-			void StoreDuringEGResult(parallel::PathDuringEGResult<BaseComplexT> const& r)
+			// Install a whole-path result on the manager.  Overwrites cleanly, so re-dispatching a
+			// crossed path in a later resolve round simply replaces its earlier (crossed) result.
+			void StoreFullPathResult(parallel::FullPathResult<BaseComplexT> const& r)
 			{
 				auto idx = static_cast<SolnIndT>(r.path_index);
+				solutions_at_endgame_boundary_[idx] =
+					EGBoundaryMetaDataT{ r.boundary_point, r.pre_endgame_success, r.boundary_stepsize, r.boundary_precision };
 				solutions_post_endgame_[idx] = r.final_solution;
+
 				auto& smd = solution_final_metadata_[idx];
-				smd.endgame_success   = r.endgame_success;
-				smd.function_residual = r.function_residual;
-				smd.condition_number  = r.condition_number;
-				smd.newton_residual   = r.newton_residual;
-				smd.final_time_used   = r.final_time_used;
-				smd.accuracy_estimate = r.accuracy_estimate;
+				smd.path_index          = idx;
+				smd.solution_index      = idx;
+				smd.pre_endgame_success = r.pre_endgame_success;
+				smd.endgame_success     = r.endgame_success;
+				smd.function_residual   = r.function_residual;
+				smd.condition_number    = r.condition_number;
+				smd.newton_residual     = r.newton_residual;
+				smd.final_time_used     = r.final_time_used;
+				smd.accuracy_estimate   = r.accuracy_estimate;
 				smd.accuracy_estimate_user_coords = r.accuracy_estimate_user_coords;
-				smd.cycle_num         = r.cycle_num;
-				// Phase 2 may have further increased precision; take the maximum.
-				if (r.precision_changed && !smd.precision_changed)
-				{
-					smd.precision_changed = true;
-					smd.time_of_first_prec_increase = r.time_of_first_prec_increase;
-				}
-				using std::max;
-				smd.max_precision_used = max(smd.max_precision_used, r.max_precision_used);
+				smd.cycle_num           = r.cycle_num;
+				smd.precision_changed   = r.precision_changed;
+				smd.time_of_first_prec_increase = r.time_of_first_prec_increase;
+				smd.max_precision_used  = r.max_precision_used;
 			}
 #endif // BERTINI2_HAVE_MPI
 

--- a/core/include/bertini2/nag_algorithms/zero_dim_solve.hpp
+++ b/core/include/bertini2/nag_algorithms/zero_dim_solve.hpp
@@ -399,18 +399,31 @@ std::ostream& operator<<(std::ostream & out, const MidpathCheckReport & r){
 				solutions_user_coords_fresh_ = false;
 
 				// Each rank built its homotopy independently in the constructor -- with its OWN
-				// random patch, start-system coefficients, and gamma -- so a given path index
-				// would mean a different path on each worker, and the manager would gather a
-				// scrambled, mostly-wrong solution set (observed: cyclic-5 returned ~17 distinct
-				// solutions instead of 70).  Make every rank agree on ONE homotopy: broadcast the
-				// manager's RNG seed and re-form the (randomized) start system + homotopy from it.
-				// The per-path tracking RNG is already deterministic in the path index
-				// (ReseedThisThread), so this is sufficient for identical results on every rank.
+				// random patch, start-system coefficients, and gamma -- so a given path index would
+				// mean a different path on each worker, and the manager would gather a scrambled,
+				// mostly-wrong solution set.  Make rank 0 the single authoritative source: broadcast
+				// its actual target system, start system, and homotopy to every rank.  These are all
+				// exact (rational coefficients + integer/rational patch), so serialization carries
+				// them bit-for-bit -- there is no per-rank re-derivation that could drift, and the
+				// distributed homotopy is identical to rank 0's serial one.  We also broadcast rank
+				// 0's RNG seed so any randomness drawn later (e.g. in the endgame) is consistent; the
+				// per-path tracking RNG is already deterministic in the path index (ReseedThisThread).
 				{
 					unsigned long seed = parallel::IsManager() ? GetGlobalSeed() : 0ul;
 					MPI_Bcast(&seed, 1, MPI_UNSIGNED_LONG, 0, comm);
 					SetGlobalSeed(seed);
-					SystemManagementPolicy::SystemSetup(this->template Get<ZeroDimConf>().path_variable_name);
+
+					// When this policy owns its systems (CloneGiven), install rank 0's authoritative
+					// systems on every rank.  For RefToGiven the user manages the systems and is
+					// responsible for their consistency across ranks, so we leave them untouched
+					// (matching the old no-op SystemSetup for that policy).
+					if constexpr (SystemManagementPolicy::OwnsSystems)
+					{
+						parallel::mpi_broadcast_serialized(comm, TargetSystem(), 0);
+						parallel::mpi_broadcast_serialized(comm, StartSystem(), 0);
+						parallel::mpi_broadcast_serialized(comm, Homotopy(),    0);
+					}
+
 					num_start_points_ = StartSystem().NumStartPoints();
 					GetTracker().SetSystem(Homotopy());
 				}

--- a/core/include/bertini2/nag_algorithms/zero_dim_solve.hpp
+++ b/core/include/bertini2/nag_algorithms/zero_dim_solve.hpp
@@ -941,69 +941,120 @@ std::ostream& operator<<(std::ostream & out, const MidpathCheckReport & r){
 
 
 			/**
-			 /brief Track a single path before we reach the endgame boundary.
+			Reference-bundle over the tracker/endgame/systems/observers a single path needs.
+			Lets one set of per-path execution bodies (ExecuteBeforeEG / ExecuteDuringEG) serve
+			both the serial flow (members) and the distributed worker (thread-owned clones), so
+			there is exactly ONE per-path code path and serial/distributed cannot diverge.
 			*/
-			void TrackSinglePathBeforeEG(SolnIndT soln_ind)
+			struct BeforeEGContext
+			{
+				TrackerType& tracker;
+				tracking::FirstPrecisionRecorder<TrackerType>&  first_prec_rec;
+				tracking::MinMaxPrecisionRecorder<TrackerType>& min_max_prec;
+			};
+			struct DuringEGContext
+			{
+				// const ref: the residual/dehomogenize/precision calls are const-callable, and the
+				// RefToGiven policy hands back a const target system.  A mutable thread-owned clone
+				// binds here too.
+				SystemType const& target_sys;
+				TrackerType& tracker;
+				EndgameType& endgame;
+				tracking::FirstPrecisionRecorder<TrackerType>&  first_prec_rec;
+				tracking::MinMaxPrecisionRecorder<TrackerType>& min_max_prec;
+			};
+
+			BeforeEGContext MemberBeforeEGContext()
+			{
+				return BeforeEGContext{ GetTracker(), first_prec_rec_, min_max_prec_ };
+			}
+			DuringEGContext MemberDuringEGContext()
+			{
+				return DuringEGContext{ TargetSystem(), GetTracker(), GetEndgame(), first_prec_rec_, min_max_prec_ };
+			}
+
+			/**
+			\brief Track one path from the start time to the endgame boundary, against `ctx`.
+
+			The single before-endgame body, shared by the serial flow and the distributed worker.
+			Uses SetThreadPrecision (thread-local) throughout, so it is correct on the main thread
+			and concurrently on worker threads alike.  Writes the boundary point + the pre-endgame
+			portion of the metadata.
+			*/
+			void ExecuteBeforeEG(BeforeEGContext ctx, SolnIndT soln_ind)
 			{
 				ReseedThisThread(static_cast<uint64_t>(soln_ind));
 
-					// if you can think of a way to replace this `if` with something meta, please do so.
-					if (tracking::TrackerTraits<TrackerType>::IsAdaptivePrec)
-					{
-						GetTracker().AddObserver(first_prec_rec_);
-						GetTracker().AddObserver(min_max_prec_);
-					}
+				if (tracking::TrackerTraits<TrackerType>::IsAdaptivePrec)
+				{
+					ctx.tracker.AddObserver(ctx.first_prec_rec);
+					ctx.tracker.AddObserver(ctx.min_max_prec);
+				}
 
-					auto& smd = solution_final_metadata_[soln_ind];
+				auto& smd = solution_final_metadata_[soln_ind];
+				smd.path_index    = soln_ind;
+				smd.solution_index = soln_ind;
 
-					smd.path_index = soln_ind;
-					smd.solution_index = soln_ind;
+				auto initial_prec = this->template Get<ZeroDimConf>().initial_ambient_precision;
+				// SetThreadPrecision: writes thread-local only, safe from concurrent threads.
+				SetThreadPrecision(initial_prec);
 
-				DefaultPrecision(this->template Get<ZeroDimConf>().initial_ambient_precision);
-				auto t_start = this->template Get<ZeroDimConf>().start_time;
+				auto t_start            = this->template Get<ZeroDimConf>().start_time;
 				auto t_endgame_boundary = this->template Get<ZeroDimConf>().endgame_boundary;
-				auto start_point = StartSystem().template StartPoint<BaseComplexT>(soln_ind);
 
-				// Begin tracking at the intended ambient precision rather than the start
-				// point's incidental precision.  Total-degree start points are generated at
+				// The start system is shared; StartPoint() mutates expression-tree value caches, so
+				// generation is serialized.  Trivial cost next to tracking.  Generated AFTER
+				// SetThreadPrecision so the point has the precision a serial run would give it.
+				Vec<BaseComplexT> start_point;
+				{
+					static std::mutex start_point_mutex;
+					std::lock_guard<std::mutex> lock(start_point_mutex);
+					start_point = StartSystem().template StartPoint<BaseComplexT>(soln_ind);
+				}
+
+				// Begin tracking at the intended ambient precision rather than the start point's
+				// incidental precision.  Total-degree start points are generated at
 				// LowestMultiplePrecision (the generator's arithmetic widens past the requested
 				// digits, see issue #308), so without this the AMP tracker would start every
 				// well-conditioned path in multiprecision and never drop to double.
 				if constexpr (tracking::TrackerTraits<TrackerType>::IsAdaptivePrec)
-					GetTracker().SetStartPrecision(this->template Get<ZeroDimConf>().initial_ambient_precision);
+					ctx.tracker.SetStartPrecision(initial_prec);
 
 				Vec<BaseComplexT> result;
-				auto tracking_success = GetTracker().TrackPath(result, t_start, t_endgame_boundary, start_point);
+				auto tracking_success = ctx.tracker.TrackPath(result, t_start, t_endgame_boundary, start_point);
 
-				solutions_at_endgame_boundary_[soln_ind] = EGBoundaryMetaDataT({ result, tracking_success, GetTracker().CurrentStepsize(), GetTracker().CurrentPrecision() });
+				solutions_at_endgame_boundary_[soln_ind] =
+					EGBoundaryMetaDataT({ result, tracking_success, ctx.tracker.CurrentStepsize(), ctx.tracker.CurrentPrecision() });
 
-				// Clear the start-precision override so it does not leak into the endgame,
-				// which shares this tracker instance (endgame_(tracker_)) for its sample
-				// circles and must be free to begin those at the sample points' precision.
+				// Clear the start-precision override so it does not leak into the endgame, which
+				// shares this tracker instance for its sample circles.
 				if constexpr (tracking::TrackerTraits<TrackerType>::IsAdaptivePrec)
+					ctx.tracker.SetStartPrecision(std::nullopt);
+
+				smd.pre_endgame_success = tracking_success;
+
+				if (tracking::TrackerTraits<TrackerType>::IsAdaptivePrec)
 				{
-					GetTracker().SetStartPrecision(std::nullopt);
-				}
-
-					smd.pre_endgame_success = tracking_success;
-
-					// if you can think of a way to replace this `if` with something meta, please do so.
-					if (tracking::TrackerTraits<TrackerType>::IsAdaptivePrec)
+					if (ctx.first_prec_rec.DidPrecisionIncrease())
 					{
-						if (first_prec_rec_.DidPrecisionIncrease())
-						{
-							smd.precision_changed = true;
-							smd.time_of_first_prec_increase = first_prec_rec_.TimeOfIncrease();
-						}
-						else
-						GetTracker().RemoveObserver(first_prec_rec_);
-						GetTracker().RemoveObserver(min_max_prec_);
-						using std::max;
-						smd.max_precision_used =
-							max(smd.max_precision_used, min_max_prec_.MaxPrecision());
+						smd.precision_changed = true;
+						smd.time_of_first_prec_increase = ctx.first_prec_rec.TimeOfIncrease();
 					}
+					else
+					ctx.tracker.RemoveObserver(ctx.first_prec_rec);
+					ctx.tracker.RemoveObserver(ctx.min_max_prec);
+					using std::max;
+					smd.max_precision_used =
+						max(smd.max_precision_used, ctx.min_max_prec.MaxPrecision());
+				}
+			}
 
-
+			/**
+			 /brief Track a single path before we reach the endgame boundary (serial flow).
+			*/
+			void TrackSinglePathBeforeEG(SolnIndT soln_ind)
+			{
+				ExecuteBeforeEG(MemberBeforeEGContext(), soln_ind);
 			}
 
 #ifdef BERTINI2_HAVE_MPI
@@ -1047,71 +1098,7 @@ std::ostream& operator<<(std::ostream & out, const MidpathCheckReport & r){
 				Phase1ThreadState& state,
 				SolnIndT soln_ind)
 			{
-				ReseedThisThread(static_cast<uint64_t>(soln_ind));
-
-					// if you can think of a way to replace this `if` with something meta, please do so.
-					if (tracking::TrackerTraits<TrackerType>::IsAdaptivePrec)
-					{
-						state.tracker.AddObserver(state.first_prec_rec);
-						state.tracker.AddObserver(state.min_max_prec);
-					}
-
-				auto& smd = solution_final_metadata_[soln_ind];
-				smd.path_index    = soln_ind;
-				smd.solution_index = soln_ind;
-
-				auto initial_prec = this->template Get<ZeroDimConf>().initial_ambient_precision;
-				// SetThreadPrecision: writes thread-local only, safe from concurrent threads.
-				SetThreadPrecision(initial_prec);
-
-				auto t_start           = this->template Get<ZeroDimConf>().start_time;
-				auto t_endgame_boundary = this->template Get<ZeroDimConf>().endgame_boundary;
-
-				// The start system is SHARED among threads, and StartPoint() evaluates
-				// expression-tree nodes (mutating their value caches), so generation is
-				// serialized.  It is trivial arithmetic compared to tracking, so the
-				// mutex costs nothing measurable.  Generated AFTER SetThreadPrecision
-				// so the point has the same precision a serial run would give it.
-				Vec<BaseComplexT> start_point;
-				{
-					static std::mutex start_point_mutex;
-					std::lock_guard<std::mutex> lock(start_point_mutex);
-					start_point = StartSystem().template StartPoint<BaseComplexT>(soln_ind);
-				}
-
-				// Begin tracking at the intended ambient precision rather than the start
-				// point's incidental precision (see TrackSinglePathBeforeEG / issue #308).
-				if constexpr (tracking::TrackerTraits<TrackerType>::IsAdaptivePrec)
-					state.tracker.SetStartPrecision(initial_prec);
-
-				Vec<BaseComplexT> result;
-				auto tracking_success = state.tracker.TrackPath(result, t_start, t_endgame_boundary, start_point);
-
-				// Each soln_ind is unique per thread — no locking needed.
-				solutions_at_endgame_boundary_[soln_ind] =
-					EGBoundaryMetaDataT({ result, tracking_success, state.tracker.CurrentStepsize(), state.tracker.CurrentPrecision() });
-
-				// Clear the start-precision override so it does not leak into the endgame
-				// (which shares this tracker instance for its sample circles).
-				if constexpr (tracking::TrackerTraits<TrackerType>::IsAdaptivePrec)
-					state.tracker.SetStartPrecision(std::nullopt);
-
-				smd.pre_endgame_success = tracking_success;
-
-					if (tracking::TrackerTraits<TrackerType>::IsAdaptivePrec)
-					{
-						if (state.first_prec_rec.DidPrecisionIncrease())
-						{
-							smd.precision_changed = true;
-							smd.time_of_first_prec_increase = state.first_prec_rec.TimeOfIncrease();
-						}
-						else
-						state.tracker.RemoveObserver(state.first_prec_rec);
-						state.tracker.RemoveObserver(state.min_max_prec);
-						using std::max;
-						smd.max_precision_used =
-							max(smd.max_precision_used, state.min_max_prec.MaxPrecision());
-					}
+				ExecuteBeforeEG(BeforeEGContext{ state.tracker, state.first_prec_rec, state.min_max_prec }, soln_ind);
 			}
 
 			/**
@@ -1123,84 +1110,7 @@ std::ostream& operator<<(std::ostream & out, const MidpathCheckReport & r){
 			*/
 			void TrackSinglePathDuringEGWith(Phase2ThreadState& state, SolnIndT soln_ind)
 			{
-				ReseedThisThread(static_cast<uint64_t>(soln_ind) + static_cast<uint64_t>(num_start_points_));
-
-					auto& smd = solution_final_metadata_[soln_ind];
-					// if you can think of a way to replace this `if` with something meta, please do so.
-					if (tracking::TrackerTraits<TrackerType>::IsAdaptivePrec)
-					{
-						if (!smd.precision_changed)
-							state.tracker.AddObserver(state.first_prec_rec);
-						state.tracker.AddObserver(state.min_max_prec);
-					}
-
-				const auto& bdry_point = solutions_at_endgame_boundary_[soln_ind].path_point;
-
-				state.tracker.SetStepSize(solutions_at_endgame_boundary_[soln_ind].last_used_stepsize);
-				state.tracker.ReinitializeInitialStepSize(false);
-
-				// Resume the endgame at the precision the path was actually using at the
-				// boundary, rather than inferring it from the (always-multiprecision) point's
-				// mantissa, which is unreliable for paths that tracked in double.
-				auto start_prec = solutions_at_endgame_boundary_[soln_ind].precision;
-
-				SetThreadPrecision(start_prec);
-
-				state.endgame.SetBoundaryTime(this->template Get<ZeroDimConf>().endgame_boundary);
-				state.endgame.SetTargetTime  (this->template Get<ZeroDimConf>().target_time);
-
-				auto eg_success = state.endgame.Run(bdry_point);
-
-				solutions_post_endgame_[soln_ind] = state.endgame.template FinalApproximation<BaseComplexT>();
-
-					// finally, store the metadata as necessary
-					smd.endgame_success = eg_success;
-
-					// an unsuccessful endgame has no final approximation, so the
-					// final-point-dependent metadata cannot be computed.
-					if (eg_success != SuccessCode::Success)
-					{
-						if (tracking::TrackerTraits<TrackerType>::IsAdaptivePrec)
-						{
-							state.tracker.RemoveObserver(state.first_prec_rec);
-							state.tracker.RemoveObserver(state.min_max_prec);
-						}
-						return;
-					}
-						// if you can think of a way to replace this `if` with something meta, please do so.
-					if (tracking::TrackerTraits<TrackerType>::IsAdaptivePrec)
-					{
-						if (!smd.precision_changed)
-						{
-							if (state.first_prec_rec.DidPrecisionIncrease())
-							{
-								smd.precision_changed = true;
-								smd.time_of_first_prec_increase = state.first_prec_rec.TimeOfIncrease();
-							}
-							state.tracker.RemoveObserver(state.first_prec_rec);
-						}
-						state.tracker.RemoveObserver(state.min_max_prec);
-						using std::max;
-						smd.max_precision_used =
-							max(smd.max_precision_used, state.min_max_prec.MaxPrecision());
-					}
-					if (tracking::TrackerTraits<TrackerType>::IsAdaptivePrec)
-					{
-						assert(Precision(solutions_post_endgame_[soln_ind])==Precision(state.endgame.template FinalApproximation<BaseComplexT>()));
-						SetThreadPrecision(Precision(solutions_post_endgame_[soln_ind]));
-						state.target_sys.precision(Precision(solutions_post_endgame_[soln_ind]));
-					}
-					smd.function_residual = static_cast<NumErrorT>(state.target_sys.Eval(solutions_post_endgame_[soln_ind]).template lpNorm<Eigen::Infinity>());
-					smd.final_time_used = state.endgame.LatestTime();
-					smd.condition_number = state.tracker.LatestConditionNumber();
-					smd.newton_residual = state.tracker.LatestNormOfStep();
-
-					smd.accuracy_estimate = state.endgame.ApproximateError();
-					smd.accuracy_estimate_user_coords =
-						static_cast<NumErrorT>( (state.target_sys.DehomogenizePoint(solutions_post_endgame_[soln_ind]) -
-						state.target_sys.DehomogenizePoint(state.endgame.template PreviousApproximation<BaseComplexT>())).template lpNorm<Eigen::Infinity>() );
-					smd.cycle_num = state.endgame.CycleNumber();
-					// end metadata gathering
+				ExecuteDuringEG(DuringEGContext{ state.target_sys, state.tracker, state.endgame, state.first_prec_rec, state.min_max_prec }, soln_ind);
 			}
 #endif // BERTINI2_HAVE_MPI
 
@@ -1311,80 +1221,94 @@ std::ostream& operator<<(std::ostream & out, const MidpathCheckReport & r){
 			}
 
 
-			void TrackSinglePathDuringEG(SolnIndT soln_ind)
+			/**
+			\brief Run the endgame on one path (boundary→target), against `ctx`.
+
+			The single during-endgame body, shared by the serial flow and the distributed worker.
+			Resumes at the precision the path was using at the boundary
+			(`solutions_at_endgame_boundary_[idx].precision`) and writes the final solution + the
+			endgame portion of the metadata.
+			*/
+			void ExecuteDuringEG(DuringEGContext ctx, SolnIndT soln_ind)
 			{
 				ReseedThisThread(static_cast<uint64_t>(soln_ind) + static_cast<uint64_t>(num_start_points_));
 
-					auto& smd = solution_final_metadata_[soln_ind];
-					// if you can think of a way to replace this `if` with something meta, please do so.
-					if (tracking::TrackerTraits<TrackerType>::IsAdaptivePrec)
-					{
-						if (!smd.precision_changed)
-							GetTracker().AddObserver(first_prec_rec_);
-						GetTracker().AddObserver(min_max_prec_);
-					}
+				auto& smd = solution_final_metadata_[soln_ind];
+				if (tracking::TrackerTraits<TrackerType>::IsAdaptivePrec)
+				{
+					if (!smd.precision_changed)
+						ctx.tracker.AddObserver(ctx.first_prec_rec);
+					ctx.tracker.AddObserver(ctx.min_max_prec);
+				}
 
 				const auto& bdry_point = solutions_at_endgame_boundary_[soln_ind].path_point;
 
+				ctx.tracker.SetStepSize(solutions_at_endgame_boundary_[soln_ind].last_used_stepsize);
+				ctx.tracker.ReinitializeInitialStepSize(false);
 
-				GetTracker().SetStepSize(solutions_at_endgame_boundary_[soln_ind].last_used_stepsize);
-				GetTracker().ReinitializeInitialStepSize(false);
-
-				// Resume the endgame at the precision the path was actually using at the
-				// boundary, rather than inferring it from the (always-multiprecision) point's
-				// mantissa, which is unreliable for paths that tracked in double.
+				// Resume the endgame at the precision the path was actually using at the boundary,
+				// rather than inferring it from the (always-multiprecision) point's mantissa, which
+				// is unreliable for paths that tracked in double.
 				auto start_prec = solutions_at_endgame_boundary_[soln_ind].precision;
+				SetThreadPrecision(start_prec);
 
-				DefaultPrecision(start_prec);
+				ctx.endgame.SetBoundaryTime(this->template Get<ZeroDimConf>().endgame_boundary);
+				ctx.endgame.SetTargetTime  (this->template Get<ZeroDimConf>().target_time);
 
-				GetEndgame().SetBoundaryTime(this->template Get<ZeroDimConf>().endgame_boundary);
-				GetEndgame().SetTargetTime  (this->template Get<ZeroDimConf>().target_time);
+				auto eg_success = ctx.endgame.Run(bdry_point);
 
-				auto eg_success = GetEndgame().Run(bdry_point);
+				solutions_post_endgame_[soln_ind] = ctx.endgame.template FinalApproximation<BaseComplexT>();
 
-				solutions_post_endgame_[soln_ind] = GetEndgame().template FinalApproximation<BaseComplexT>();
+				smd.endgame_success = eg_success;
 
-
-					// finally, store the metadata as necessary
-					smd.endgame_success = eg_success;
-						// if you can think of a way to replace this `if` with something meta, please do so.
+				// an unsuccessful endgame has no final approximation, so the final-point-dependent
+				// metadata cannot be computed.
+				if (eg_success != SuccessCode::Success)
+				{
 					if (tracking::TrackerTraits<TrackerType>::IsAdaptivePrec)
 					{
-						if (!smd.precision_changed)
+						ctx.tracker.RemoveObserver(ctx.first_prec_rec);
+						ctx.tracker.RemoveObserver(ctx.min_max_prec);
+					}
+					return;
+				}
+				if (tracking::TrackerTraits<TrackerType>::IsAdaptivePrec)
+				{
+					if (!smd.precision_changed)
+					{
+						if (ctx.first_prec_rec.DidPrecisionIncrease())
 						{
-							if (first_prec_rec_.DidPrecisionIncrease())
-							{
-								smd.precision_changed = true;
-								smd.time_of_first_prec_increase = first_prec_rec_.TimeOfIncrease();
-							}
+							smd.precision_changed = true;
+							smd.time_of_first_prec_increase = ctx.first_prec_rec.TimeOfIncrease();
 						}
-						GetTracker().RemoveObserver(first_prec_rec_);
-						GetTracker().RemoveObserver(min_max_prec_);
-						using std::max;
-						smd.max_precision_used =
-							max(smd.max_precision_used, min_max_prec_.MaxPrecision());
+						ctx.tracker.RemoveObserver(ctx.first_prec_rec);
 					}
-					// an unsuccessful endgame has no final approximation, so the
-					// final-point-dependent metadata cannot be computed.
-					if (eg_success != SuccessCode::Success)
-						return;
-					if (tracking::TrackerTraits<TrackerType>::IsAdaptivePrec)
-					{
-						assert(Precision(solutions_post_endgame_[soln_ind])==Precision(GetEndgame().template FinalApproximation<BaseComplexT>()));
-						DefaultPrecision(Precision(solutions_post_endgame_[soln_ind]));
-						TargetSystem().precision(Precision(solutions_post_endgame_[soln_ind]));
-					}
-					smd.function_residual = static_cast<NumErrorT>(TargetSystem().Eval(solutions_post_endgame_[soln_ind]).template lpNorm<Eigen::Infinity>());
-					smd.final_time_used = GetEndgame().LatestTime();
-					smd.condition_number = GetTracker().LatestConditionNumber();
-					smd.newton_residual = GetTracker().LatestNormOfStep();
+					ctx.tracker.RemoveObserver(ctx.min_max_prec);
+					using std::max;
+					smd.max_precision_used =
+						max(smd.max_precision_used, ctx.min_max_prec.MaxPrecision());
+				}
+				if (tracking::TrackerTraits<TrackerType>::IsAdaptivePrec)
+				{
+					assert(Precision(solutions_post_endgame_[soln_ind])==Precision(ctx.endgame.template FinalApproximation<BaseComplexT>()));
+					SetThreadPrecision(Precision(solutions_post_endgame_[soln_ind]));
+					ctx.target_sys.precision(Precision(solutions_post_endgame_[soln_ind]));
+				}
+				smd.function_residual = static_cast<NumErrorT>(ctx.target_sys.Eval(solutions_post_endgame_[soln_ind]).template lpNorm<Eigen::Infinity>());
+				smd.final_time_used = ctx.endgame.LatestTime();
+				smd.condition_number = ctx.tracker.LatestConditionNumber();
+				smd.newton_residual = ctx.tracker.LatestNormOfStep();
 
-					smd.accuracy_estimate = GetEndgame().ApproximateError();
-					smd.accuracy_estimate_user_coords =
-						static_cast<NumErrorT>( (TargetSystem().DehomogenizePoint(solutions_post_endgame_[soln_ind]) -
-						TargetSystem().DehomogenizePoint(GetEndgame().template PreviousApproximation<BaseComplexT>())).template lpNorm<Eigen::Infinity>() );
-					smd.cycle_num = GetEndgame().CycleNumber();
-					// end metadata gathering
+				smd.accuracy_estimate = ctx.endgame.ApproximateError();
+				smd.accuracy_estimate_user_coords =
+					static_cast<NumErrorT>( (ctx.target_sys.DehomogenizePoint(solutions_post_endgame_[soln_ind]) -
+					ctx.target_sys.DehomogenizePoint(ctx.endgame.template PreviousApproximation<BaseComplexT>())).template lpNorm<Eigen::Infinity>() );
+				smd.cycle_num = ctx.endgame.CycleNumber();
+			}
+
+			void TrackSinglePathDuringEG(SolnIndT soln_ind)
+			{
+				ExecuteDuringEG(MemberDuringEGContext(), soln_ind);
 			}
 
 

--- a/core/include/bertini2/nag_algorithms/zero_dim_solve.hpp
+++ b/core/include/bertini2/nag_algorithms/zero_dim_solve.hpp
@@ -1015,6 +1015,15 @@ std::ostream& operator<<(std::ostream & out, const MidpathCheckReport & r){
 				// SetThreadPrecision: writes thread-local only, safe from concurrent threads.
 				SetThreadPrecision(initial_prec);
 
+				// Draw the condition-number probe direction ONCE here, for the whole track of this
+				// point (pre-endgame AND endgame).  We have just reseeded this thread's RNG to a value
+				// determined solely by the path index, so the probe is deterministic per path and
+				// identical whether the path is tracked in a serial loop or on a distributed worker --
+				// regardless of how the paths were split across ranks.  It is NOT refreshed for the
+				// endgame (which would churn the RNG across its sample-circle sub-tracks), so the same
+				// direction persists start to finish.
+				ctx.tracker.RefreshConditionDirection();
+
 				auto t_start            = this->template Get<ZeroDimConf>().start_time;
 				auto t_endgame_boundary = this->template Get<ZeroDimConf>().endgame_boundary;
 

--- a/core/include/bertini2/parallel/initialize_finalize.hpp
+++ b/core/include/bertini2/parallel/initialize_finalize.hpp
@@ -35,7 +35,7 @@
 #include "bertini2/io/splash.hpp"
 
 #ifdef BERTINI2_HAVE_MPI
-#include <mpi.h>
+#include "bertini2/parallel/mpi_include.hpp"
 #endif
 
 namespace bertini{

--- a/core/include/bertini2/parallel/manager.hpp
+++ b/core/include/bertini2/parallel/manager.hpp
@@ -46,7 +46,7 @@ via Phase2Task<ComplexT>::sentinel().
 #include "bertini2/parallel/path_result.hpp"
 #include "bertini2/parallel/mpi_utils.hpp"
 
-#include <mpi.h>
+#include "bertini2/parallel/mpi_include.hpp"
 
 #include <functional>
 #include <limits>

--- a/core/include/bertini2/parallel/mpi_include.hpp
+++ b/core/include/bertini2/parallel/mpi_include.hpp
@@ -1,0 +1,43 @@
+//This file is part of Bertini 2.
+//
+//bertini2/parallel/mpi_include.hpp is free software: you can redistribute it and/or modify
+//it under the terms of the GNU General Public License as published by
+//the Free Software Foundation, either version 3 of the License, or
+//(at your option) any later version.
+//
+//bertini2/parallel/mpi_include.hpp is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//GNU General Public License for more details.
+//
+//You should have received a copy of the GNU General Public License
+//along with bertini2/parallel/mpi_include.hpp.  If not, see <http://www.gnu.org/licenses/>.
+//
+// Copyright(C) Bertini2 Development Team
+
+/**
+\file bertini2/parallel/mpi_include.hpp
+
+\brief Single include point for the MPI C API.
+
+Bertini 2 uses only the MPI **C** API.  Including `<mpi.h>` directly from C++ otherwise drags in the
+deprecated MPI **C++** bindings (the `MPI::` namespace, `mpicxx.h`).  MPICH compiles those in by
+default, and they fail to build under modern C++ (notably clang) -- so the project built against
+OpenMPI but not Homebrew MPICH on macOS.
+
+Defining `MPICH_SKIP_MPICXX` / `OMPI_SKIP_MPICXX` before `<mpi.h>` pulls in only the C API.  These are
+also defined on the compile command line by CMake (`ENABLE_MPI` block); having them here too is belt
+and suspenders, so the guard holds even if the build-system definition fails to reach a translation
+unit.  Always include this header instead of `<mpi.h>` directly.
+*/
+
+#pragma once
+
+#ifndef MPICH_SKIP_MPICXX
+#define MPICH_SKIP_MPICXX
+#endif
+#ifndef OMPI_SKIP_MPICXX
+#define OMPI_SKIP_MPICXX
+#endif
+
+#include <mpi.h>

--- a/core/include/bertini2/parallel/mpi_utils.hpp
+++ b/core/include/bertini2/parallel/mpi_utils.hpp
@@ -130,6 +130,39 @@ inline void mpi_broadcast_string(MPI_Comm comm, std::string& s, int root)
 }
 
 
+/**
+\brief Broadcast a Boost-serializable object from \p root to all ranks in \p comm.
+
+\p root serializes \p obj and broadcasts the bytes; every other rank deserializes into \p obj
+(overwriting it).  Used to make \p root the single authoritative source of an object (e.g. the
+homotopy / start system) rather than having each rank re-derive its own copy.
+*/
+template<typename T>
+void mpi_broadcast_serialized(MPI_Comm comm, T& obj, int root)
+{
+	int rank = 0;
+	MPI_Comm_rank(comm, &rank);
+
+	std::string s;
+	if (rank == root)
+	{
+		std::ostringstream oss;
+		boost::archive::binary_oarchive oa(oss);
+		oa << obj;
+		s = oss.str();
+	}
+
+	mpi_broadcast_string(comm, s, root);
+
+	if (rank != root)
+	{
+		std::istringstream iss(s);
+		boost::archive::binary_iarchive ia(iss);
+		ia >> obj;
+	}
+}
+
+
 } // namespace parallel
 } // namespace bertini
 

--- a/core/include/bertini2/parallel/mpi_utils.hpp
+++ b/core/include/bertini2/parallel/mpi_utils.hpp
@@ -35,7 +35,7 @@ that would arise with MPI_ANY_SOURCE.
 
 #ifdef BERTINI2_HAVE_MPI
 
-#include <mpi.h>
+#include "bertini2/parallel/mpi_include.hpp"
 
 #include <sstream>
 #include <string>

--- a/core/include/bertini2/parallel/path_result.hpp
+++ b/core/include/bertini2/parallel/path_result.hpp
@@ -171,6 +171,67 @@ struct PathDuringEGResult
 	}
 };
 
+/**
+\brief Result of executing one WHOLE path: start -> endgame boundary -> target.
+
+The single result type for the speculative-full-path model.  A worker carries a path through both
+the pre-endgame tracking and the endgame, so this bundles the boundary data (needed for the manager's
+midpath/crossing check) together with the final solution and all endgame metadata.  The task that
+produces it is just the path index (SolnIndT), so no separate task struct is needed.
+*/
+template<typename ComplexT>
+struct FullPathResult
+{
+	using SolnIndT = std::size_t;
+	using RealT    = typename NumTraits<ComplexT>::Real;
+
+	SolnIndT      path_index             = 0;
+
+	// boundary (pre-endgame) data
+	SuccessCode   pre_endgame_success    = SuccessCode::NeverStarted;
+	Vec<ComplexT> boundary_point;
+	RealT         boundary_stepsize      = RealT(0);
+	unsigned      boundary_precision     = DoublePrecision();
+
+	// endgame data
+	SuccessCode   endgame_success        = SuccessCode::NeverStarted;
+	Vec<ComplexT> final_solution;
+	double        function_residual              = 0;
+	double        condition_number               = 0;
+	double        newton_residual                = 0;
+	ComplexT      final_time_used;
+	double        accuracy_estimate              = 0;
+	double        accuracy_estimate_user_coords  = 0;
+	unsigned      cycle_num                      = 0;
+
+	// precision metadata (spans the whole path)
+	bool          precision_changed              = false;
+	ComplexT      time_of_first_prec_increase;
+	unsigned      max_precision_used             = 0;
+
+	template<class Archive>
+	void serialize(Archive& ar, unsigned const)
+	{
+		ar & path_index;
+		ar & pre_endgame_success;
+		ar & boundary_point;
+		ar & boundary_stepsize;
+		ar & boundary_precision;
+		ar & endgame_success;
+		ar & final_solution;
+		ar & function_residual;
+		ar & condition_number;
+		ar & newton_residual;
+		ar & final_time_used;
+		ar & accuracy_estimate;
+		ar & accuracy_estimate_user_coords;
+		ar & cycle_num;
+		ar & precision_changed;
+		ar & time_of_first_prec_increase;
+		ar & max_precision_used;
+	}
+};
+
 namespace detail {
 
 // Sentinel detection and factory — overloaded for each task type so manager

--- a/core/include/bertini2/parallel/path_result.hpp
+++ b/core/include/bertini2/parallel/path_result.hpp
@@ -51,12 +51,46 @@ constexpr int TAG_CAPACITY  = 3;  // worker -> manager: int, max tasks in flight
 
 
 /**
+\brief Work item for the speculative-full-path model: a path index plus its start point.
+
+Rank 0 computes start points authoritatively and ships them to workers, so a worker never derives
+its own (that, with authoritative pi, is what keeps start points -- and hence whole tracks --
+identical across serial and distributed runs).
+*/
+template<typename ComplexT>
+struct StartPointTask
+{
+	using SolnIndT = std::size_t;
+
+	SolnIndT      path_index = std::numeric_limits<SolnIndT>::max();  // max = sentinel
+	Vec<ComplexT> start_point;
+
+	bool is_sentinel() const
+	{
+		return path_index == std::numeric_limits<SolnIndT>::max();
+	}
+
+	static StartPointTask sentinel()
+	{
+		return StartPointTask{};  // default path_index == max
+	}
+
+	template<class Archive>
+	void serialize(Archive& ar, unsigned const)
+	{
+		ar & path_index;
+		ar & start_point;
+	}
+};
+
+
+/**
 \brief Result of executing one WHOLE path: start -> endgame boundary -> target.
 
 The single result type for the speculative-full-path model.  A worker carries a path through both
 the pre-endgame tracking and the endgame, so this bundles the boundary data (needed for the manager's
-midpath/crossing check) together with the final solution and all endgame metadata.  The task that
-produces it is just the path index (SolnIndT), so no separate task struct is needed.
+midpath/crossing check) together with the final solution and all endgame metadata.  The work item
+that produces it is a StartPointTask (path index + rank 0's start point).
 */
 template<typename ComplexT>
 struct FullPathResult
@@ -113,8 +147,8 @@ struct FullPathResult
 
 namespace detail {
 
-// Sentinel detection and factory for the work-item type.  The task in the unified model is just
-// the path index (std::size_t); the max value marks "no more work".
+// Sentinel detection and factory for the work-item type.  The work item is a StartPointTask whose
+// max path_index marks "no more work".  (The plain-size_t overloads remain for any other caller.)
 
 inline bool is_sentinel(std::size_t v)
 {
@@ -124,6 +158,18 @@ inline bool is_sentinel(std::size_t v)
 inline std::size_t make_sentinel(std::size_t)
 {
 	return std::numeric_limits<std::size_t>::max();
+}
+
+template<typename ComplexT>
+bool is_sentinel(StartPointTask<ComplexT> const& t)
+{
+	return t.is_sentinel();
+}
+
+template<typename ComplexT>
+StartPointTask<ComplexT> make_sentinel(StartPointTask<ComplexT> const&)
+{
+	return StartPointTask<ComplexT>::sentinel();
 }
 
 } // namespace detail

--- a/core/include/bertini2/parallel/path_result.hpp
+++ b/core/include/bertini2/parallel/path_result.hpp
@@ -18,18 +18,15 @@
 /**
 \file bertini2/parallel/path_result.hpp
 
-\brief Task and result structs used in the manager-worker MPI protocol for ZeroDim.
+\brief Result struct used in the manager-worker MPI protocol for ZeroDim.
 
-Phase 1 (before endgame):
+In the unified speculative-full-path model a worker executes one WHOLE path (pre-endgame +
+endgame), so the protocol is a single task/result pair:
   task   = SolnIndT path index
-  result = PathBeforeEGResult<ComplexT>
+  result = FullPathResult<ComplexT>  (boundary data + final solution + endgame metadata)
 
-Phase 2 (during endgame):
-  task   = Phase2Task<ComplexT>  (includes boundary point so workers are self-contained)
-  result = PathDuringEGResult<ComplexT>
-
-All structs carry Boost.Serialization support so Boost.MPI can transmit them
-via the existing serialization for Eigen vectors and arbitrary-precision types.
+FullPathResult carries Boost.Serialization support so Boost.MPI can transmit it via the existing
+serialization for Eigen vectors and arbitrary-precision types.
 */
 
 #pragma once
@@ -52,124 +49,6 @@ constexpr int TAG_RESULT    = 2;
 constexpr int TAG_CAPACITY  = 3;  // worker -> manager: int, max tasks in flight on that rank
 
 
-/**
-\brief Result of tracking a single path from start time to the endgame boundary.
-
-Sent from worker to manager after TrackSinglePathBeforeEG(idx).
-*/
-template<typename ComplexT>
-struct PathBeforeEGResult
-{
-	using SolnIndT = std::size_t;
-	using RealT    = typename NumTraits<ComplexT>::Real;
-
-	SolnIndT      path_index             = 0;
-	SuccessCode   pre_endgame_success    = SuccessCode::NeverStarted;
-	Vec<ComplexT> boundary_point;
-	RealT         boundary_stepsize      = RealT(0);
-	bool          precision_changed      = false;
-	ComplexT      time_of_first_prec_increase;
-	unsigned      max_precision_used     = 0;
-	// The precision the tracker was using at the endgame boundary; see EGBoundaryMetaData.
-	unsigned      boundary_precision     = DoublePrecision();
-
-	template<class Archive>
-	void serialize(Archive& ar, unsigned const)
-	{
-		ar & path_index;
-		ar & pre_endgame_success;
-		ar & boundary_point;
-		ar & boundary_stepsize;
-		ar & precision_changed;
-		ar & time_of_first_prec_increase;
-		ar & max_precision_used;
-		ar & boundary_precision;
-	}
-};
-
-
-/**
-\brief Task for Phase 2 (during-endgame) tracking.
-
-Carries the path index and the boundary point/stepsize so each worker is
-self-contained: workers only tracked a subset of paths in Phase 1 and may
-not have the boundary data for paths assigned to them in Phase 2.
-*/
-template<typename ComplexT>
-struct Phase2Task
-{
-	using SolnIndT = std::size_t;
-	using RealT    = typename NumTraits<ComplexT>::Real;
-
-	SolnIndT      path_index        = std::numeric_limits<SolnIndT>::max();  // max = sentinel
-	Vec<ComplexT> boundary_point;
-	RealT         boundary_stepsize = RealT(0);
-
-	bool is_sentinel() const
-	{
-		return path_index == std::numeric_limits<SolnIndT>::max();
-	}
-
-	static Phase2Task sentinel()
-	{
-		return Phase2Task{};  // default path_index == max
-	}
-
-	template<class Archive>
-	void serialize(Archive& ar, unsigned const)
-	{
-		ar & path_index;
-		ar & boundary_point;
-		ar & boundary_stepsize;
-	}
-};
-
-
-/**
-\brief Result of tracking a single path through the endgame.
-
-Sent from worker to manager after TrackSinglePathDuringEG.
-Carries the final solution and all endgame metadata fields that would
-normally be written into SolutionMetaData by the tracking code.
-*/
-template<typename ComplexT>
-struct PathDuringEGResult
-{
-	using SolnIndT = std::size_t;
-
-	SolnIndT      path_index                     = 0;
-	Vec<ComplexT> final_solution;
-
-	SuccessCode   endgame_success                = SuccessCode::NeverStarted;
-	double        function_residual              = 0;
-	double        condition_number               = 0;
-	double        newton_residual                = 0;
-	ComplexT      final_time_used;
-	double        accuracy_estimate              = 0;
-	double        accuracy_estimate_user_coords  = 0;
-	unsigned      cycle_num                      = 0;
-	bool          precision_changed              = false;
-	ComplexT      time_of_first_prec_increase;
-	unsigned      max_precision_used             = 0;
-
-	template<class Archive>
-	void serialize(Archive& ar, unsigned const)
-	{
-		ar & path_index;
-		ar & final_solution;
-		ar & endgame_success;
-		ar & function_residual;
-		ar & condition_number;
-		ar & newton_residual;
-		ar & final_time_used;
-		ar & accuracy_estimate;
-		ar & accuracy_estimate_user_coords;
-		ar & cycle_num;
-		ar & precision_changed;
-		ar & time_of_first_prec_increase;
-		ar & max_precision_used;
-	}
-};
 
 /**
 \brief Result of executing one WHOLE path: start -> endgame boundary -> target.
@@ -234,8 +113,8 @@ struct FullPathResult
 
 namespace detail {
 
-// Sentinel detection and factory — overloaded for each task type so manager
-// and worker can use the same logic without knowing the concrete type.
+// Sentinel detection and factory for the work-item type.  The task in the unified model is just
+// the path index (std::size_t); the max value marks "no more work".
 
 inline bool is_sentinel(std::size_t v)
 {
@@ -245,18 +124,6 @@ inline bool is_sentinel(std::size_t v)
 inline std::size_t make_sentinel(std::size_t)
 {
 	return std::numeric_limits<std::size_t>::max();
-}
-
-template<typename ComplexT>
-bool is_sentinel(Phase2Task<ComplexT> const& t)
-{
-	return t.is_sentinel();
-}
-
-template<typename ComplexT>
-Phase2Task<ComplexT> make_sentinel(Phase2Task<ComplexT> const&)
-{
-	return Phase2Task<ComplexT>::sentinel();
 }
 
 } // namespace detail

--- a/core/include/bertini2/parallel/worker.hpp
+++ b/core/include/bertini2/parallel/worker.hpp
@@ -40,7 +40,7 @@ Each tracking thread owns its state (System copy + Tracker copy) built by state_
 #include "bertini2/parallel/mpi_utils.hpp"
 #include "bertini2/parallel/thread_pool.hpp"
 
-#include <mpi.h>
+#include "bertini2/parallel/mpi_include.hpp"
 
 #include <chrono>
 #include <cstdlib>   // std::getenv

--- a/core/include/bertini2/trackers/base_tracker.hpp
+++ b/core/include/bertini2/trackers/base_tracker.hpp
@@ -219,6 +219,21 @@ namespace bertini{
 
 
 			/**
+			\brief (Re)draw the random probe direction used for condition-number estimation.
+
+			Call this once, from the algorithm, at the start of tracking a point -- after any per-path
+			RNG reseed and before TrackPath -- so the direction is fixed for that whole point's track
+			(pre-endgame tracking and the endgame both) and is reproducible across runs/ranks.  Do NOT
+			call it per TrackPath: the endgame issues many TrackPath calls per point, and refreshing
+			the direction mid-track perturbs condition estimates and churns the RNG.
+			*/
+			void RefreshConditionDirection()
+			{
+				corrector_.RefreshRandomDirection();
+			}
+
+
+			/**
 			\brief Track a start point through time, from a start time to a target time.
 
 			\param[out] solution_at_endtime The value of the solution at the end time.

--- a/core/include/bertini2/trackers/newton_corrector.hpp
+++ b/core/include/bertini2/trackers/newton_corrector.hpp
@@ -112,10 +112,26 @@ namespace bertini{
 					std::get< Vec<mpfr_complex> >(f_temp_).resize(numTotalFunctions_);
 					std::get< Vec<dbl> >(step_temp_).resize(numTotalFunctions_);
 					std::get< Vec<mpfr_complex> >(step_temp_).resize(numTotalFunctions_);
-					std::get< Vec<dbl> >(rand_temp_) = RandomOfUnits<dbl>(numVariables_);
-					std::get< Vec<mpfr_complex> >(rand_temp_) = RandomOfUnits<mpfr_complex>(numVariables_);
 					std::get< Vec<dbl> >(solve_temp_).resize(numVariables_);
 					std::get< Vec<mpfr_complex> >(solve_temp_).resize(numVariables_);
+					RefreshRandomDirection();
+				}
+
+				/**
+				 \brief (Re)draw the random probe direction used to estimate ||J^{-1}|| (the condition
+				 number) from this thread's RNG engine.
+
+				 The tracker calls this once at the start of a path track (see Tracker::TrackPath's
+				 caller / the per-path reseed point), so the direction is held fixed for the ENTIRE
+				 track of that point -- every Newton step and the endgame's sample-circle sub-tracks
+				 -- and, given a per-path RNG reseed, is reproducible regardless of how paths were
+				 distributed across workers.  It is NOT redrawn per Newton step or per TrackPath, which
+				 would both perturb condition estimates and (in the endgame) churn the RNG mid-track.
+				 */
+				void RefreshRandomDirection()
+				{
+					std::get< Vec<dbl> >(rand_temp_) = RandomOfUnits<dbl>(numVariables_);
+					std::get< Vec<mpfr_complex> >(rand_temp_) = RandomOfUnits<mpfr_complex>(numVariables_);
 				}
 
 				

--- a/core/src/blackbox/main_mode_switch.cpp
+++ b/core/src/blackbox/main_mode_switch.cpp
@@ -40,7 +40,7 @@
 #include <iostream>
 
 #ifdef BERTINI2_HAVE_MPI
-#include <mpi.h>
+#include "bertini2/parallel/mpi_include.hpp"
 #endif
 
 

--- a/core/src/function_tree/symbols/special_number.cpp
+++ b/core/src/function_tree/symbols/special_number.cpp
@@ -26,6 +26,8 @@
 
 #include "bertini2/function_tree/symbols/special_number.hpp"
 
+#include <boost/math/constants/constants.hpp>
+
 
 
 
@@ -34,26 +36,33 @@ namespace bertini{
 		namespace special_number{
 using ::pow;
 
-// Return value of constant
+// Return value of constant.
+//
+// pi is computed from the authoritative source -- Boost.Math's `pi` constant, which for the mpfr
+// backend defers to MPFR's `mpfr_const_pi` (correctly rounded to the working precision, and cached)
+// -- rather than `acos(-1)`, whose result is not guaranteed correctly rounded and varies with the
+// inverse-cosine implementation.  This keeps pi identical across ranks/runs at a given precision,
+// which matters because the Cauchy endgame's roots of unity and the total-degree start points are
+// built from pi.  See https://github.com/bertiniteam/b2/issues/156.
 dbl Pi::FreshEval_d(std::shared_ptr<Variable> const& /*diff_variable*/) const
 {
-	return acos(-1.0);
+	return boost::math::constants::pi<double>();
 }
 
 void Pi::FreshEval_d(dbl& evaluation_value, std::shared_ptr<Variable> const& /*diff_variable*/) const
 {
-	evaluation_value = acos(-1.0);
+	evaluation_value = boost::math::constants::pi<double>();
 }
 
 
 mpfr_complex Pi::FreshEval_mp(std::shared_ptr<Variable> const& /*diff_variable*/) const
 {
-	return mpfr_complex(mpfr_float(acos(mpfr_float(-1))));
+	return mpfr_complex(boost::math::constants::pi<mpfr_float>());
 }
 
 void Pi::FreshEval_mp(mpfr_complex& evaluation_value, std::shared_ptr<Variable> const& /*diff_variable*/) const
 {
-	evaluation_value = mpfr_complex(mpfr_float(acos(mpfr_float(-1))));
+	evaluation_value = mpfr_complex(boost::math::constants::pi<mpfr_float>());
 }
 
 

--- a/core/src/system/start/total_degree.cpp
+++ b/core/src/system/start/total_degree.cpp
@@ -24,6 +24,8 @@
 
 #include "bertini2/system/start/total_degree.hpp"
 
+#include <boost/math/constants/constants.hpp>
+
 
 BOOST_CLASS_EXPORT(bertini::start_system::TotalDegree);
 
@@ -80,7 +82,8 @@ namespace bertini {
 				offset = 1;
 			}
 
-			auto two_i_pi = std::acos(-1.0) * dbl(0,2);
+			// authoritative pi (see issue #156 / special_number.cpp), not acos(-1)
+			auto two_i_pi = boost::math::constants::pi<double>() * dbl(0,2);
 
 			for (size_t ii = 0; ii< NumNaturalVariables(); ++ii)
 				start_point(ii+offset) = exp( two_i_pi * static_cast<double>(indices[ii]) / static_cast<double>(degrees_[ii])  ) * pow(random_values_[ii]->Eval<dbl>(), 1.0 / static_cast<double>(degrees_[ii]));
@@ -109,7 +112,8 @@ namespace bertini {
 // TODO: this code should be cleaned up after issue 308 is solved -- namely, the two precision adjustment calls should be removed.  They're only necessary because prec16 / ulonglog = prec19.
 
 			auto one = mpfr_float(1);
-			mpfr_complex two_i_pi = mpfr_complex(0,2) * acos( mpfr_float(-1) );
+			// authoritative pi (see issue #156 / special_number.cpp), not acos(-1)
+			mpfr_complex two_i_pi = mpfr_complex(0,2) * boost::math::constants::pi<mpfr_float>();
 			for (size_t ii = 0; ii< NumNaturalVariables(); ++ii)
 			{
 				mpfr_complex a = exp( (two_i_pi * indices[ii]) / degrees_[ii]);

--- a/core/test/nag_algorithms/zero_dim.cpp
+++ b/core/test/nag_algorithms/zero_dim.cpp
@@ -411,6 +411,155 @@ BOOST_AUTO_TEST_SUITE_END()
 
 
 
+// Path-crossing (midpath) detection and the EGBoundaryAction re-track machinery.
+//
+// Two distinct paths landing on the same point at the endgame boundary is a probability-0 event:
+// it signals a path crossing (under-resolved tracking), which the algorithm is supposed to detect
+// and re-track.  These tests guard the two historical defects in that machinery:
+//   * Bug 1: MidpathChecker computed `same_start` with an inverted comparison, so a genuine
+//     crossing (distinct starts, coincident boundary points) was flagged rerun==false and never
+//     re-tracked.
+//   * Bug 2: MidpathChecker::Check did not reset its pass flag / crossed-path list between calls,
+//     so the resolve loop never saw a clean pass and operated on stale data.
+// The first three cases are deterministic (hand-built boundary + start data) so they always pass
+// once the logic is correct, independent of tracker numerics.  The end-to-end "provoke a spurious
+// crossing and watch it get resolved" scenario is exercised in the Python suite on the cyclic
+// system (see python/test/zero_dim/crossed_paths_test.py), where a cyclic builder exists and the
+// phenomenon is documented (ADR-0017); the C++ wiring case below just confirms a clean solve
+// reports no crossings and the new accessors work.
+BOOST_AUTO_TEST_SUITE(crossed_paths)
+
+using bertini::dbl_complex;
+using bertini::Vec;
+using bertini::SuccessCode;
+using MidPathConfig = bertini::algorithm::MidPathConfig;
+using BoundaryMD = bertini::algorithm::EGBoundaryMetaData<dbl_complex>;
+using Checker = bertini::algorithm::MidpathChecker<double, dbl_complex, BoundaryMD>;
+
+namespace {
+	// Minimal stand-in providing just the StartPoint<ComplexT>(index) interface MidpathChecker
+	// needs, so the test controls both the boundary points and the start points.
+	struct MockStartSystem
+	{
+		std::vector<Vec<dbl_complex>> pts;
+
+		template<typename ComplexT>
+		Vec<ComplexT> StartPoint(unsigned long long i) const
+		{
+			return pts[i].template cast<ComplexT>();
+		}
+	};
+
+	Vec<dbl_complex> Pt(dbl_complex a, dbl_complex b)
+	{
+		Vec<dbl_complex> v(2);
+		v << a, b;
+		return v;
+	}
+
+	BoundaryMD MakeBoundaryPoint(Vec<dbl_complex> const& p)
+	{
+		return BoundaryMD(p, SuccessCode::Success, 0.01, 16);
+	}
+}
+
+
+// Bug 1: two coincident boundary points from DISTINCT start points is a genuine crossing -- it must
+// be detected (Check fails) and both involved paths must be flagged for re-tracking (rerun==true).
+BOOST_AUTO_TEST_CASE(distinct_starts_coincident_endpoints_are_rerun)
+{
+	Checker mp{MidPathConfig()};
+
+	// paths 0 and 1 land on (essentially) the same boundary point; path 2 is elsewhere.
+	auto p = Pt(1.0, 1.0);
+	auto p_nudged = Pt(1.0 + 1e-9, 1.0 - 1e-9);
+	auto p_far = Pt(5.0, 5.0);
+	Checker::BoundaryData boundary{MakeBoundaryPoint(p), MakeBoundaryPoint(p_nudged), MakeBoundaryPoint(p_far)};
+
+	MockStartSystem starts{{Pt(1.0, 0.0), Pt(2.0, 0.0), Pt(3.0, 0.0)}}; // all distinct
+
+	bool passed = mp.Check(boundary, starts);
+
+	BOOST_CHECK(!passed);
+	auto crossed = mp.GetCrossedPaths();
+	BOOST_REQUIRE_EQUAL(crossed.size(), 2u); // paths 0 and 1
+	for (auto const& c : crossed)
+	{
+		BOOST_CHECK(c.index() == 0 || c.index() == 1);
+		BOOST_CHECK(c.rerun()); // distinct starts -> genuine crossing -> must re-track
+	}
+}
+
+
+// Two coincident boundary points that began at the SAME start point are not a crossing to re-track:
+// the crossing is still detected (Check fails) but rerun must be false.
+BOOST_AUTO_TEST_CASE(same_start_coincident_endpoints_are_not_rerun)
+{
+	Checker mp{MidPathConfig()};
+
+	auto p = Pt(1.0, 1.0);
+	auto p_nudged = Pt(1.0 + 1e-9, 1.0 - 1e-9);
+	auto p_far = Pt(5.0, 5.0);
+	Checker::BoundaryData boundary{MakeBoundaryPoint(p), MakeBoundaryPoint(p_nudged), MakeBoundaryPoint(p_far)};
+
+	// paths 0 and 1 share a start point.
+	MockStartSystem starts{{Pt(1.0, 0.0), Pt(1.0, 0.0), Pt(3.0, 0.0)}};
+
+	bool passed = mp.Check(boundary, starts);
+
+	BOOST_CHECK(!passed);
+	auto crossed = mp.GetCrossedPaths();
+	BOOST_REQUIRE_EQUAL(crossed.size(), 2u);
+	for (auto const& c : crossed)
+		BOOST_CHECK(!c.rerun()); // same start -> not a re-trackable crossing
+}
+
+
+// Bug 2: Check must reset its state each call.  A first call that finds a crossing must not leave
+// the checker permanently "failed": a subsequent call on clean data must pass and report no
+// crossings.
+BOOST_AUTO_TEST_CASE(check_resets_state_between_calls)
+{
+	Checker mp{MidPathConfig()};
+
+	auto p = Pt(1.0, 1.0);
+	auto p_nudged = Pt(1.0 + 1e-9, 1.0 - 1e-9);
+	auto p_far = Pt(5.0, 5.0);
+	MockStartSystem starts{{Pt(1.0, 0.0), Pt(2.0, 0.0), Pt(3.0, 0.0)}};
+
+	Checker::BoundaryData crossing{MakeBoundaryPoint(p), MakeBoundaryPoint(p_nudged), MakeBoundaryPoint(p_far)};
+	BOOST_CHECK(!mp.Check(crossing, starts));
+	BOOST_CHECK(!mp.GetCrossedPaths().empty());
+
+	// now feed clean (all-distinct) data: must pass, and the stale crossing list must be gone.
+	Checker::BoundaryData clean{MakeBoundaryPoint(Pt(1.0, 1.0)), MakeBoundaryPoint(Pt(5.0, 5.0)), MakeBoundaryPoint(Pt(9.0, 9.0))};
+	BOOST_CHECK(mp.Check(clean, starts));
+	BOOST_CHECK(mp.GetCrossedPaths().empty());
+}
+
+
+// Wiring: a clean solve populates the midpath report (no crossings) and the boundary accessors work.
+BOOST_AUTO_TEST_CASE(clean_solve_reports_no_crossings)
+{
+	using namespace bertini;
+	using TrackerT = tracking::DoublePrecisionTracker;
+
+	auto sys = system::Precon::GriewankOsborn();
+	auto zd = algorithm::ZeroDim<TrackerT, endgame::EndgameSelector<TrackerT>::Cauchy, decltype(sys), start_system::TotalDegree>(sys);
+	zd.DefaultSetup();
+	zd.Solve();
+
+	auto const& report = zd.EndgameBoundaryMetadata();
+	BOOST_CHECK(report.passed);
+	BOOST_CHECK_EQUAL(report.num_crossings_detected, 0u);
+	BOOST_CHECK_EQUAL(report.num_resolve_attempts, 0u);
+	BOOST_CHECK(zd.EndgameBoundarySolutions().size() > 0u);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+
+
 // Solution-metadata classification (is_finite / is_real / is_singular / multiplicity) and the
 // PostProcessing config knobs that drive it.  These pin the Bertini-1 behaviour: an endpoint is
 // at infinity if the infinity norm of its dehomogenized coordinates exceeds

--- a/core/test/nag_algorithms/zero_dim.cpp
+++ b/core/test/nag_algorithms/zero_dim.cpp
@@ -411,7 +411,7 @@ BOOST_AUTO_TEST_SUITE_END()
 
 
 
-// Path-crossing (midpath) detection and the EGBoundaryAction re-track machinery.
+// Path-crossing (midpath) detection and the re-track machinery (RunMidpathResolution).
 //
 // Two distinct paths landing on the same point at the endgame boundary is a probability-0 event:
 // it signals a path crossing (under-resolved tracking), which the algorithm is supposed to detect

--- a/docs/adr/0022-path-crossings-are-detected-and-retracked.md
+++ b/docs/adr/0022-path-crossings-are-detected-and-retracked.md
@@ -1,0 +1,83 @@
+# ADR-0022: Path crossings at the endgame boundary are detected and re-tracked, not tolerated
+
+**Status:** Accepted
+**Date:** 2026-06-16
+
+## Context
+
+The zero-dim solve has always included a *midpath check* (`MidpathChecker`,
+`EGBoundaryAction`): at the endgame boundary it compares every pair of path
+endpoints and, if two land on the same point (within a relaxed tolerance), it is
+supposed to re-track the offending paths with tightened settings. Two distinct
+paths reaching the *same* point at the boundary is a probability-0 event, so when
+it happens it is a **path crossing** — a symptom of under-resolved tracking (most
+often a too-low-order predictor) — not a benign coincidence.
+
+The machinery did not work, for two reasons:
+
+- **Inverted `same_start`.** `MidpathChecker::Check` computed
+  `same_start = (||start_i - start_j|| > tol)`, i.e. true when the start points
+  *differ*. Since `CrossedPath` sets `rerun = !same_start`, a genuine crossing
+  (distinct starts, coincident endpoints) was flagged `rerun == false` and **never
+  re-tracked**. The comparison must be `<`.
+- **`Check` never reset its state.** `passed_` was only ever set `false`, and
+  `crossed_paths_` was never cleared. `EGBoundaryAction` calls `Check` in a loop
+  (once before any resolve, again after each `MidpathResolve`); on the second call
+  it returned a stale `false` and re-tracked stale indices, so the loop always
+  burned all attempts and never observed a clean pass.
+
+Separately, ADR-0017 ("flakiness is tolerances, not seeding") had framed boundary
+duplicates as a tolerance-flakiness nuisance to *measure around* by counting
+distinct points (dividing by multiplicity). That framing — and the "harmless
+duplicate" language in the `solving_at_scale` tutorial — is misleading: a boundary
+duplicate is a crossing the algorithm should *fix*, not merely tolerate.
+
+## Decision
+
+- **Fix the two bugs.** `same_start` uses `<`; `Check` resets `passed_ = true` and
+  clears `crossed_paths_` at entry.
+- **Make the resolve a bounded, escalating action — never an open-ended loop.**
+  `EGBoundaryAction` re-tracks crossed paths at most
+  `ZeroDimConfig::max_num_crossed_path_resolve_attempts` times (default 2), so it
+  always terminates. `max_num_crossed_path_resolve_attempts == 0` means
+  *detect-and-report only* (the conservative, Bertini-1-style choice).
+- **Escalate the remedy, don't just shrink tolerance.** Each attempt tightens the
+  tracking tolerance **and** raises the ODE predictor to the default (RKF45) if a
+  low-order predictor is in use — a too-low-order predictor (notably Euler) is the
+  usual root cause, and tightening tolerance on a first-order predictor is far less
+  effective than moving to a higher order.
+- **Unresolved crossings stay observable, and we keep tracking them.** After the
+  attempts are exhausted, the still-crossed paths still go through the endgame (we
+  never drop more answers than Bertini 1 would), but the outcome is recorded in a
+  `MidpathCheckReport` (`passed`, `num_crossings_detected`, `num_resolve_attempts`,
+  `crossed_path_indices`), retrievable via `ZeroDim::EndgameBoundaryMetadata()`
+  (Python: `endgame_boundary_metadata`), and a warning is emitted. We do **not**
+  add a `SuccessCode::MidpathCrossing`: those paths tracked fine, they just
+  collided, so the crossing fact belongs in the report, not in per-path
+  `success_code`.
+- **Refine ADR-0017, don't contradict it.** Tolerances/precision are still the
+  right fix; this work simply *automates* that fix inside `EGBoundaryAction` and
+  stops calling duplicates harmless. The distinct-solution count remains a valid
+  *verification*, but it is a check, not an excuse. "Harmless duplicate" language is
+  removed from the tutorials, examples, and comments.
+
+## Consequences
+
+- The accessor `EndgameBoundaryData()` is renamed `EndgameBoundarySolutions()`
+  (Python `endgame_boundary_data` → `endgame_boundary_solutions`); a new
+  `EndgameBoundaryMetadata()` exposes the report. This is a breaking rename, but the
+  old name had only internal callers.
+- A solve that hits a crossing now self-corrects (with the default predictor it
+  generally does not hit one at all); a caller can detect an unresolved crossing
+  programmatically rather than discovering a wrong count later.
+- See ADR-0017 (tolerances vs. seeding) and ADR-0015 (same-point classification),
+  which this ADR refines and complements.
+
+## Future work (deferred — intentionally not built here)
+
+The per-attempt remedy wants to become a **configurable, ordered remedy list**
+(tighten tolerance, more Newton iterations, bump predictor, shrink min step size,
+…), applied in sequence until exhausted, so a user can compose a resolution
+strategy. For now the escalation is a fixed, minimal two-remedy step; getting the
+strategy abstraction right is out of scope. Termination is guaranteed regardless,
+because the attempt count is bounded.

--- a/docs/adr/0023-unified-speculative-full-path-parallelism.md
+++ b/docs/adr/0023-unified-speculative-full-path-parallelism.md
@@ -1,0 +1,80 @@
+# ADR-0023: ZeroDim uses one per-path primitive and a speculative-full-path parallel model
+
+**Status:** Accepted
+**Date:** 2026-06-17
+
+## Context
+
+The distributed ZeroDim solve was a **two-phase, barrier-separated** manager-worker model:
+
+1. Phase 1 — workers track every path start→boundary; each boundary result is serialized back to
+   the manager.
+2. A barrier, then the manager alone runs the midpath (path-crossing) check and any re-tracks while
+   the workers sit idle.
+3. Phase 2 — the manager serializes each boundary point back out to a worker, which runs the endgame.
+
+Three problems came out of the crossed-paths work (ADR-0022):
+
+- **A precision-transfer bug by construction of the handoff.** The Phase-2 task serialized the
+  boundary point and stepsize but dropped the boundary *precision*. An adaptive-precision worker
+  therefore resumed the endgame at double precision, and a distributed AMP solve diverged from the
+  serial one — cyclic-5 returned a precision-degraded subset instead of all 70 finite solutions. The
+  bug existed *only because* boundary state crossed the worker→manager→worker handoff.
+- **A mid-solve barrier + idle-manager window.** The slowest pre-endgame path stalled every worker
+  before any endgame began, and all workers idled during the manager-only midpath check / re-track
+  (flagged in a code comment as a known bottleneck).
+- **Two separate per-path code paths** (a serial flow and a distributed worker flow) that set up
+  precision/tolerance/stepsize differently and could drift.
+
+## Decision
+
+**One per-path primitive.** The four near-duplicate per-path routines collapse onto two shared
+bodies, `ExecuteBeforeEG` / `ExecuteDuringEG`, driven through a reference-context
+(`BeforeEGContext` / `DuringEGContext`). The serial flow passes its member tracker/endgame/observers;
+a worker thread passes its cloned `PathThreadState`. They standardize on `SetThreadPrecision`
+(thread-local), correct on the main thread and on worker threads alike. `ExecuteOnePath` composes
+the two into a whole path (set pre-endgame tolerance → track to boundary → set endgame tolerance →
+run endgame).
+
+**Speculative-full-path model.** A worker (or the serial loop) executes one *whole* path as the unit
+of work. Because the boundary state never leaves the executing context, the precision-transfer bug
+*cannot recur* — it is designed out, not patched.
+
+**Crossing resolution is bounded and parallel.** After a round of whole-path execution, the manager
+runs the midpath check on the collected boundary points; crossed paths are re-dispatched as ordinary
+whole-path tasks to the same worker pool (re-tracking is path-independent — no idle-manager
+bottleneck), with escalated settings, bounded by `max_num_crossed_path_resolve_attempts`
+(`0` = detect-and-report only). A one-int `MPI_Bcast` between rounds tells workers whether to run
+again and to apply the same `EscalateRetrackSettings` the serial flow uses. Serial and distributed
+share the per-path primitive and the same resolution logic.
+
+**One MPI message type.** `PathBeforeEGResult` / `Phase2Task` / `PathDuringEGResult` collapse to a
+single `FullPathResult` (boundary data + final solution + endgame metadata); the task is just the
+path index.
+
+## Consequences
+
+- A distributed solve now produces the same correct answer as serial on generic problems: cyclic-5
+  recovers all 70 distinct finite solutions in **both** double and adaptive precision, serial and
+  distributed. Guarded by new acceptance tests in `python/test/parallel/test_mpi_zerodim.py`.
+- In the speculative model a crossed path's (now-wasted) endgame runs before the crossing is
+  detected, so a re-track redoes the *whole* path including a second endgame. Crossings are
+  probability-0 events, so the expected extra cost is ~0 and the barrier is removed on *every* solve;
+  a deliberately crossing-heavy config (e.g. the `crossed_paths` tutorial) pays more, bounded by the
+  attempt count.
+- `ReinitializeInitialStepSize(true)` is re-asserted at the start of each pre-endgame track: a path's
+  endgame now runs immediately before the next path's pre-endgame on the same tracker and leaves a
+  tiny step, which would otherwise make the next path crawl from the start time.
+
+## Known limitation (separate from this work)
+
+Serial and distributed are **not** bit-for-bit identical on pathological systems (e.g. Griewank-Osborn
+at a tight endgame boundary): per-path `max_precision_used` and the classification of *infinite/singular*
+paths can differ. The cause is that the distributed solve re-forms the homotopy from the broadcast
+seed (ADR-0016) and that re-form is not bit-identical to the serially-constructed homotopy, so the
+two solve slightly different (but equally valid) random homotopies. The *finite* solutions — the
+gamma-independent answer — agree. Making the re-form reproduce construction bit-for-bit is a separate
+reproducibility fix tracked against ADR-0016, not the parallelism model.
+
+See ADR-0016 (broadcast homotopy seed), ADR-0017 (tolerances, not seeding), ADR-0022 (detect and
+re-track crossings).

--- a/docs/adr/0024-condition-probe-tracker-owned-per-path.md
+++ b/docs/adr/0024-condition-probe-tracker-owned-per-path.md
@@ -1,0 +1,58 @@
+# ADR-0024: The condition-number random direction is refreshed once per path, by the tracker
+
+**Status:** Accepted
+**Date:** 2026-06-17
+
+## Context
+
+The adaptive-precision machinery estimates a path's condition number by solving `J x = r` for a
+random probe direction `r` and forming `||J|| * ||J^{-1}||`.  That probe, `rand_temp_`, was drawn in
+`NewtonCorrector::ChangeSystem` -- i.e. **once per `SetSystem`** -- via `RandomOfUnits`, which reads
+this thread's RNG engine (`bertini::ThreadEngine()`).
+
+That draw was at an **uncontrolled RNG point**.  The zero-dim algorithm reseeds the thread RNG per
+path (`ReseedThisThread(idx)`) so tracking is reproducible, but the probe was drawn before any such
+reseed, at whatever engine state `SetSystem` happened to leave.  That state differs between a serial
+solve and a distributed worker (which has just called `SetGlobalSeed` of the broadcast seed), so the
+two got **different probes**.  For well-conditioned paths the probe doesn't change the outcome; for
+ill-conditioned/near-singular paths it changes adaptive-precision decisions, so serial and
+distributed diverged there.  This surfaced while making distributed solves reproducible (ADR-0023,
+authoritative pi (#156), broadcasting rank 0's systems, rank 0 shipping start points).
+
+The probe's correct lifecycle is **per path**: one direction, held fixed for the *entire* track of a
+point -- all Newton steps and the endgame's sample-circle sub-tracks -- which also keeps condition
+estimates comparable across steps.  A first attempt that refreshed the probe inside
+`Tracker::TrackPath` was **wrong and reverted**: the endgame issues many `TrackPath` calls per point,
+so it redrew mid-track, churned the RNG, and regressed bit-identity.
+
+## Decision
+
+Refresh the probe **once per path, triggered by the algorithm, through the tracker** -- not in
+`ChangeSystem`, not in `TrackPath`, not per Newton step:
+
+- `NewtonCorrector::RefreshRandomDirection()` (re)draws the probe; `ChangeSystem` calls it once for
+  initialization.
+- `Tracker::RefreshConditionDirection()` forwards to the corrector.
+- `ZeroDim::ExecuteBeforeEG` calls it once, right after the per-path `ReseedThisThread(idx)` and
+  `SetThreadPrecision`, before tracking -- and **not** again for the endgame.  So the direction is
+  drawn from an RNG state determined solely by the path index, identical whether the path runs in a
+  serial loop or on a distributed worker, and held for the whole track (pre-endgame + endgame).
+
+## Consequences
+
+- The probe is now a reproducible, per-path quantity.  Bit-identity that already held on
+  well-conditioned finite solutions is preserved (cyclic-5 finite hash unchanged), and more
+  ill-conditioned cases now agree serial vs distributed.  All suites pass (C++, 53 serial pytest, 6
+  MPI under `mpirun -n 3`).
+- **The probe was not the whole story.** Controlling it did *not* fully close the Griewank-Osborn
+  seed-1 case, so there is at least **one more uncontrolled non-deterministic input** on deeply
+  singular paths still to find (low priority: a measure-zero case whose finite answer is already
+  correct in both modes).
+- **Ownership is still split:** the corrector owns the probe storage and the tracker merely triggers
+  the refresh.  The cleaner end state -- the random direction fully owned by the tracker/track and
+  the corrector a **pure kernel** (`(J, f, probe) -> (step, condition estimate)`, no hidden RNG or
+  scratch) -- is left to the **planned predict/correct rewrite**, whose interface is meant to express
+  exactly a direction that persists over a whole track.  The seed-1 residual is best hunted there too.
+
+See ADR-0023 (unified speculative-full-path parallelism), ADR-0016 (broadcast homotopy seed),
+ADR-0017 (tolerances, not seeding).

--- a/python/bertini/config.py
+++ b/python/bertini/config.py
@@ -44,6 +44,7 @@ newly added algorithm and its configs get the whole interface for free:
     owner's own ``config_types()`` so they always reflect what the owner accepts.
 """
 
+import copyreg
 import re
 
 
@@ -162,8 +163,21 @@ def _make_eq(fields):
     return __eq__
 
 
+def _reconstruct_enhanced(cls, mapping):
+    """Pickle reconstructor for enhanced config/metadata classes: rebuild from a field dict."""
+    return cls.from_dict(mapping)
+
+
+def _make_reduce():
+    def __reduce__(self):
+        # Pickle via the (to_dict / from_dict) round-trip.  Works for any enhanced class; the field
+        # values must themselves be picklable (numbers, including multiprec.Complex/Float).
+        return (_reconstruct_enhanced, (type(self), self.to_dict()))
+    return __reduce__
+
+
 def _enhance_config_class(cls):
-    """Add update/to_dict/from_dict/repr/eq to a bound config class (idempotent)."""
+    """Add update/to_dict/from_dict/repr/eq/pickle to a bound config class (idempotent)."""
     if getattr(cls, "_b2_config_enhanced", False):
         return cls
     fields = writable_fields(cls)
@@ -174,6 +188,9 @@ def _enhance_config_class(cls):
     try:
         cls.__repr__ = _make_repr(fields)
         cls.__eq__ = _make_eq(fields)
+        # Make the class picklable (copy.copy/deepcopy too) via to_dict/from_dict, overriding the
+        # Boost.Python "pickling not enabled" default.
+        cls.__reduce__ = _make_reduce()
     except (TypeError, AttributeError):
         # some bound types may refuse dunder assignment; the rest still apply
         pass
@@ -190,15 +207,52 @@ def _is_owner(cls):
 def _looks_like_config(cls):
     return (isinstance(cls, type)
             and not _is_owner(cls)
+            and not _is_bound_enum(cls)
             and len(writable_fields(cls)) > 0)
 
 
+def _is_bound_enum(cls):
+    """True for a Boost.Python enum class.
+
+    Boost.Python enums subclass ``int``, so ``writable_fields`` would otherwise mistake int's
+    read-only ``real``/``imag``/``numerator``/``denominator`` descriptors (and the enum's own
+    ``name``) for writable config fields and wrongly "enhance" the enum -- corrupting its repr and
+    its pickling.  No genuine config struct subclasses int, so this is a safe, precise exclusion.
+    """
+    return isinstance(cls, type) and issubclass(cls, int) and cls not in (int, bool)
+
+
+# ---------------------------------------------------------------------------
+# enum pickling
+# ---------------------------------------------------------------------------
+
+def _reconstruct_enum(cls, value):
+    """Pickle reconstructor for a Boost.Python enum value: rebuild the member from its int value."""
+    return cls(value)
+
+
+def _reduce_enum(member):
+    return (_reconstruct_enum, (type(member), int(member)))
+
+
+def _enable_enum_pickling(cls):
+    """Make a Boost.Python enum picklable (its built-in ``__reduce_ex__`` is broken).
+
+    Registered via ``copyreg`` so the pickler reconstructs the member from its int value; this also
+    lets structs that *contain* enum fields (e.g. ``SolutionMetaData.endgame_success``) round-trip.
+    """
+    copyreg.pickle(cls, _reduce_enum)
+    return cls
+
+
 def _enhance_all(module):
-    """Enhance every config-like class found in a bound module."""
+    """Enhance every config-like class found in a bound module; make bound enums picklable."""
     for name in dir(module):
         obj = getattr(module, name)
         try:
-            if _looks_like_config(obj):
+            if _is_bound_enum(obj):
+                _enable_enum_pickling(obj)
+            elif _looks_like_config(obj):
                 _enhance_config_class(obj)
         except Exception:
             # never let one odd member break importing the package

--- a/python/bertini/config.py
+++ b/python/bertini/config.py
@@ -162,7 +162,7 @@ def _make_eq(fields):
     return __eq__
 
 
-def enhance_config_class(cls):
+def _enhance_config_class(cls):
     """Add update/to_dict/from_dict/repr/eq to a bound config class (idempotent)."""
     if getattr(cls, "_b2_config_enhanced", False):
         return cls
@@ -193,13 +193,13 @@ def _looks_like_config(cls):
             and len(writable_fields(cls)) > 0)
 
 
-def enhance_all(module):
+def _enhance_all(module):
     """Enhance every config-like class found in a bound module."""
     for name in dir(module):
         obj = getattr(module, name)
         try:
             if _looks_like_config(obj):
-                enhance_config_class(obj)
+                _enhance_config_class(obj)
         except Exception:
             # never let one odd member break importing the package
             pass
@@ -261,7 +261,7 @@ def config_names(self):
     return sorted({config_key(c) for c in self.config_types() if c is not None})
 
 
-def enhance_owner_class(cls):
+def _enhance_owner_class(cls):
     """Attach configure()/config_names() to a tracker/algorithm class (idempotent)."""
     if getattr(cls, "_b2_owner_enhanced", False):
         return cls
@@ -271,12 +271,12 @@ def enhance_owner_class(cls):
     return cls
 
 
-def enhance_owners(module):
+def _enhance_owners(module):
     """Attach owner helpers to every config-owning class in a bound module."""
     for name in dir(module):
         obj = getattr(module, name)
         try:
             if isinstance(obj, type) and _is_owner(obj):
-                enhance_owner_class(obj)
+                _enhance_owner_class(obj)
         except Exception:
             pass

--- a/python/bertini/endgame/__init__.py
+++ b/python/bertini/endgame/__init__.py
@@ -79,8 +79,8 @@ from bertini._pybertini.endgame import (
 )
 
 # configs gain update()/to_dict()/from_dict()/repr/eq
-from ..config import enhance_all
-enhance_all(_pybe)
+from ..config import _enhance_all
+_enhance_all(_pybe)
 
 
 class _EndgameBase:

--- a/python/bertini/linalg.py
+++ b/python/bertini/linalg.py
@@ -253,21 +253,30 @@ def add_linear(system, A, x, b=None):
 
     Parameters
     ----------
-    system : the System to add to.  Its variable groups must already be set -- the block is
+    system
+        the System to add to.  Its variable groups must already be set -- the block is
         built over the system's current variable ordering.
-    A : an exact (m x n) coefficient matrix (array/list of lists).
-    x : a length-n vector of the system's variables (numpy object array of Variable, e.g.
+    A
+        an exact (m x n) coefficient matrix (array/list of lists).
+    x
+        a length-n vector of the system's variables (numpy object array of Variable, e.g.
         from :func:`variable_vector`).  Each x[j] must already belong to a variable group of
         ``system``.
-    b : optional length-m exact constant vector (default all zero).
+    b
+        optional length-m exact constant vector (default all zero).
 
+    Returns
+    -------
+    System
+        ``system``, for chaining.
+
+    Notes
+    -----
     Coefficients must be exact (see :func:`coefficient`); Python floats are refused.
 
     The resulting linear-forms block is homogenization-aware, so it survives the
     homogenization the zero-dim solver performs: a system mixing polynomial functions with an
     ``add_linear`` block solves end to end (currently for a single affine variable group).
-
-    Returns ``system`` for chaining.
 
     Examples
     --------
@@ -334,20 +343,27 @@ def add_products_of_linears(system, factors):
 
     Parameters
     ----------
-    system : the System to add to.
-    factors : a list with one entry per function.  Entry i is an exact (k_i x (num_vars+1)) matrix
+    system
+        the System to add to.
+    factors
+        a list with one entry per function.  Entry i is an exact (k_i x (num_vars+1)) matrix
         (array/list of lists): one row per linear factor, the trailing column being that factor's
         constant term.  Different functions may have different numbers of factors, but every matrix
         must have the same number of columns (num_vars+1).
 
+    Returns
+    -------
+    System
+        ``system``, for chaining.
+
+    Notes
+    -----
     Coefficients must be exact (see :func:`coefficient`); Python floats are refused.
 
     Works across multiple variable groups: the coefficient columns follow the system's variable
     ordering and the trailing column is the affine constant.  For a *projective* (homogeneous)
     variable group, write homogeneous factors -- give the constant column as ``0`` -- since the
     block is evaluated as authored (it does not re-homogenize).
-
-    Returns ``system`` for chaining.
 
     Examples
     --------

--- a/python/bertini/nag_algorithm/__init__.py
+++ b/python/bertini/nag_algorithm/__init__.py
@@ -39,9 +39,9 @@ from bertini._pybertini import nag_algorithms as _pybnalag
 from bertini._pybertini.nag_algorithms import *
 
 # config structs gain update()/repr/to_dict/...; algorithm classes gain configure().
-from ..config import enhance_all, enhance_owners
-enhance_all(_pybnalag)
-enhance_owners(_pybnalag)
+from ..config import _enhance_all, _enhance_owners
+_enhance_all(_pybnalag)
+_enhance_owners(_pybnalag)
 
 
 # --- ZeroDim: a friendly factory over the 18 bound ZeroDim<endgame x precision x start> classes ---
@@ -273,7 +273,10 @@ def blend_homotopy(target, start, *, path_variable='t', gamma=None):
         The gamma coefficient.  ``None`` (default) draws a random rational gamma.  Pass an exact
         node (e.g. from :func:`bertini.linalg.coefficient`) off the real axis for a reproducible path.
 
-    Returns the homotopy System; pair it with :func:`user_homotopy` and your start points to solve.
+    Returns
+    -------
+    System
+        The homotopy; pair it with :func:`user_homotopy` and your start points to solve.
     """
     from bertini._pybertini import system as _system
     return _system.make_homotopy(target, start, path_variable, gamma)

--- a/python/bertini/tracking/__init__.py
+++ b/python/bertini/tracking/__init__.py
@@ -38,9 +38,9 @@ from bertini._pybertini.tracking import *
 
 # trackers gain configure()/config_names() built on their type-list config interface;
 # configs gain update()/to_dict()/from_dict()/repr/eq.
-from ..config import enhance_owners, enhance_all
-enhance_owners(_pybtracking)
-enhance_all(_pybtracking)
+from ..config import _enhance_owners, _enhance_all
+_enhance_owners(_pybtracking)
+_enhance_all(_pybtracking)
 
 __all__ = dir(_pybtracking)
 

--- a/python/docs/source/detailed/config_module.rst
+++ b/python/docs/source/detailed/config_module.rst
@@ -1,0 +1,13 @@
+🎛 bertini.config
+====================
+
+Ergonomics for Bertini's config structs (round-tripping, field introspection, the ``configure``
+helper).  For the config *classes* themselves see :doc:`configs`.
+
+
+Auto-generated docs
+--------------------
+
+.. automodule:: bertini.config
+   :members:
+   :undoc-members:

--- a/python/docs/source/detailed/detailed.rst
+++ b/python/docs/source/detailed/detailed.rst
@@ -29,10 +29,13 @@ This page acts to point you to more specific places in the documentation.  Table
    tracking
    endgame
    parse
+   sympy_bridge
    containers
    logging
    parallel
-   
+   random
+   config_module
+
 
 🎱 Things you probably don't need
 ----------------------------------------

--- a/python/docs/source/detailed/random.rst
+++ b/python/docs/source/detailed/random.rst
@@ -1,0 +1,14 @@
+🎲 bertini.random
+====================
+
+Random-number utilities: seed the global RNG for reproducible solves
+(:func:`~bertini.random.set_random_seed` / :func:`~bertini.random.get_random_seed`) and draw random
+complex/real values.
+
+
+Auto-generated docs
+--------------------
+
+.. automodule:: bertini.random
+   :members:
+   :undoc-members:

--- a/python/docs/source/detailed/sympy_bridge.rst
+++ b/python/docs/source/detailed/sympy_bridge.rst
@@ -1,0 +1,14 @@
+🔁 bertini.sympy_bridge
+==========================
+
+Exact two-way conversion between sympy expressions/systems and bertini function trees/systems
+(:func:`~bertini.sympy_bridge.from_sympy`, :func:`~bertini.sympy_bridge.to_sympy`,
+:func:`~bertini.sympy_bridge.system_from_sympy`).
+
+
+Auto-generated docs
+--------------------
+
+.. automodule:: bertini.sympy_bridge
+   :members:
+   :undoc-members:

--- a/python/docs/source/tutorials/crossed_paths.rst
+++ b/python/docs/source/tutorials/crossed_paths.rst
@@ -1,0 +1,133 @@
+🪢 Crossed paths: when two paths become one
+*********************************************
+
+Homotopy continuation tracks one path per start point, from a generic start system at :math:`t=1`
+to your target system at :math:`t=0`.  The homotopy carries a random parameter :math:`\gamma`, and
+that randomness is load-bearing: it guarantees, *with probability 1*, that the paths stay
+**separate** for all :math:`0 < t \le 1`.  Distinct paths simply do not meet.
+
+So if two distinct paths *do* arrive at the **same** point, something has gone wrong.  It is not a
+benign "duplicate" -- it is a **path crossing**: somewhere along the way the numerical tracker took
+a step coarse enough to jump from one path onto a neighbouring one, and from there the two are
+indistinguishable.  They reach the endgame boundary as the same point, the endgame sends both to
+the same solution, and you are left with a duplicate where there should have been two answers --
+**a solution silently lost.**
+
+This tutorial does three things: provoke a crossing on purpose, see how Bertini 2 detects and
+*fixes* it, and -- the real point -- show why you should never see one with the defaults.
+
+What Bertini does at the endgame boundary
+=========================================
+
+A zero-dim solve has a definite shape: track every path to the **endgame boundary** (by default
+:math:`t = 0.1`), then run the endgame from there to :math:`t=0`.  In between sits the **midpath
+check**.  It compares every pair of boundary points and, if two agree to within a relaxed
+same-point tolerance, flags a crossing.  Then :func:`EGBoundaryAction` re-tracks the offending
+paths with **tightened settings** -- a smaller tolerance *and* a higher-order predictor -- and
+checks again, up to ``max_num_crossed_path_resolve_attempts`` times (default 2).
+
+Two distinct paths agreeing to several digits at :math:`t=0.1` is a measure-zero coincidence, which
+is exactly why it is a reliable alarm: under correct tracking it never fires.
+
+Provoking one
+=============
+
+The classic way to under-resolve paths is a low-order predictor with a loose tolerance.  We use the
+**Euler** predictor (order 1) and a loose pre-endgame tolerance on the cyclic-5 system (120 paths,
+70 distinct finite solutions).  The complete script is :download:`crossed_paths.py
+<../../../examples/crossed_paths.py>`:
+
+.. literalinclude:: ../../../examples/crossed_paths.py
+   :language: python
+   :caption: examples/crossed_paths.py
+
+The key knobs are three lines on the solver:
+
+.. code-block:: python
+
+    solver.get_tracker().predictor(pb.tracking.Predictor.Euler)   # order-1 predictor: the culprit
+
+    tols = solver.get_config(pb.nag_algorithm.TolerancesConfig)
+    tols.newton_before_endgame = 1e-4                              # loose tracking before the endgame
+    solver.set_config(tols)
+
+    zd = solver.get_config(pb.nag_algorithm.ZeroDimConfigDoublePrec)
+    zd.max_num_crossed_path_resolve_attempts = 0                  # 0 = detect & report, do NOT re-track
+    solver.set_config(zd)
+
+.. note::
+
+   The fixed seed only makes the *bad behaviour* reproducible so we can talk about it.  Pinning a
+   seed is **never** the fix for a flaky solve -- the fixes are tolerance, precision, and predictor.
+   See :doc:`solving_at_scale` and the project's ADR-0017.
+
+Seeing the damage, then the repair
+===================================
+
+Run with re-tracking **disabled** first, so the crossing stands uncorrected:
+
+.. code-block:: text
+
+    Euler + loose tolerance, re-tracking DISABLED (max_num_crossed_path_resolve_attempts=0):
+      crossings detected : 2
+      crossed path indices: [16, 58]
+      midpath check passed: False
+      distinct finite solutions: 69 / 70
+
+      --> the crossed paths merged into one, so a true solution was lost
+
+Paths 16 and 58 jumped onto each other.  The solver *tells you* this -- the report from
+:func:`endgame_boundary_metadata` carries ``passed = False`` and the offending indices -- but with
+re-tracking off it does nothing about it, and the distinct finite count comes up one short: **69
+instead of 70.**
+
+Now the default behaviour, re-tracking **enabled**:
+
+.. code-block:: text
+
+    Same solve, re-tracking ENABLED (the default):
+      crossings detected : 2
+      re-track attempts  : 1
+      midpath check passed: True
+      distinct finite solutions: 70 / 70
+
+      --> the crossing was resolved and the lost solution recovered.
+
+One re-track attempt -- tighter tolerance, and Euler bumped up to the default RKF45 -- pulls the two
+paths back apart, and the missing solution reappears.  **70 of 70.**
+
+Reading the report
+==================
+
+Every solve exposes what the midpath check found, via :func:`endgame_boundary_metadata`:
+
+.. code-block:: python
+
+    report = solver.endgame_boundary_metadata()
+    report.passed                  # did the check ultimately pass (no crossings left)?
+    report.num_crossings_detected  # how many crossed paths were found on the first check
+    report.num_resolve_attempts    # how many re-track attempts were performed
+    report.crossed_path_indices    # which paths were involved
+
+Use it as a correctness gate in your own scripts: if ``report.passed`` is ``False`` after a solve,
+some crossings were left unresolved and the affected solutions may be wrong -- re-solve with a
+better predictor or a tighter tolerance.
+
+What to actually do about crossings
+===================================
+
+* **Prefer prevention.**  The defaults exist precisely so this never happens: the default predictor
+  is **RKF45** (order 4 with an embedded error estimate), not Euler.  Swap the one Euler line out --
+  or just don't put it in -- and the crossing disappears at the source.  A modestly tighter
+  ``newton_before_endgame`` does the same.
+* **Let the solver self-correct.**  With ``max_num_crossed_path_resolve_attempts > 0`` (the default
+  is 2) the re-track usually fixes a stray crossing for you, as above.
+* **Decide what "give up" means.**  Set ``max_num_crossed_path_resolve_attempts = 0`` to *detect and
+  report only* -- the solve keeps tracking the crossed paths through the endgame (you never get
+  fewer answers than you would without the check), but it does not spend time re-tracking; you read
+  ``report.passed`` and decide.  This is the conservative choice when you would rather re-solve the
+  whole system with better settings than retry individual paths.
+
+The honest summary: a crossing is a signal you tracked too coarsely.  Bertini 2 will catch it and,
+within a bounded number of attempts, usually fix it -- but the best solve is the one where the
+predictor and tolerance are good enough that the alarm never sounds.

--- a/python/docs/source/tutorials/solving_at_scale.rst
+++ b/python/docs/source/tutorials/solving_at_scale.rst
@@ -105,9 +105,19 @@ Two things to notice.  First, the **whole** distributed machinery is the single
 the answer*.  Second, the check is real and uses the solver's *own* classification rather than a
 hand-rolled cutoff: it counts the endpoints the library marks **finite** (``is_finite``, which
 applies the configured ``endpoint_finite_threshold``) and confirms the number of *distinct* such
-solutions equals the mathematically known cyclic-:math:`n` value.  (Counting *distinct* points
-matters: the total-degree homotopy can occasionally send two paths to the same solution, a harmless
-duplicate -- so we divide by each point's ``multiplicity``, the deterministic, meaningful count.)
+solutions equals the mathematically known cyclic-:math:`n` value.  We count *distinct* points by
+summing :math:`1/\text{multiplicity}` over the finite endpoints, so a genuine **multiple root** --
+several paths converging to one true solution of higher multiplicity -- is counted once, as it
+should be.  That is the only reason two endpoints should ever coincide.
+
+.. note::
+
+   Two *distinct* paths landing on the **same** point is a different matter entirely.  Because the
+   homotopy's :math:`\gamma` is random, distinct paths meeting is a probability-0 event: if it
+   happens it is a **path crossing** -- a sign the tracker under-resolved the paths -- not a benign
+   duplicate.  The solver checks for exactly this at the endgame boundary and re-tracks the
+   offending paths; with the default predictor and tolerances it essentially never triggers.  The
+   :doc:`crossed_paths` tutorial provokes one on purpose and shows what to do about it.
 
 .. _correctness-across-ranks:
 

--- a/python/docs/source/tutorials/tutorials.rst
+++ b/python/docs/source/tutorials/tutorials.rst
@@ -15,7 +15,7 @@
    user_product_of_linears
    real_points
    solving_at_scale
+   crossed_paths
    evaluation_cyclic
    tracking_nonsingular
    manual_endgame_usage
-

--- a/python/examples/crossed_paths.py
+++ b/python/examples/crossed_paths.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python
+"""Provoke a path crossing on purpose, and watch Bertini 2 detect and re-track it.
+
+Two *distinct* homotopy paths reaching the **same** point at the endgame boundary is a
+probability-0 event -- the homotopy's gamma is random, so generic paths never meet.  When it does
+happen it is a **path crossing**: a symptom that the tracker under-resolved the paths (most often a
+too-low-order predictor or a too-loose tolerance), not a benign duplicate.  The zero-dim solver
+checks for this at the endgame boundary and, by default, re-tracks the offending paths with
+tightened settings.
+
+To see the machinery work we deliberately break the tracking: the **Euler** predictor (order 1)
+with a **loose** pre-endgame tolerance, on the cyclic-5 system.  The fixed seed only makes the bad
+behaviour reproducible -- it is NOT the fix.  The fix is the solver's re-tracking (and, in normal
+use, the better default predictor / a tighter tolerance).
+
+Run it::
+
+    python crossed_paths.py            # uses a seed known to cross on the author's machine
+    python crossed_paths.py --seed 7   # try another seed
+
+Which seed crosses depends on platform numerics; if the chosen one does not cross, the script says
+so and suggests trying another.
+"""
+
+import argparse
+import numpy as np
+
+import bertini as pb
+
+CYCLIC_N = 5
+KNOWN_FINITE = 70            # distinct finite solutions of cyclic-5
+OK = int(pb.tracking.SuccessCode.Success)
+
+
+def cyclic_system(n):
+    """The cyclic-n system: the n-1 cyclic sums of products, plus (prod - 1)."""
+    x = [pb.Variable('x{}'.format(i)) for i in range(n)]
+    w = x + x
+    sys = pb.System()
+    for length in range(1, n):
+        sys.add_function(np.sum([np.prod(w[start:start + length]) for start in range(n)]))
+    sys.add_function(np.prod(x) - 1)
+    sys.add_variable_group(pb.VariableGroup(x))
+    return sys
+
+
+def solve(seed, resolve_attempts, tol=1e-4):
+    """Solve cyclic-5 with the Euler predictor + a loose tolerance at a fixed seed.
+
+    ``resolve_attempts`` is how many times the solver may re-track crossed paths at the endgame
+    boundary; 0 means "detect and report only".  Returns (report, distinct_finite_count).
+    """
+    pb.random.set_random_seed(seed)
+    solver = pb.nag_algorithm.ZeroDimCauchyDoublePrecisionTotalDegree(cyclic_system(CYCLIC_N))
+
+    # The deliberate culprit: a first-order predictor.
+    solver.get_tracker().predictor(pb.tracking.Predictor.Euler)
+
+    tols = solver.get_config(pb.nag_algorithm.TolerancesConfig)
+    tols.newton_before_endgame = tol
+    tols.newton_during_endgame = tol / 10
+    solver.set_config(tols)
+
+    zd = solver.get_config(pb.nag_algorithm.ZeroDimConfigDoublePrec)
+    zd.max_num_crossed_path_resolve_attempts = resolve_attempts
+    solver.set_config(zd)
+
+    solver.solve()
+
+    report = solver.endgame_boundary_metadata()
+    finite = [m for m in solver.solution_metadata()
+              if int(m.endgame_success) == OK and m.is_finite]
+    distinct = round(sum(1.0 / m.multiplicity for m in finite))
+    return report, distinct
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('--seed', type=int, default=3,
+                        help='RNG seed (default 3; chosen to cross on the author\'s machine)')
+    args = parser.parse_args()
+
+    # First, turn OFF re-tracking, so we can see the damage a crossing does on its own.
+    report, distinct = solve(args.seed, resolve_attempts=0)
+    print('Euler + loose tolerance, re-tracking DISABLED (max_num_crossed_path_resolve_attempts=0):')
+    print('  crossings detected : {}'.format(report.num_crossings_detected))
+    print('  crossed path indices: {}'.format(list(report.crossed_path_indices)))
+    print('  midpath check passed: {}'.format(report.passed))
+    print('  distinct finite solutions: {} / {}'.format(distinct, KNOWN_FINITE))
+
+    if report.num_crossings_detected == 0:
+        print('\nNo crossing was provoked at seed {} on this machine.  Try another --seed.'.format(args.seed))
+        return
+
+    print('\n  --> the crossed paths merged into one, so a true solution was lost'
+          if distinct < KNOWN_FINITE else
+          '\n  --> a crossing was detected (the endpoints happened to still be recoverable)')
+
+    # Now the default behaviour: re-track the crossed paths with tightened settings.
+    report, distinct = solve(args.seed, resolve_attempts=2)
+    print('\nSame solve, re-tracking ENABLED (the default):')
+    print('  crossings detected : {}'.format(report.num_crossings_detected))
+    print('  re-track attempts  : {}'.format(report.num_resolve_attempts))
+    print('  midpath check passed: {}'.format(report.passed))
+    print('  distinct finite solutions: {} / {}'.format(distinct, KNOWN_FINITE))
+
+    assert distinct == KNOWN_FINITE, \
+        'expected the re-track to recover all {} solutions'.format(KNOWN_FINITE)
+    print('\n  --> the crossing was resolved and the lost solution recovered.')
+    print('      The real lesson: use a higher-order predictor (the default RKF45) or a tighter')
+    print('      tolerance, and the crossing never happens in the first place.')
+
+
+if __name__ == '__main__':
+    main()

--- a/python/test/classes/clone_concatenate_test.py
+++ b/python/test/classes/clone_concatenate_test.py
@@ -1,0 +1,235 @@
+# This file is part of Bertini 2.
+#
+# python/test/classes/clone_concatenate_test.py is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later version.
+#
+# Bertini 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+# even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+#  Copyright(C) Bertini2 Development Team
+
+"""Tests for bertini.system.clone and bertini.system.concatenate.
+
+clone is a *serialization round-trip* deep copy (boost text-archive, see C++ ``Clone``), so it is
+the natural place for serialization bugs to surface -- the same round-trip the distributed solver
+uses to broadcast systems.  These tests check that a clone (and a concatenation) is not just
+structurally the right shape but *evaluates* identically -- functions AND Jacobian, with and without
+a path variable -- and is a genuinely independent deep copy.  Systems are now pickleable (a
+boost-archive round-trip, same machinery as clone), so copy.copy / copy.deepcopy / pickle round-trip
+a System too; those are exercised here alongside clone.
+"""
+
+import copy
+
+import numpy as np
+import pytest
+
+import bertini as pb
+from bertini import linalg
+
+
+TOL = 1e-12
+
+
+def _eval(s, pt, time=None):
+    return [complex(c) for c in (s.eval(pt) if time is None else s.eval(pt, time))]
+
+
+def _jac(s, pt, time=None):
+    s.differentiate()
+    j = s.eval_jacobian(pt) if time is None else s.eval_jacobian(pt, time)
+    # eval_jacobian returns a 1-D gradient for a single-function system and a 2-D matrix otherwise;
+    # ravel() flattens both.  Clone and original share a shape, so a flat compare is valid.
+    return [complex(z) for z in np.asarray(j).ravel()]
+
+
+def _assert_close(a, b, tol=TOL):
+    assert len(a) == len(b)
+    for u, v in zip(a, b):
+        assert abs(u - v) < tol, (u, v)
+
+
+# ----------------------------- clone: evaluation parity -----------------------------
+
+def test_clone_preserves_function_values():
+    x, y = pb.Variable('x'), pb.Variable('y')
+    s = pb.System()
+    s.add_variable_group(pb.VariableGroup([x, y]))
+    s.add_function(x * x + y * y - 1)
+    s.add_function(x * y - 2)
+
+    c = pb.system.clone(s)
+    assert c.num_functions() == 2 and c.num_variables() == 2
+
+    pt = np.array([complex(2.3, -1.1), complex(-0.7, 0.4)])
+    _assert_close(_eval(c, pt), _eval(s, pt))
+
+
+def test_clone_preserves_jacobian():
+    # The Jacobian is the fragile part of the round trip: C++ Clone re-derives derivatives
+    # (Differentiate()) because the serialized SLP's derivative outputs did not survive faithfully.
+    x, y = pb.Variable('x'), pb.Variable('y')
+    s = pb.System()
+    s.add_variable_group(pb.VariableGroup([x, y]))
+    s.add_function(x * x * y)
+    s.add_function(x - y * y)
+
+    c = pb.system.clone(s)
+    pt = np.array([complex(1.5, 0.3), complex(-2.0, 1.0)])
+    _assert_close(_jac(c, pt), _jac(s, pt))
+
+
+def test_clone_with_path_variable_preserves_eval_and_jacobian():
+    # A time-dependent system exercises the time-derivative path the C++ Clone comment specifically
+    # flags as having read stale memory after the round trip.
+    x, y, t = pb.Variable('x'), pb.Variable('y'), pb.Variable('t')
+    s = pb.System()
+    s.add_variable_group(pb.VariableGroup([x, y]))
+    s.add_path_variable(t)
+    s.add_function((1 - t) * (x * x + y * y - 1) + t * (x - y))
+
+    c = pb.system.clone(s)
+    assert c.have_path_variable()
+
+    sp = np.array([complex(2.0, 0.5), complex(3.0, -0.25)])
+    tm = complex(0.4, -0.2)
+    _assert_close(_eval(c, sp, tm), _eval(s, sp, tm))
+    _assert_close(_jac(c, sp, tm), _jac(s, sp, tm))
+
+
+def test_clone_of_linear_forms_block_preserves_eval_and_jacobian():
+    # A LinearFormsBlock (add_linear) is a structured evaluation block; it must survive the
+    # serialization round trip just like the products-of-linears block does.
+    x, y = pb.Variable('x'), pb.Variable('y')
+    s = pb.System()
+    s.add_variable_group(pb.VariableGroup([x, y]))
+    s.add_function(x * x + y * y - 1)
+    linalg.add_linear(s, np.array([[2, 1], [1, -3]]), np.array([x, y]), [-1, 4])
+
+    c = pb.system.clone(s)
+    assert list(c.degrees()) == list(s.degrees())
+
+    pt = np.array([complex(0.6, 0.2), complex(-0.9, 0.1)])
+    _assert_close(_eval(c, pt), _eval(s, pt))
+    _assert_close(_jac(c, pt), _jac(s, pt))
+
+
+def test_clone_of_homogenized_patched_preserves_eval():
+    x, y = pb.Variable('x'), pb.Variable('y')
+    s = pb.System()
+    s.add_variable_group(pb.VariableGroup([x, y]))
+    s.add_function(x * x + y * y - 1)
+    s.homogenize()
+    s.auto_patch()
+
+    c = pb.system.clone(s)
+    assert c.num_functions() == s.num_functions()
+    assert c.num_variables() == s.num_variables()
+
+    # one coordinate per (now 3) variables, on the patch is not required for a plain eval check
+    pt = np.array([complex(0.3, 0.1), complex(-0.5, 0.2), complex(0.8, -0.4)])
+    _assert_close(_eval(c, pt), _eval(s, pt))
+
+
+# ----------------------------- clone: independence (deep copy) -----------------------------
+
+def test_clone_is_independent_of_the_original():
+    x, y = pb.Variable('x'), pb.Variable('y')
+    s = pb.System()
+    s.add_variable_group(pb.VariableGroup([x, y]))
+    s.add_function(x * x + y * y - 1)
+
+    c = pb.system.clone(s)
+    pt = np.array([complex(2.0), complex(3.0)])
+    before = _eval(c, pt)
+
+    # mutate the original after cloning
+    s.add_function(x - y)
+    assert s.num_functions() == 2
+    assert c.num_functions() == 1, "clone must not see the original's new function"
+    _assert_close(_eval(c, pt), before)
+
+
+# ----------------------------- concatenate -----------------------------
+
+def _two_systems():
+    x, y = pb.Variable('x'), pb.Variable('y')
+    a = pb.System()
+    a.add_variable_group(pb.VariableGroup([x, y]))
+    a.add_function(x * x + y * y - 1)
+    b = pb.System()
+    b.add_variable_group(pb.VariableGroup([x, y]))
+    b.add_function(x - y)
+    b.add_function(x * y - 2)
+    return a, b
+
+
+def test_concatenate_appends_and_evaluates():
+    a, b = _two_systems()
+    u = pb.system.concatenate(a, b)
+    assert u.num_functions() == a.num_functions() + b.num_functions() == 3
+
+    pt = np.array([complex(2.0, 0.3), complex(-1.0, 0.5)])
+    _assert_close(_eval(u, pt), _eval(a, pt) + _eval(b, pt))
+
+
+def test_concatenate_is_independent_of_inputs():
+    a, b = _two_systems()
+    u = pb.system.concatenate(a, b)
+    pt = np.array([complex(1.0), complex(2.0)])
+    before = _eval(u, pt)
+
+    x = pb.Variable('x')
+    a.add_function(x)        # mutate an input after concatenating
+    assert u.num_functions() == 3, "concatenation must not see the input's new function"
+    _assert_close(_eval(u, pt), before)
+
+
+# ----------------------------- pickle / copy / deepcopy round-trip -----------------------------
+
+import pickle
+
+
+def _time_system():
+    x, y, t = pb.Variable('x'), pb.Variable('y'), pb.Variable('t')
+    s = pb.System()
+    s.add_variable_group(pb.VariableGroup([x, y]))
+    s.add_path_variable(t)
+    s.add_function((1 - t) * (x * x + y * y - 1) + t * (x - y))
+    return s
+
+
+@pytest.mark.parametrize("roundtrip", [
+    lambda s: pickle.loads(pickle.dumps(s)),
+    copy.copy,
+    copy.deepcopy,
+])
+def test_pickle_copy_deepcopy_preserve_eval_and_jacobian(roundtrip):
+    # System is pickleable (boost-archive round-trip), so copy.copy / copy.deepcopy / pickle all
+    # produce an independent System that evaluates identically -- functions and Jacobian, including
+    # the time-derivative path that the C++ Clone comment flags as fragile.
+    s = _time_system()
+    c = roundtrip(s)
+
+    sp = np.array([complex(2.0, 0.5), complex(3.0, -0.25)])
+    tm = complex(0.4, -0.2)
+    _assert_close(_eval(c, sp, tm), _eval(s, sp, tm))
+    _assert_close(_jac(c, sp, tm), _jac(s, sp, tm))
+
+
+def test_pickle_roundtrip_is_independent_of_the_original():
+    # A pickled-and-restored System must be a genuine deep copy, not an alias.
+    x, y = pb.Variable('x'), pb.Variable('y')
+    s = pb.System()
+    s.add_variable_group(pb.VariableGroup([x, y]))
+    s.add_function(x * x + y * y - 1)
+
+    c = pickle.loads(pickle.dumps(s))
+    pt = np.array([complex(2.0), complex(3.0)])
+    before = _eval(c, pt)
+
+    s.add_function(x - y)
+    assert c.num_functions() == 1, "restored System must not see the original's new function"
+    _assert_close(_eval(c, pt), before)

--- a/python/test/classes/pickle_test.py
+++ b/python/test/classes/pickle_test.py
@@ -1,0 +1,107 @@
+# This file is part of Bertini 2.
+#
+# python/test/classes/pickle_test.py is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free Software Foundation,
+# either version 3 of the License, or (at your option) any later version.
+#
+# Bertini 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+# even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+#  Copyright(C) Bertini2 Development Team
+
+"""Pickling support across the bound types.
+
+What is pickleable, and how:
+
+  * ``multiprec.Float`` / ``multiprec.Complex`` -- C++ boost-archive pickle suite (exact, every bit
+    of the mantissa survives -- see the precision-sensitive round-trip below);
+  * config structs (stepping, newton, tolerances, the zero-dim configs, ...) -- via their
+    ``to_dict``/``from_dict`` enhancement (``config.py``);
+  * Boost.Python enums (``SuccessCode``, ``Predictor``, ...) -- via a ``copyreg`` registration that
+    reconstructs the member from its int value (their built-in ``__reduce_ex__`` is broken);
+  * result metadata (``SolutionMetaData*``) -- enhanced like a config, and now round-trips because
+    its enum fields (e.g. ``endgame_success``) are pickleable.
+
+(System pickling lives in ``clone_concatenate_test.py``, next to the clone serialization tests.)
+"""
+
+import copy
+import pickle
+
+import pytest
+
+import bertini as pb
+import bertini.multiprec as mp
+
+
+# ----------------------------- numbers -----------------------------
+
+@pytest.mark.parametrize("precision", [30, 50, 80], indirect=True)
+def test_complex_pickles_exactly_at_high_precision(precision):
+    # The whole point of multiprecision: a float pickle that drops low bits is silently wrong.  Use
+    # a value with more significant digits than double can hold and demand exact equality.
+    z = mp.Complex("1.23456789012345678901234567890123456789",
+                   "-9.87654321098765432109876543210987654321")
+    assert pickle.loads(pickle.dumps(z)) == z
+    assert copy.deepcopy(z) == z
+
+
+@pytest.mark.parametrize("precision", [30, 50, 80], indirect=True)
+def test_float_pickles_exactly_at_high_precision(precision):
+    f = mp.Float("3.14159265358979323846264338327950288419716939937510")
+    assert pickle.loads(pickle.dumps(f)) == f
+    assert copy.deepcopy(f) == f
+
+
+# ----------------------------- enums -----------------------------
+
+@pytest.mark.parametrize("member", [
+    pb.tracking.SuccessCode.Success,
+    pb.tracking.SuccessCode.GoingToInfinity,
+    pb.tracking.Predictor.RK4,
+    pb.tracking.Predictor.Euler,
+])
+def test_enum_members_pickle(member):
+    r = pickle.loads(pickle.dumps(member))
+    assert r == member
+    assert int(r) == int(member)
+    assert type(r) is type(member)
+
+
+def test_enum_is_not_config_enhanced():
+    # Boost.Python enums subclass int; they must NOT be mistaken for config structs (that corrupts
+    # their repr and pickling).  The clean enum repr is the tell.
+    SC = pb.tracking.SuccessCode
+    assert not getattr(SC, "_b2_config_enhanced", False)
+    assert "SuccessCode.Success" in repr(SC.Success)
+
+
+# ----------------------------- config structs -----------------------------
+
+@pytest.mark.parametrize("cls", [
+    pb.tracking.SteppingConfig,
+    pb.tracking.NewtonConfig,
+    pb.tracking.AMPConfig,
+    pb.endgame.PowerSeriesConfig,
+])
+def test_config_struct_round_trips(cls):
+    cfg = cls()
+    r = pickle.loads(pickle.dumps(cfg))
+    assert r == cfg
+    assert copy.deepcopy(cfg) == cfg
+
+
+# ----------------------------- result metadata -----------------------------
+
+@pytest.mark.parametrize("cls", [
+    pb.nag_algorithm.SolutionMetaDataDoublePrec,
+    pb.nag_algorithm.SolutionMetaDataMultiPrec,
+])
+def test_solution_metadata_round_trips_including_enum_field(cls):
+    m = cls()
+    m.endgame_success = pb.tracking.SuccessCode.GoingToInfinity
+    m.condition_number = 12.5
+    r = pickle.loads(pickle.dumps(m))
+    assert r.endgame_success == m.endgame_success
+    assert r == m

--- a/python/test/parallel/test_mpi_zerodim.py
+++ b/python/test/parallel/test_mpi_zerodim.py
@@ -25,13 +25,19 @@ Tests are skipped automatically if mpi4py is not available.
 Run with: mpirun -n <N> python -m pytest python/test/parallel/test_mpi_zerodim.py -v
 """
 
+import numpy as np
 import pytest
 
 pytest.importorskip("mpi4py")
 
 from mpi4py import MPI
 import bertini as pb
-from bertini.nag_algorithm import ZeroDimCauchyAdaptivePrecisionTotalDegree
+from bertini.nag_algorithm import (
+    ZeroDimCauchyAdaptivePrecisionTotalDegree,
+    ZeroDimCauchyDoublePrecisionTotalDegree,
+)
+
+OK = int(pb.tracking.SuccessCode.Success)
 
 
 @pytest.fixture
@@ -43,6 +49,23 @@ def circle_intersection_solver():
     sys.add_function(x + y)
     sys.add_variable_group(pb.VariableGroup([x, y]))
     return ZeroDimCauchyAdaptivePrecisionTotalDegree(sys)
+
+
+def _cyclic_system(n):
+    x = [pb.Variable('x{}'.format(i)) for i in range(n)]
+    w = x + x
+    sys = pb.System()
+    for length in range(1, n):
+        sys.add_function(np.sum([np.prod(w[start:start + length]) for start in range(n)]))
+    sys.add_function(np.prod(x) - 1)
+    sys.add_variable_group(pb.VariableGroup(x))
+    return sys
+
+
+def _distinct_finite(solver):
+    finite = [m for m in solver.solution_metadata()
+              if int(m.endgame_success) == OK and m.is_finite]
+    return round(sum(1.0 / m.multiplicity for m in finite))
 
 
 def test_parallel_rank_size():
@@ -94,3 +117,44 @@ def test_serial_solve_works(circle_intersection_solver):
     if pb.parallel.is_manager():
         solns = solver.solutions()
         assert len(solns) == 2
+
+
+# Acceptance tests for the unified speculative-full-path model: a distributed solve must produce the
+# SAME correct answer as serial.  cyclic-5 has 70 distinct finite solutions; under `mpirun -n N` the
+# whole-path workers must recover exactly that count.  The adaptive-precision case is the one the old
+# two-phase model got wrong (the endgame resumed at double precision because Phase2 dropped the
+# boundary precision across the worker->manager->worker handoff) -- the whole-path model carries the
+# boundary precision in-memory, so it can no longer be lost.  Runs under plain pytest (serial) too,
+# where it confirms serial agrees.
+CYCLIC5_FINITE = 70
+
+
+def _solve_cyclic5(solver_cls):
+    pb.random.set_random_seed(2)
+    solver = solver_cls(_cyclic_system(5))
+    tol = solver.get_config(pb.nag_algorithm.TolerancesConfig)
+    tol.newton_before_endgame = 1e-7
+    tol.newton_during_endgame = 1e-8
+    solver.set_config(tol)
+    comm = MPI.COMM_WORLD
+    if comm.Get_size() > 1:
+        solver.solve(communicator=comm)
+    else:
+        solver.solve()
+    return solver
+
+
+def test_distributed_cyclic5_double_matches_known_count():
+    solver = _solve_cyclic5(ZeroDimCauchyDoublePrecisionTotalDegree)
+    if pb.parallel.is_manager():
+        assert len(solver.solutions()) == 120
+        assert _distinct_finite(solver) == CYCLIC5_FINITE
+
+
+def test_distributed_cyclic5_adaptive_matches_known_count():
+    # Guards the endgame-boundary precision-transfer fix: adaptive-precision distributed solve must
+    # recover all 70 finite solutions, not a precision-degraded subset.
+    solver = _solve_cyclic5(ZeroDimCauchyAdaptivePrecisionTotalDegree)
+    if pb.parallel.is_manager():
+        assert len(solver.solutions()) == 120
+        assert _distinct_finite(solver) == CYCLIC5_FINITE

--- a/python/test/zero_dim/crossed_paths_test.py
+++ b/python/test/zero_dim/crossed_paths_test.py
@@ -1,0 +1,116 @@
+"""Path-crossing detection and the endgame-boundary re-track machinery, at the Python layer.
+
+Two *distinct* paths landing on the same point at the endgame boundary is a probability-0 event:
+it is a path crossing (under-resolved tracking), which the zero-dim solver is supposed to detect
+and re-track.  Mirrors the C++ tests in ``core/test/nag_algorithms/zero_dim.cpp``; here we exercise
+the whole pipeline and the ``endgame_boundary_metadata`` report.
+
+To *provoke* a crossing we deliberately use the low-order Euler predictor with a loose pre-endgame
+tolerance on the cyclic-5 system -- the regime documented in ADR-0017.  The fixed seed only makes
+the bad behaviour reproducible; the *fix* is the solver's re-tracking (and, in real use, the better
+default predictor / tighter tolerance), never the seed (see ADR-0017).  Because exactly which seed
+crosses depends on platform numerics, the test searches a small range for one rather than hard-coding
+it.
+"""
+
+import numpy as np
+import pytest
+
+import bertini as pb
+from bertini.nag_algorithm import ZeroDimCauchyDoublePrecisionTotalDegree
+
+OK = int(pb.tracking.SuccessCode.Success)
+
+CYCLIC_N = 5
+KNOWN_FINITE = 70           # distinct finite solutions of cyclic-5
+LOOSE_TOL = 1e-4            # loose enough (with Euler) to occasionally cross a pair of paths
+SEEDS_TO_TRY = range(1, 13)
+
+
+def cyclic_system(n):
+    """The cyclic-n system: the n-1 cyclic sums of products, plus (prod - 1)."""
+    x = [pb.Variable('x{}'.format(i)) for i in range(n)]
+    w = x + x
+    sys = pb.System()
+    for length in range(1, n):
+        sys.add_function(np.sum([np.prod(w[start:start + length]) for start in range(n)]))
+    sys.add_function(np.prod(x) - 1)
+    sys.add_variable_group(pb.VariableGroup(x))
+    return sys
+
+
+def _solve(seed, resolve_attempts):
+    """Solve cyclic-5 with Euler + loose tolerance at a fixed seed.
+
+    Returns (report, distinct_finite_count).
+    """
+    pb.random.set_random_seed(seed)
+    solver = ZeroDimCauchyDoublePrecisionTotalDegree(cyclic_system(CYCLIC_N))
+
+    # Euler (order 1) is the root cause of the crossing we want to provoke.
+    solver.get_tracker().predictor(pb.tracking.Predictor.Euler)
+
+    tol = solver.get_config(pb.nag_algorithm.TolerancesConfig)
+    tol.newton_before_endgame = LOOSE_TOL
+    tol.newton_during_endgame = LOOSE_TOL / 10
+    solver.set_config(tol)
+
+    zd = solver.get_config(pb.nag_algorithm.ZeroDimConfigDoublePrec)
+    zd.max_num_crossed_path_resolve_attempts = resolve_attempts
+    solver.set_config(zd)
+
+    solver.solve()
+
+    report = solver.endgame_boundary_metadata()
+    finite = [m for m in solver.solution_metadata()
+              if int(m.endgame_success) == OK and m.is_finite]
+    distinct = round(sum(1.0 / m.multiplicity for m in finite))
+    return report, distinct
+
+
+def _find_crossing_seed():
+    """Find a seed whose report-only solve detects an (unresolved) crossing; skip if none."""
+    for seed in SEEDS_TO_TRY:
+        report, distinct = _solve(seed, resolve_attempts=0)
+        if report.num_crossings_detected > 0:
+            return seed, report, distinct
+    pytest.skip("no path crossing provoked in the searched seed range on this platform; "
+                "the detection/resolve logic is still covered by the deterministic C++ tests")
+
+
+@pytest.mark.timeout(360)  # several cyclic-5 Euler solves; loose Euler tracking is slow
+def test_crossing_is_detected_then_resolved():
+    """Report-only loses a solution to the crossing; re-tracking recovers it."""
+    seed, report_only, distinct_unresolved = _find_crossing_seed()
+
+    # With re-tracking disabled the crossing is detected but left unresolved, and the two merged
+    # paths cost us a solution: the distinct finite count comes up short.
+    assert not report_only.passed
+    assert report_only.num_resolve_attempts == 0
+    assert len(report_only.crossed_path_indices) == report_only.num_crossings_detected
+    assert distinct_unresolved < KNOWN_FINITE
+
+    # Re-enable the default re-tracking: the same crossing is detected, then resolved, and the lost
+    # solution is recovered -- the count is now exactly right.
+    resolved, distinct_resolved = _solve(seed, resolve_attempts=2)
+    assert resolved.num_crossings_detected > 0
+    assert resolved.num_resolve_attempts >= 1
+    assert resolved.passed
+    assert distinct_resolved == KNOWN_FINITE
+
+
+def test_clean_solve_reports_no_crossings():
+    """With the good default predictor and a sane tolerance, no crossing is detected."""
+    pb.random.set_random_seed(1)
+    solver = ZeroDimCauchyDoublePrecisionTotalDegree(cyclic_system(CYCLIC_N))
+    tol = solver.get_config(pb.nag_algorithm.TolerancesConfig)
+    tol.newton_before_endgame = 1e-6
+    tol.newton_during_endgame = 1e-7
+    solver.set_config(tol)
+    solver.solve()
+
+    report = solver.endgame_boundary_metadata()
+    assert report.passed
+    assert report.num_crossings_detected == 0
+    assert report.num_resolve_attempts == 0
+    assert len(solver.endgame_boundary_solutions()) > 0

--- a/python_bindings/include/zero_dim_export.hpp
+++ b/python_bindings/include/zero_dim_export.hpp
@@ -195,7 +195,8 @@ void ZDVisitor<AlgoT>::visit(PyClass& cl) const
 		return_internal_reference<>(),
 		"get the prepared target system: the homogenized, auto-patched clone of the system you supplied.  its patch is the one internal-coordinate solutions lie on; use its dehomogenize_point/homogenize_point/variable_ordering to move between representations.")
 	.def("solution_metadata", &AlgoT::FinalSolutionMetadata, return_internal_reference<>(), "get the metadata for the solutions at the target time")
-	.def("endgame_boundary_data", &AlgoT::EndgameBoundaryData, return_internal_reference<>(), "get the data for the state at the endgame boundary (when we switch from regular tracking to endgame tracking")
+	.def("endgame_boundary_solutions", &AlgoT::EndgameBoundarySolutions, return_internal_reference<>(), "get the solutions (per-path point data) at the endgame boundary, where regular tracking switches to the endgame")
+	.def("endgame_boundary_metadata", &AlgoT::EndgameBoundaryMetadata, return_internal_reference<>(), "get the MidpathCheckReport from the path-crossing check at the endgame boundary: how many crossings were detected, which paths, how many re-track attempts were made, and whether the check ultimately passed")
 	;
 }
 

--- a/python_bindings/include/zero_dim_export.hpp
+++ b/python_bindings/include/zero_dim_export.hpp
@@ -44,7 +44,7 @@
 #include <boost/python/stl_iterator.hpp>
 
 #ifdef BERTINI2_HAVE_MPI
-#include <mpi.h>
+#include "bertini2/parallel/mpi_include.hpp"
 #endif
 
 

--- a/python_bindings/src/mpfr_export.cpp
+++ b/python_bindings/src/mpfr_export.cpp
@@ -39,6 +39,10 @@
 
 #include "mpfr_export.hpp"
 
+#include <sstream>
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/archive/text_iarchive.hpp>
+
 
 
 namespace bertini{
@@ -375,11 +379,37 @@ namespace bertini{
 
 
 
+		// Pickle support backed by Boost.Serialization (defined for the mpfr backends in
+		// mpfr_extensions.hpp).  Captures value AND precision exactly, so the multiprecision numbers
+		// round-trip faithfully through pickle / copy / deepcopy.
+		template<typename T>
+		struct BoostArchivePickle : boost::python::pickle_suite
+		{
+			static boost::python::object getstate(T const& v)
+			{
+				std::ostringstream oss;
+				{
+					boost::archive::text_oarchive oa(oss);
+					oa << v;
+				}
+				return boost::python::str(oss.str());
+			}
+
+			static void setstate(T& v, boost::python::object state)
+			{
+				std::string s = boost::python::extract<std::string>(state)();
+				std::istringstream iss(s);
+				boost::archive::text_iarchive ia(iss);
+				ia >> v;
+			}
+		};
+
 		void ExposeFloat()
 		{
 			using T = mpfr_float;
 
 			class_<T>("Float", init<>("Default Construct a variable-precision float"))
+			.def_pickle(BoostArchivePickle<T>())
 			.def(init<std::string>((arg("self"),arg("val")),"Construct a variable-precision float from a string.  The best way."))
 			.def(init<long int>((arg("self"),arg("val")),"Construct a variable-precision float from a regular old integer."))
 			.def(init<T>((arg("self"),arg("val")),"Construct a variable-precision float from another."))
@@ -465,6 +495,7 @@ namespace bertini{
 			using T = bertini::mpfr_complex;
 
 			class_<T>("Complex", init<>())
+			.def_pickle(BoostArchivePickle<T>())
 			.def(init<double>((arg("self"),arg("real")),"Construct variable-precision complex number from a double, with 0 imaginary part. do this with caution, as 0.1 is not what you think it is -- there's noise at the end.")) // this should probably be made an explicit constructor rather than implicit
 			.def(init<mpfr_float>((arg("self"),arg("real")),"Construct variable-precision complex number from a variable-precision float, with 0 imaginary part"))
 			.def(init<std::string>((arg("self"),arg("real")),"Construct variable-precision complex number from a string, with 0 imaginary part"))

--- a/python_bindings/src/system_export.cpp
+++ b/python_bindings/src/system_export.cpp
@@ -35,7 +35,10 @@
 //  python/system_export.cpp:  Source file for exposing systems to python, including start systems.
 
 #include <stdio.h>
+#include <sstream>
 #include <boost/python/stl_iterator.hpp>
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/archive/text_iarchive.hpp>
 #include "system_export.hpp"
 
 
@@ -226,6 +229,44 @@ namespace bertini{
 				Simplify(sys);
 			};
 
+		// Pickle support for System, backed by the same Boost text-archive serialization that
+		// bertini::Clone and the MPI system-broadcast use.  setstate applies the same
+		// post-deserialize fixups as Clone: rebuild the SLP's derivatives (the archived SLP's
+		// derivative outputs do not round-trip faithfully) and normalize precision across the tree.
+		// This makes copy.copy / copy.deepcopy work and lets Systems cross process boundaries
+		// (multiprocessing).  As with clone, the result's variables are distinct node objects from
+		// the original's.
+		struct SystemPickleSuite : boost::python::pickle_suite
+		{
+			static boost::python::tuple getinitargs(System const&)
+			{
+				return boost::python::make_tuple();
+			}
+
+			static boost::python::object getstate(System const& sys)
+			{
+				std::ostringstream oss;
+				{
+					boost::archive::text_oarchive oa(oss);
+					oa << sys;
+				}
+				return boost::python::str(oss.str());
+			}
+
+			static void setstate(System& sys, boost::python::object state)
+			{
+				std::string s = boost::python::extract<std::string>(state)();
+				std::istringstream iss(s);
+				{
+					boost::archive::text_iarchive ia(iss);
+					ia >> sys;
+				}
+				if (sys.GetEvalMethod() == EvalMethod::SLP)
+					sys.Differentiate();
+				sys.precision(sys.precision());
+			}
+		};
+
 		void ExportSystem()
 		{
 			
@@ -233,6 +274,7 @@ namespace bertini{
 		class_<System, std::shared_ptr<System> >("System", "The type in Bertini for systems of simultaneous equations.  Add functions and variable groups via member functions.", init<>())
 			.def(init< std::vector<std::shared_ptr<node::Function>> >((arg("functions")), "Construct a System from a list of functions.  The variables are auto-discovered from the functions and placed into a single affine variable group, ordered alphabetically by name."))
 			.def(SystemVisitor<System>())
+			.def_pickle(SystemPickleSuite())
 			;
 
 			// free functions

--- a/python_bindings/src/zero_dim_configs_export.cpp
+++ b/python_bindings/src/zero_dim_configs_export.cpp
@@ -86,6 +86,9 @@ namespace bertini{
 				"The time value the homotopy tracks to (where the solutions of interest live).")
 			.def_readwrite("endgame_boundary", &ZeroDimConfig<dbl_complex>::endgame_boundary,
 				"The time value at which tracking stops and the endgame takes over.")
+			.def_readwrite("max_num_crossed_path_resolve_attempts", &ZeroDimConfig<dbl_complex>::max_num_crossed_path_resolve_attempts,
+				"How many times to re-track crossed paths (with tightened settings) at the endgame "
+				"boundary before giving up. 0 = detect and report only, do not re-track. Default 2.")
 			;
 
 			class_<ZeroDimConfig<mpfr_complex>>("ZeroDimConfigMultiprec", init<>())
@@ -95,6 +98,9 @@ namespace bertini{
 				"The time value the homotopy tracks to (where the solutions of interest live).")
 			.def_readwrite("endgame_boundary", &ZeroDimConfig<mpfr_complex>::endgame_boundary,
 				"The time value at which tracking stops and the endgame takes over.")
+			.def_readwrite("max_num_crossed_path_resolve_attempts", &ZeroDimConfig<mpfr_complex>::max_num_crossed_path_resolve_attempts,
+				"How many times to re-track crossed paths (with tightened settings) at the endgame "
+				"boundary before giving up. 0 = detect and report only, do not re-track. Default 2.")
 			;
 
 			// metadata types
@@ -111,6 +117,24 @@ namespace bertini{
 
 			ExposeEndgameBoundaryMetaData<mpfr_complex>("EndgameBoundaryMetaDataMultiPrec");
 			ExposeEndgameBoundaryMetaData<dbl_complex>("EndgameBoundaryMetaDataDoublePrec");
+
+			// Report from the path-crossing (midpath) check at the endgame boundary.
+			class_<MidpathCheckReport>("MidpathCheckReport", init<>())
+			.def_readonly("passed", &MidpathCheckReport::passed,
+				"Did the final midpath check pass (no path crossings remained)?  False means one or "
+				"more crossings were left unresolved and the affected solutions may be wrong.")
+			.def_readonly("num_crossings_detected", &MidpathCheckReport::num_crossings_detected,
+				"Number of crossed paths found on the FIRST check, before any re-tracking.")
+			.def_readonly("num_resolve_attempts", &MidpathCheckReport::num_resolve_attempts,
+				"How many re-track attempts were actually performed.")
+			.add_property("crossed_path_indices",
+				+[](MidpathCheckReport const& r){
+					boost::python::list out;
+					for (auto i : r.crossed_path_indices) out.append(i);
+					return out;
+				},
+				"Indices of the paths flagged as crossed on the first check.")
+			;
 		}
 
 }} // namespaces


### PR DESCRIPTION
Continues `develop` (rebased on the just-merged docs PR #20). One branch, several self-contained threads.

## 1. Crossed paths are detected and re-tracked
Two distinct paths landing on the same point at the endgame boundary is a probability-0 event — a **path crossing**, not a benign duplicate. Two bugs meant the machinery never actually re-tracked them:
- `MidpathChecker` computed `same_start` with an inverted comparison, so genuine crossings were flagged "don't rerun".
- `Check()` never reset its state between calls, so the resolve loop ran on stale data.

Fixed both; `EGBoundaryAction` now re-tracks crossed paths with an escalation (tighter tolerance + bump a low-order predictor), bounded by `max_num_crossed_path_resolve_attempts` (`0` = detect-and-report). Exposed a `MidpathCheckReport` via `endgame_boundary_metadata`. New `crossed_paths` tutorial + `examples/crossed_paths.py` + test; rewrote the "harmless duplicate" narrative in `solving_at_scale`. **ADR-0022.**

## 2. ZeroDim parallelism redesign (speculative full-path)
Replaced the two-phase, barrier-separated distributed solve with a model where **one worker executes a whole path** (pre-endgame + endgame) and returns one `FullPathResult`; the manager detects crossings from the collected boundary points and **re-dispatches crossed paths to the same worker pool** (the re-track is now parallel — no idle-manager bottleneck). This **designs out** a precision-transfer bug (the old Phase-2 handoff dropped the boundary precision, so adaptive-precision distributed solves silently diverged — cyclic-5 returned a degraded subset; now it recovers all 70). Unifies serial and distributed onto one per-path primitive; collapses the MPI task/result/thread-state structs. **ADR-0023.**

## 3. Serial == distributed reproducibility
Chased the AMP serial-vs-distributed divergence input by input:
- **Authoritative π** via `mpfr_const_pi`, not `acos(-1)` (#156).
- **Broadcast rank 0's actual systems** (Boost-serialized, exact) instead of per-rank seed re-derivation.
- **Rank 0 computes & ships start points** (the only transcendental input); precision settable to carry forward across chained solves.
- **Condition-number probe** refreshed once per path (it was drawn at an uncontrolled RNG point). **ADR-0024.**

Result: distributed finite solutions are **bit-identical** to serial (double and adaptive). A residual remains only on deeply-singular paths' precision usage (finite answer correct in both); deferred to a future predict/correct rewrite (ADR-0024).

## 4. MPI build portability
`<mpi.h>` from C++ pulls the deprecated `MPI::` C++ bindings, which MPICH compiles in and which fail under clang (Homebrew MPICH failed; OpenMPI was fine). Define `MPICH_SKIP_MPICXX`/`OMPI_SKIP_MPICXX` (CMake + a guard header routing all `<mpi.h>` includes). *Not reproducible on the dev VM (conda MPICH lacks the bindings; system MPICH header-less), so unverified against the specific failure but the standard remedy.*

## 5. Docs
New pages for previously-undocumented user-facing submodules (`random`, `sympy_bridge`, `config`); underscored `config`'s internal enhancement machinery so it drops out of the public surface; fixed 3 napoleon warnings. Docs build with zero warnings.

## 6. Pickling across the bound types
A user reported `copy.deepcopy` of a `System` failing, while investigating `clone`/`concatenate` (both serialization-backed). Enabled pickling — and therefore `copy.copy`/`copy.deepcopy` and crossing process boundaries — for:
- **`System`** — a Boost text-archive `pickle_suite`, the same machinery as `Clone` and the MPI system-broadcast (with Clone's post-deserialize fixups: rebuild SLP derivatives, normalize precision).
- **`multiprec.Float` / `multiprec.Complex`** — a Boost-archive `pickle_suite` capturing value **and** precision, so the numbers round-trip *exactly* (verified at 30/50/80 digits).
- **config structs** — wired their `to_dict`/`from_dict` enhancement to `__reduce__`.
- **Boost.Python enums** (`SuccessCode`, `Predictor`) — via a `copyreg` registration reconstructing the member from its int value.
- **result metadata** (`SolutionMetaData*`) — now round-trips, since its enum fields are pickleable.

Added `clone_concatenate_test.py` (clone/concatenate eval + Jacobian parity, deep-copy independence) and `pickle_test.py`. Still deferred (larger scope): `function_tree` nodes and `MidpathCheckReport`.

## Bugs fixed
1. **`MidpathChecker::same_start` inverted comparison** — genuine path crossings were flagged "don't rerun", so crossed paths were never re-tracked. (Thread 1)
2. **`MidpathChecker::Check()` did not reset state** between calls — the crossed-path resolve loop ran on stale data. (Thread 1)
3. **Distributed AMP precision-transfer bug** — the two-phase Phase-2 handoff dropped the boundary precision, so adaptive-precision distributed solves resumed the endgame at double precision and silently diverged (cyclic-5 returned a degraded subset). Designed out by the speculative-full-path model. (Thread 2)
4. **Non-reproducible π** — `acos(-1)` instead of the authoritative `mpfr_const_pi`, a source of serial/distributed divergence. (#156, Thread 3)
5. **Per-rank system re-derivation drift** — workers re-derived the homotopy from a seed instead of receiving rank 0's exact, serialized systems. (Thread 3)
6. **Condition-number probe drawn at an uncontrolled RNG point** — perturbed reproducibility; now refreshed deterministically once per path. (Thread 3)
7. **MPI build failure under MPICH + clang** — `<mpi.h>` pulled the deprecated `MPI::` C++ bindings; skipped via `MPICH_SKIP_MPICXX`/`OMPI_SKIP_MPICXX`. (Thread 4)
8. **Boost.Python enums wrongly config-enhanced** — enums subclass `int`, so the enhancement layer mistook int's read-only `real`/`imag`/`numerator`/`denominator` descriptors (and the enum's `name`) for writable config fields, corrupting every enum's `repr`. Excluded via an `issubclass(cls, int)` guard. (Thread 6)
9. **`System` copy/deepcopy and number/enum pickling were unsupported** — Boost's default "pickling not enabled" (and the enums' broken built-in `__reduce_ex__`). Now enabled. (Thread 6)

## Testing
C++ (`test_classes`/`test_tracking_basics`/`test_endgames`/`test_nag_algorithms`), the full serial Python suite (**396 passed**, incl. `zero_dim`, `clone_concatenate_test`, `pickle_test`), and 6 MPI `test_mpi_zerodim` (under `mpirun -n 3`) all pass. MPI **scaling** is not measurable on the dev VM (broken hwloc topology → oversubscription); the `solving_at_scale` timing tables are left for a real-hardware refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
