### PR TITLE
Config UX: string-valued fields, owner.update(**fields) router, get/set_settings carry; slice_ rename + ZeroDimConfig de-template

### DIFF
--- a/core/include/bertini2/blackbox/global_configs.hpp
+++ b/core/include/bertini2/blackbox/global_configs.hpp
@@ -58,7 +58,7 @@ struct Configs
 	using Endgame = detail::TypeList<SecurityConfig, EndgameConfig, PowerSeriesConfig, CauchyConfig, TrackBackConfig>;
 
 	template<typename T>
-	using Algorithm = detail::TypeList<TolerancesConfig, MidPathConfig, AutoRetrackConfig, SharpeningConfig, RegenerationConfig, PostProcessingConfig, ZeroDimConfig<T>, classic::AlgoChoice, classic::EndgameChoiceConfig, RandomConfig>;
+	using Algorithm = detail::TypeList<TolerancesConfig, MidPathConfig, AutoRetrackConfig, SharpeningConfig, RegenerationConfig, PostProcessingConfig, ZeroDimConfig, classic::AlgoChoice, classic::EndgameChoiceConfig, RandomConfig>;
 
 	template<typename T>
 	using All = detail::ListCat<Tracking, Endgame, Algorithm<T>>;

--- a/core/include/bertini2/io/parsing/settings_parsers/algorithm.hpp
+++ b/core/include/bertini2/io/parsing/settings_parsers/algorithm.hpp
@@ -600,15 +600,15 @@ namespace bertini {
 															 }, _val, _1 )]
 								   ^ slice_before_[phx::bind( [this](algorithm::RegenerationConfig & S, T num)
 															 {
-																 S.newton_before_endgame = num;
+																 S.slice_newton_before_endgame = num;
 															 }, _val, _1 )]
 								   ^ slice_during_[phx::bind( [this](algorithm::RegenerationConfig & S, T num)
 															 {
-																 S.newton_during_endgame = num;
+																 S.slice_newton_during_endgame = num;
 															 }, _val, _1 )]
 								   ^ slice_final_[phx::bind( [this](algorithm::RegenerationConfig & S, T num)
 															 {
-																 S.final_tolerance = num;
+																 S.slice_final_tolerance = num;
 															 }, _val, _1 )]
 								   )
 								  >> -no_setting_) | no_setting_;

--- a/core/include/bertini2/io/parsing/settings_parsers/algorithm.hpp
+++ b/core/include/bertini2/io/parsing/settings_parsers/algorithm.hpp
@@ -163,8 +163,8 @@ namespace bertini {
 			
 			
 
-			template<typename Iterator, typename ComplexT, typename Skipper> 
-			struct ConfigSettingParser<Iterator, algorithm::ZeroDimConfig<ComplexT>, Skipper> : qi::grammar<Iterator, algorithm::ZeroDimConfig<ComplexT>(), Skipper>
+			template<typename Iterator, typename Skipper>
+			struct ConfigSettingParser<Iterator, algorithm::ZeroDimConfig, Skipper> : qi::grammar<Iterator, algorithm::ZeroDimConfig(), Skipper>
 			{
 
 				ConfigSettingParser() : ConfigSettingParser::base_type(root_rule_, "algorithm::ZeroDimConfig")
@@ -195,27 +195,27 @@ namespace bertini {
 
 					root_rule_.name("config::ZeroDim");
 					
-					root_rule_ = ((init_prec_[phx::bind( [this](algorithm::ZeroDimConfig<ComplexT> & S, int num)
+					root_rule_ = ((init_prec_[phx::bind( [this](algorithm::ZeroDimConfig & S, int num)
 														   {
 															   S.initial_ambient_precision = num;
 														   }, _val, _1 )]
-								   ^ path_variable_name_[phx::bind( [this](algorithm::ZeroDimConfig<ComplexT> & S, std::string omnom)
+								   ^ path_variable_name_[phx::bind( [this](algorithm::ZeroDimConfig & S, std::string omnom)
 															 {
 																 S.path_variable_name = omnom;
 															 }, _val, _1 )]
-								   ^ max_cross_resolve_[phx::bind( [this](algorithm::ZeroDimConfig<ComplexT> & S, int num)
+								   ^ max_cross_resolve_[phx::bind( [this](algorithm::ZeroDimConfig & S, int num)
 															 {
 																 S.max_num_crossed_path_resolve_attempts = num;
 															 }, _val, _1 )]
-								   ^ start_time_[phx::bind( [this](algorithm::ZeroDimConfig<ComplexT> & S, ComplexT num)
+								   ^ start_time_[phx::bind( [this](algorithm::ZeroDimConfig & S, mpq_rational num)
 															 {
 																 S.start_time = num;
 															 }, _val, _1 )]
-								   ^ endgame_boundary_[phx::bind( [this](algorithm::ZeroDimConfig<ComplexT> & S, ComplexT num)
+								   ^ endgame_boundary_[phx::bind( [this](algorithm::ZeroDimConfig & S, mpq_rational num)
 															 {
 																 S.endgame_boundary = num;
 															 }, _val, _1 )]
-								   ^ target_time_[phx::bind( [this](algorithm::ZeroDimConfig<ComplexT> & S, ComplexT num)
+								   ^ target_time_[phx::bind( [this](algorithm::ZeroDimConfig & S, mpq_rational num)
 															 {
 																 S.target_time = num;
 															 }, _val, _1 )]
@@ -231,9 +231,11 @@ namespace bertini {
 								 ;
 					
 
-					auto str_to_ComplexT = [this](ComplexT & num, std::string str)
+					// The times are stored as exact, precision-free mpq_rational.  Parse the number
+					// string to a multiprecision real, then to a rational (the homotopy times are real).
+					auto str_to_rational = [this](mpq_rational & num, std::string str)
 									   {
-										   num = bertini::NumTraits<ComplexT>::FromString(str);
+										   num = mpq_rational(mpfr_float(str));
 									   };
 
 
@@ -253,15 +255,15 @@ namespace bertini {
 
 					start_time_.name("start_time_");
 					start_time_ = *(char_ - all_names_) >> (no_case[start_time_name] >> ':')
-					>> mpfr_rules.number_string_[phx::bind( str_to_ComplexT, _val, _1 )] >> ';';
+					>> mpfr_rules.number_string_[phx::bind( str_to_rational, _val, _1 )] >> ';';
 
 					endgame_boundary_.name("endgame_boundary_");
 					endgame_boundary_ = *(char_ - all_names_) >> (no_case[endgame_boundary_name] >> ':')
-					>> mpfr_rules.number_string_[phx::bind( str_to_ComplexT, _val, _1 )] >> ';';
+					>> mpfr_rules.number_string_[phx::bind( str_to_rational, _val, _1 )] >> ';';
 
 					target_time_.name("target_time_");
 					target_time_ = *(char_ - all_names_) >> (no_case[target_time_name] >> ':')
-					>> mpfr_rules.number_string_[phx::bind( str_to_ComplexT, _val, _1 )] >> ';';
+					>> mpfr_rules.number_string_[phx::bind( str_to_rational, _val, _1 )] >> ';';
 
 
 
@@ -285,9 +287,9 @@ namespace bertini {
 				
 				
 			private:
-				qi::rule<Iterator, algorithm::ZeroDimConfig<ComplexT>(), ascii::space_type > root_rule_;
+				qi::rule<Iterator, algorithm::ZeroDimConfig(), ascii::space_type > root_rule_;
 
-				qi::rule<Iterator, ComplexT(), ascii::space_type > start_time_, target_time_, endgame_boundary_;
+				qi::rule<Iterator, mpq_rational(), ascii::space_type > start_time_, target_time_, endgame_boundary_;
 				qi::rule<Iterator, int(), ascii::space_type > init_prec_, max_cross_resolve_;
 				qi::rule<Iterator, std::string(), ascii::space_type > valid_variable_name_, path_variable_name_;
 				

--- a/core/include/bertini2/nag_algorithms/common/config.hpp
+++ b/core/include/bertini2/nag_algorithms/common/config.hpp
@@ -123,9 +123,14 @@ struct RegenerationConfig
 
 	bool higher_dimension_check = true; ///< RegenHigherDimTest
 	unsigned start_level = 0;
-	T newton_before_endgame; ///< The tolerance for tracking before reaching the endgame.  SliceTolBeforeEG
-	T newton_during_endgame; ///< The tolerance for tracking during the endgame.  SliceTolDuringEG
-	T final_tolerance; ///< The final tolerance to track to, using the endgame.  SliceFinalTol
+	// These are the SLICE-moving tracking tolerances (Bertini 1's SliceTol* family) -- the tolerances
+	// for moving the linear slices during regeneration, kept separate from the main tracking
+	// tolerances in TolerancesConfig.  The slice_ prefix makes every config field name unique across
+	// structs, which is what lets a field be set on an owner without naming its struct
+	// (owner.update(field=...) routes by field).
+	T slice_newton_before_endgame; ///< Slice-moving tracking tolerance before the endgame.  SliceTolBeforeEG
+	T slice_newton_during_endgame; ///< Slice-moving tracking tolerance during the endgame.  SliceTolDuringEG
+	T slice_final_tolerance; ///< Final tolerance to track the slice move to, using the endgame.  SliceFinalTol
 };
 
 

--- a/core/include/bertini2/nag_algorithms/common/config.hpp
+++ b/core/include/bertini2/nag_algorithms/common/config.hpp
@@ -165,15 +165,25 @@ inline unsigned DefaultInitialAmbientPrecision()
 		return DefaultPrecision();
 }
 
-template<typename ComplexT>
+// Not templated on the complex type: the three times are stored as exact, precision-free
+// mpq_rational (real) and converted to the tracking complex type at the current working precision at
+// use -- the same pattern SteppingConfig uses for its step sizes.  This keeps the config precision-
+// agnostic (one struct, not a DoublePrec/Multiprec pair), and is in fact more correct under adaptive
+// precision: a value like the endgame boundary 1/10 is materialized at full working precision rather
+// than frozen at whatever precision the config happened to be constructed at.
+//
+// The times are real because a zero-dim solve tracks along the real t-axis (1 -> 0).  Complex
+// homotopy times remain available at the endgame level (set directly), just not through this config.
 struct ZeroDimConfig
 {
-	unsigned initial_ambient_precision = DefaultInitialAmbientPrecision<ComplexT>();
+	// Per-complex-type default; the ZeroDim algorithm overwrites this in DefaultSettingsSetup with
+	// DefaultInitialAmbientPrecision<BaseComplexT>() (it knows its tracking type, this struct does not).
+	unsigned initial_ambient_precision = DefaultPrecision();
 	unsigned max_num_crossed_path_resolve_attempts = 2; ///< The maximum number of times to attempt to re-solve crossed paths at the endgame boundary.
 
-	ComplexT start_time = ComplexT(1);
-	ComplexT endgame_boundary = ComplexT(1)/ComplexT(10);
-	ComplexT target_time = ComplexT(0);
+	mpq_rational start_time{1};          ///< Homotopy start time (t=1).
+	mpq_rational endgame_boundary{1, 10}; ///< Time at which tracking hands off to the endgame (t=1/10).
+	mpq_rational target_time{0};         ///< Homotopy target time (t=0).
 
 	std::string path_variable_name = "ZERO_DIM_PATH_VARIABLE";
 };

--- a/core/include/bertini2/nag_algorithms/zero_dim_solve.hpp
+++ b/core/include/bertini2/nag_algorithms/zero_dim_solve.hpp
@@ -80,7 +80,7 @@ struct AlgoTraits <ZeroDim<TrackerType, EndgameType, SystemType, StartSystemType
 	using NeededConfigs = detail::TypeList<
 								TolerancesConfig,
 								PostProcessingConfig,
-								ZeroDimConfig<BaseComplexT>,
+								ZeroDimConfig,
 								AutoRetrackConfig
 								>;
 };
@@ -434,7 +434,7 @@ std::ostream& operator<<(std::ostream & out, const SolveReport & r)
 
 			using Tolerances = TolerancesConfig;
 			using PostProcessing = PostProcessingConfig;
-			using ZeroDimConf = ZeroDimConfig<BaseComplexT>;
+			using ZeroDimConf = ZeroDimConfig;
 			using AutoRetrack = AutoRetrackConfig;
 
 
@@ -743,7 +743,11 @@ std::ostream& operator<<(std::ostream & out, const SolveReport & r)
 
 				this->template Set<Tolerances>(Tolerances());
 				this->template Set<PostProcessing>(PostProcessing());
-				this->template Set<ZeroDimConf>(ZeroDimConf());
+				// ZeroDimConfig is not templated on the complex type, so it cannot pick its own
+				// per-type ambient-precision default.  Set it here, where the tracking type is known.
+				ZeroDimConf zdc;
+				zdc.initial_ambient_precision = DefaultInitialAmbientPrecision<BaseComplexT>();
+				this->template Set<ZeroDimConf>(zdc);
 				this->template Set<AutoRetrack>(AutoRetrack());
 			}
 
@@ -1201,8 +1205,10 @@ std::ostream& operator<<(std::ostream & out, const SolveReport & r)
 				// direction persists start to finish.
 				ctx.tracker.RefreshConditionDirection();
 
-				auto t_start            = this->template Get<ZeroDimConf>().start_time;
-				auto t_endgame_boundary = this->template Get<ZeroDimConf>().endgame_boundary;
+				// The times are stored precision-free (mpq_rational); materialize them as the tracking
+				// complex type at the current working precision.
+				BaseComplexT t_start           ( BaseRealT(this->template Get<ZeroDimConf>().start_time) );
+				BaseComplexT t_endgame_boundary( BaseRealT(this->template Get<ZeroDimConf>().endgame_boundary) );
 
 				// The start point is supplied by the caller (computed once, authoritatively, via
 				// ComputeStartPoint) rather than regenerated here.  In a distributed solve rank 0
@@ -1413,8 +1419,8 @@ std::ostream& operator<<(std::ostream & out, const SolveReport & r)
 				auto start_prec = solutions_at_endgame_boundary_[soln_ind].precision;
 				SetThreadPrecision(start_prec);
 
-				ctx.endgame.SetBoundaryTime(this->template Get<ZeroDimConf>().endgame_boundary);
-				ctx.endgame.SetTargetTime  (this->template Get<ZeroDimConf>().target_time);
+				ctx.endgame.SetBoundaryTime(BaseComplexT(BaseRealT(this->template Get<ZeroDimConf>().endgame_boundary)));
+				ctx.endgame.SetTargetTime  (BaseComplexT(BaseRealT(this->template Get<ZeroDimConf>().target_time)));
 
 				auto eg_success = ctx.endgame.Run(bdry_point);
 

--- a/python/bertini/config.py
+++ b/python/bertini/config.py
@@ -357,12 +357,67 @@ def config_names(self):
     return sorted({config_key(c) for c in self.config_types() if c is not None})
 
 
+def _field_owners(owner):
+    """Map {field_name: config_class} across all of this owner's configs, plus any collisions.
+
+    Field names are unique across an owner's configs (the RegenerationConfig slice_ rename and the
+    ZeroDimConfig de-template removed the only collisions), so each field routes to exactly one
+    config.  Collisions, if ever reintroduced, are reported so update() can refuse them rather than
+    silently pick one.
+    """
+    owners = {}
+    collisions = {}
+    for cls in owner.config_types():
+        if cls is None:
+            continue
+        for f in writable_fields(cls):
+            if f in owners and owners[f] is not cls:
+                collisions.setdefault(f, {owners[f]})
+                collisions[f].add(cls)
+            owners[f] = cls
+    return owners, collisions
+
+
+def update(self, **fields):
+    """Set config fields on this owner by NAME, each routed to whichever config owns it.
+
+    You never name the config struct::
+
+        solver.update(final_tolerance="1e-11",          # -> TolerancesConfig
+                      max_num_crossed_path_resolve_attempts=3)   # -> ZeroDimConfig
+
+    Strings work for every numeric field (converted exactly).  A field that none of this owner's
+    configs has raises AttributeError with the valid names -- so a typo, or trying to set a tracker
+    field on the algorithm (or vice versa), never silently does nothing.  Returns self, so calls
+    chain.  To set a whole config at once, or to name the config explicitly, use configure().
+    """
+    owners, collisions = _field_owners(self)
+    by_config = {}
+    for key, value in fields.items():
+        if key in collisions:
+            raise AttributeError(
+                "config field {0!r} is ambiguous on {1} (in {2}); set it with configure() naming "
+                "the config".format(key, type(self).__name__,
+                                    sorted(c.__name__ for c in collisions[key])))
+        cls = owners.get(key)
+        if cls is None:
+            raise AttributeError(
+                "{0} has no config field {1!r}; valid fields: {2}".format(
+                    type(self).__name__, key, sorted(owners)))
+        by_config.setdefault(cls, {})[key] = value
+    # one get/update/set per touched config, not per field
+    for cls, kv in by_config.items():
+        self.set_config(self.get_config(cls).update(**kv))
+    return self
+
+
 def _enhance_owner_class(cls):
     """Attach configure()/config_names() to a tracker/algorithm class (idempotent)."""
     if getattr(cls, "_b2_owner_enhanced", False):
         return cls
     cls.configure = configure
     cls.config_names = config_names
+    cls.update = update
     cls._b2_owner_enhanced = True
     return cls
 

--- a/python/bertini/config.py
+++ b/python/bertini/config.py
@@ -95,20 +95,43 @@ def config_key(cls):
 # ---------------------------------------------------------------------------
 
 def _coerced_setattr(obj, key, value):
-    """setattr, retrying strings as multiprecision Floats.
+    """setattr, retrying a string as the field's numeric type.
 
     Strings are the blessed noise-free way to express numeric settings
-    (e.g. max_step_size="0.05"); plain Python floats stay rejected by policy,
-    since 0.05 the double is not 1/20.  Coercion is retry-on-failure so any
-    genuinely string-valued field is unaffected.
+    (e.g. max_step_size="0.05", final_tolerance="1e-11"); plain Python floats
+    stay rejected for the *exact* fields by policy, since 0.05 the double is not
+    1/20.  The catch is that the fields have different underlying types:
+    mpq_rational / mpfr_float fields (step sizes, factors) take a multiprecision
+    Float, while NumErrorT / double fields (tolerances, AMP bounds, min_step_size)
+    take a plain double, and integer-count fields take an int.  So one string
+    spelling works for EVERY field: we try it as an exact Float first, then as a
+    plain float, then as an int, and keep the first that the field accepts.
+
+    Coercion only happens for strings (a non-string that the field rejects raises
+    straight through), so the float-rejection policy on the exact fields stands:
+    passing the double 0.05 to max_step_size is still an error.
     """
     try:
         setattr(obj, key, value)
-    except TypeError:
+        return
+    except TypeError:                       # Boost.Python.ArgumentError is a TypeError
         if not isinstance(value, str):
             raise
-        from .multiprec import Float
-        setattr(obj, key, Float(value))
+
+    from .multiprec import Float
+    last_error = None
+    for convert in (Float, float, int):
+        try:
+            converted = convert(value)      # e.g. int("1e-7") is a ValueError -- skip it
+        except (ValueError, TypeError):
+            continue
+        try:
+            setattr(obj, key, converted)
+            return
+        except TypeError as e:              # field rejected this representation; try the next
+            last_error = e
+    raise last_error if last_error is not None else TypeError(
+        "could not set {0!r} to {1!r}".format(key, value))
 
 
 def _make_update(fields):

--- a/python/bertini/config.py
+++ b/python/bertini/config.py
@@ -411,6 +411,53 @@ def update(self, **fields):
     return self
 
 
+def get_settings(self):
+    """This owner's whole configuration as a carryable dict ``{config_name: config}``.
+
+    Each value is a copy of one of the owner's configs (e.g. ``{'stepping': SteppingConfig(...),
+    'tolerances': TolerancesConfig(...)}``), keyed by the same short names config_names() lists.  The
+    configs are independent copies (and picklable), so the dict is a plain Python value you can stash,
+    tweak, and apply to other owners -- the way to carry one set of tracking settings across a series
+    of related solves::
+
+        settings = first_solver.get_settings()
+        next_solver.set_settings(settings)
+
+    See set_settings() for applying one back.
+    """
+    return {config_key(cls): self.get_config(cls)
+            for cls in self.config_types() if cls is not None}
+
+
+def set_settings(self, settings, strict=False):
+    """Apply a settings dict (from get_settings()) onto this owner.  Returns self.
+
+    ``settings`` is ``{config_name: config}`` (or ``{config_name: {field: value}}``).  By default only
+    the configs this owner actually has are applied and the rest are skipped -- so a bundle carried
+    from one solver drops cleanly onto another whose config set differs (e.g. a different precision
+    model, or a different algorithm stage).  Pass ``strict=True`` to instead raise on any key this
+    owner does not have.
+    """
+    have = set(config_names(self))
+    for key, value in dict(settings).items():
+        if key not in have:
+            if strict:
+                raise KeyError(
+                    "{0} has no config {1!r}; available: {2}".format(
+                        type(self).__name__, key, sorted(have)))
+            continue
+        cls = _resolve_config_class(self, key)
+        if isinstance(value, cls):
+            self.set_config(value)
+        elif isinstance(value, dict):
+            self.set_config(self.get_config(cls).update(**value))
+        else:
+            raise TypeError(
+                "value for {0!r} must be a {1} or a dict of fields, got {2}".format(
+                    key, cls.__name__, type(value).__name__))
+    return self
+
+
 def _enhance_owner_class(cls):
     """Attach configure()/config_names() to a tracker/algorithm class (idempotent)."""
     if getattr(cls, "_b2_owner_enhanced", False):
@@ -418,6 +465,8 @@ def _enhance_owner_class(cls):
     cls.configure = configure
     cls.config_names = config_names
     cls.update = update
+    cls.get_settings = get_settings
+    cls.set_settings = set_settings
     cls._b2_owner_enhanced = True
     return cls
 

--- a/python/docs/source/tutorials/carrying_settings.rst
+++ b/python/docs/source/tutorials/carrying_settings.rst
@@ -1,0 +1,121 @@
+⚙️ Carrying settings across related solves
+*******************************************
+
+.. testsetup:: *
+
+   import numpy as np
+   import bertini
+
+A real computation is rarely one solve. A numerical irreducible decomposition, a parameter sweep, a
+multi-stage pipeline -- each runs *many* related solves, and you usually want the **same** tracking
+settings on every one of them. Re-typing tolerances and step controls for each solver is both tedious
+and a place for them to silently drift apart.
+
+Bertini gives every **config owner** -- every tracker and every solver -- the same small interface for
+this. (Owning configs is a capability, not a class: a tracker is not a solver, but both carry configs,
+so both get these methods.)
+
+Set fields by name
+==================
+
+Every numeric config field accepts a **string** -- the exact, noise-free way to write a number
+(``0.05`` the Python float is not :math:`1/20`; ``"0.05"`` is). And you can set fields right on the
+solver without naming which config struct they live in: :meth:`update` routes each field to whichever
+config owns it.
+
+.. testcode::
+
+   x, y = bertini.Variable('x'), bertini.Variable('y')
+   system = bertini.System()
+   system.add_function(x*x + y*y - 1)
+   system.add_function(x + y)
+   system.add_variable_group(bertini.VariableGroup([x, y]))
+
+   solver = bertini.nag_algorithm.ZeroDim(system)
+   solver.update(final_tolerance="1e-11",                 # -> TolerancesConfig
+                 max_num_crossed_path_resolve_attempts=3) # -> ZeroDimConfig
+
+   from bertini.nag_algorithm import TolerancesConfig, ZeroDimConfig
+   assert solver.get_config(TolerancesConfig).final_tolerance == 1e-11
+   assert solver.get_config(ZeroDimConfig).max_num_crossed_path_resolve_attempts == 3
+
+A misspelled field, or one that lives on a different owner, raises immediately rather than silently
+doing nothing -- ``max_step_size`` is a *tracker* setting, so the solver rejects it:
+
+.. testcode::
+
+   try:
+       solver.update(max_step_size="0.05")     # that field is on the tracker, not the solver
+       raise AssertionError("should have raised")
+   except AttributeError:
+       pass
+
+   solver.get_tracker().update(max_step_size="0.05")   # set it where it lives
+   from bertini.tracking import SteppingConfig
+   assert solver.get_tracker().get_config(SteppingConfig).max_step_size == bertini.multiprec.Float("0.05")
+
+Carry a whole bundle
+====================
+
+:meth:`get_settings` hands you the owner's entire configuration as a plain dict ``{name: config}`` --
+independent, picklable copies. :meth:`set_settings` applies one back. So you configure **once** and
+stamp every subsequent solver with the same settings.
+
+.. testcode::
+
+   reference = bertini.nag_algorithm.ZeroDim(system)
+   reference.update(final_tolerance="1e-11", newton_before_endgame="1e-6")
+   settings = reference.get_settings()
+   assert set(settings) == set(reference.config_names())     # one entry per config
+
+   # ... later, for each related solve ...
+   next_solver = bertini.nag_algorithm.ZeroDim(system)
+   next_solver.set_settings(settings)
+   assert next_solver.get_config(TolerancesConfig).final_tolerance == 1e-11
+
+The bundle is an ordinary picklable value, so it can be stored or sent to another process -- the same
+settings then drive a worker's solves as drive the manager's.
+
+.. testcode::
+
+   import pickle
+   carried = pickle.loads(pickle.dumps(settings))
+   worker_solver = bertini.nag_algorithm.ZeroDim(system)
+   worker_solver.set_settings(carried)
+   assert worker_solver.get_config(TolerancesConfig).final_tolerance == 1e-11
+
+The settings are precision-agnostic
+===================================
+
+A bundle built from one precision model applies **unchanged** to another. This is what lets a
+multi-stage workflow mix precision models -- a quick double-precision pass, then an adaptive
+re-solve -- while carrying one set of tracking tolerances through all of them.
+
+.. testcode::
+
+   tuned = bertini.nag_algorithm.ZeroDim(system, mptype='double')
+   tuned.update(final_tolerance="1e-10")
+   bundle = tuned.get_settings()
+
+   for mptype in ('multiple', 'adaptive'):
+       solver = bertini.nag_algorithm.ZeroDim(system, mptype=mptype)
+       solver.set_settings(bundle)                       # drops on cleanly, any precision model
+       assert solver.get_config(TolerancesConfig).final_tolerance == 1e-10
+
+By default :meth:`set_settings` applies only the configs the target actually has and skips the rest,
+so a bundle also moves between *different kinds* of owner (a tracker has no solver-level tolerances).
+Pass ``strict=True`` to instead require every config in the bundle to be applicable.
+
+.. testcode::
+
+   from bertini.tracking import AMPTracker
+   tracker = AMPTracker(system)
+   tracker.set_settings(settings)             # silently skips the solver-only configs
+   try:
+       tracker.set_settings(settings, strict=True)
+       raise AssertionError("should have raised")
+   except KeyError:
+       pass
+
+Put together, the pattern for any multi-solve workflow is: **tune one owner, ``get_settings()``, and
+``set_settings()`` on each of the rest.**

--- a/python/docs/source/tutorials/crossed_paths.rst
+++ b/python/docs/source/tutorials/crossed_paths.rst
@@ -51,7 +51,7 @@ The key knobs are three lines on the solver:
     tols.newton_before_endgame = 1e-4                              # loose tracking before the endgame
     solver.set_config(tols)
 
-    zd = solver.get_config(pb.nag_algorithm.ZeroDimConfigDoublePrec)
+    zd = solver.get_config(pb.nag_algorithm.ZeroDimConfig)
     zd.max_num_crossed_path_resolve_attempts = 0                  # 0 = detect & report, do NOT re-track
     solver.set_config(zd)
 

--- a/python/docs/source/tutorials/precision_models.rst
+++ b/python/docs/source/tutorials/precision_models.rst
@@ -1,0 +1,110 @@
+🔬 Precision models: double, multiple, adaptive
+*************************************************
+
+.. testsetup:: *
+
+   import numpy as np
+   import bertini
+
+Bertini can track in three precision models, and ``ZeroDim`` selects between them with ``mptype``:
+
+* ``'double'`` -- hardware double precision (≈16 digits). Fastest; fine when the paths are
+  well-conditioned.
+* ``'multiple'`` -- a fixed multiprecision, the same number of digits throughout.
+* ``'adaptive'`` -- adaptive multiprecision (AMP, the default): the precision rises and falls along
+  each path as the conditioning demands. The most robust, and what makes a near-singular path solvable.
+
+This tutorial is about how the three models differ *in the interface* -- the types you get back and
+how you set the precision. For *why and when* you reach for adaptive precision (the conditioning
+story), see :doc:`precision_matters`.
+
+.. testcode::
+
+   x, y = bertini.Variable('x'), bertini.Variable('y')
+   system = bertini.System()
+   system.add_function(x*x + y*y - 1)
+   system.add_function(x + y)
+   system.add_variable_group(bertini.VariableGroup([x, y]))
+
+   names = {mptype: type(bertini.nag_algorithm.ZeroDim(system, mptype=mptype)).__name__
+            for mptype in ('double', 'multiple', 'adaptive')}
+   assert names['double']   == 'ZeroDimCauchyDoublePrecisionTotalDegree'
+   assert names['multiple'] == 'ZeroDimCauchyFixedMultiplePrecisionTotalDegree'
+   assert names['adaptive'] == 'ZeroDimCauchyAdaptivePrecisionTotalDegree'
+
+Reading solutions: convert with ``complex()``
+=============================================
+
+The model changes the **type** of the numbers you get back. A double solve returns NumPy
+``complex128``; a multiprecision solve returns arrays of :class:`bertini.multiprec.Complex` (NumPy
+arrays with ``dtype`` ``Complex``). The portable habit -- works in every model -- is to convert each
+coordinate with :func:`complex`:
+
+.. testcode::
+
+   bertini.random.set_random_seed(2)
+
+   dbl = bertini.nag_algorithm.ZeroDim(system, mptype='double'); dbl.solve()
+   assert dbl.solutions()[0].dtype == np.complex128
+
+   amp = bertini.nag_algorithm.ZeroDim(system, mptype='adaptive'); amp.solve()
+   assert str(amp.solutions()[0].dtype) == 'Complex'        # bertini.multiprec.Complex
+
+   # the same code reads either one:
+   def to_python(solution):
+       return np.array([complex(c) for c in solution])
+
+   for solver in (dbl, amp):
+       pts = sorted(tuple(np.round(to_python(s).real, 4)) for s in solver.solutions())
+       assert pts == [(-0.7071, 0.7071), (0.7071, -0.7071)]
+
+Setting the precision
+=====================
+
+A **fixed multiple** solve works at one precision *everywhere*: the system, the tracker, and the
+points must all agree. So set the default precision and lift the system to it before constructing the
+solver:
+
+.. testcode::
+
+   bertini.default_precision(40)                  # 40 digits for this solve
+   system.precision(40)                           # the system must match
+   m = bertini.nag_algorithm.ZeroDim(system, mptype='multiple')
+   m.solve()
+   assert len(m.solutions()) == 2
+
+   bertini.default_precision(30)                  # restore a modest default
+   system.precision(30)
+
+(Mismatch is reported, not silently tolerated: constructing a multiple-precision solve whose system
+sits at a different precision raises rather than tracking at the wrong precision.)
+
+An **adaptive** solve manages precision itself; its knobs live in the AMP config -- most usefully
+``maximum_precision``, the ceiling above which a path is declared to have failed:
+
+.. testcode::
+
+   from bertini.tracking import AMPConfig
+   amp = bertini.nag_algorithm.ZeroDim(system, mptype='adaptive')
+   assert amp.get_tracker().get_config(AMPConfig).maximum_precision == 300
+   amp.get_tracker().update(maximum_precision=200)     # tighten the ceiling
+   assert amp.get_tracker().get_config(AMPConfig).maximum_precision == 200
+
+The config surface is the same shape across models
+==================================================
+
+Apart from the precision-specific tracker knobs (the ``amp`` config exists only for an adaptive
+tracker), the configs are the same across precision models -- ``tolerances``, ``zero_dim``, stepping,
+and so on are not precision-stamped. That is exactly why a settings bundle carries between models (see
+:doc:`carrying_settings`):
+
+.. testcode::
+
+   shared = {'tolerances', 'zero_dim', 'post_processing', 'auto_retrack'}
+   for mptype in ('double', 'multiple', 'adaptive'):
+       names = set(bertini.nag_algorithm.ZeroDim(system, mptype=mptype).config_names())
+       assert shared <= names
+
+So the rule of thumb: reach for ``'adaptive'`` by default; drop to ``'double'`` for speed when the
+problem is well-conditioned; use ``'multiple'`` when you want a fixed, known precision throughout. And
+read every solution through :func:`complex` so your code does not care which model produced it.

--- a/python/docs/source/tutorials/tutorials.rst
+++ b/python/docs/source/tutorials/tutorials.rst
@@ -20,6 +20,8 @@
    solving_at_scale
    crossed_paths
    precision_matters
+   precision_models
+   carrying_settings
    evaluation_cyclic
    canonical_ordering
    tracking_nonsingular

--- a/python/examples/crossed_paths.py
+++ b/python/examples/crossed_paths.py
@@ -61,7 +61,7 @@ def solve(seed, resolve_attempts, tol=1e-4):
     tols.newton_during_endgame = tol / 10
     solver.set_config(tols)
 
-    zd = solver.get_config(pb.nag_algorithm.ZeroDimConfigDoublePrec)
+    zd = solver.get_config(pb.nag_algorithm.ZeroDimConfig)
     zd.max_num_crossed_path_resolve_attempts = resolve_attempts
     solver.set_config(zd)
 

--- a/python/test/tracking/config_test.py
+++ b/python/test/tracking/config_test.py
@@ -280,3 +280,68 @@ def test_owner_update_routes_only_across_this_owners_configs(solver):
 def test_owner_update_rejects_unknown_field(solver):
     with pytest.raises(AttributeError):
         solver.update(finaltol="1e-9")
+
+
+# ------------------------------------------------ get_settings / set_settings (the carry)
+
+def _square():
+    x, y = pb.Variable('x'), pb.Variable('y')
+    s = pb.System()
+    s.add_function(x ** 2 + y ** 2 - 1); s.add_function(x + y)
+    s.add_variable_group(pb.VariableGroup([x, y]))
+    return s
+
+
+def test_get_settings_is_a_named_dict_of_configs():
+    a = ZeroDimCauchyAdaptivePrecisionTotalDegree(_square())
+    settings = a.get_settings()
+    assert set(settings) == set(a.config_names())
+    assert isinstance(settings['tolerances'], TolerancesConfig)
+
+
+def test_settings_round_trip_onto_another_solver():
+    from bertini.nag_algorithm import ZeroDimConfig
+    a = ZeroDimCauchyAdaptivePrecisionTotalDegree(_square())
+    a.update(final_tolerance="1e-12", max_num_crossed_path_resolve_attempts=4)
+
+    b = ZeroDimCauchyAdaptivePrecisionTotalDegree(_square())
+    b.set_settings(a.get_settings())
+    assert b.get_config(TolerancesConfig).final_tolerance == 1e-12
+    assert b.get_config(ZeroDimConfig).max_num_crossed_path_resolve_attempts == 4
+
+
+def test_settings_carry_across_precision_models():
+    # the de-templated, precision-agnostic configs are what make this work: a bundle from a multiple-
+    # precision solver applies unchanged to a double or adaptive one.  This is the cross-stage carry
+    # an NID-style workflow needs.
+    src = pb.nag_algorithm.ZeroDim(_square(), mptype='multiple')
+    src.update(final_tolerance="1e-11")
+    for mptype in ('double', 'adaptive'):
+        dst = pb.nag_algorithm.ZeroDim(_square(), mptype=mptype)
+        dst.set_settings(src.get_settings())
+        assert dst.get_config(TolerancesConfig).final_tolerance == 1e-11
+
+
+def test_settings_bundle_is_picklable():
+    import pickle
+    a = ZeroDimCauchyAdaptivePrecisionTotalDegree(_square())
+    a.update(final_tolerance="1e-9")
+    restored = pickle.loads(pickle.dumps(a.get_settings()))
+    b = ZeroDimCauchyAdaptivePrecisionTotalDegree(_square())
+    b.set_settings(restored)
+    assert b.get_config(TolerancesConfig).final_tolerance == 1e-9
+
+
+def test_set_settings_skips_inapplicable_by_default_strict_raises():
+    from bertini.tracking import AMPTracker
+    settings = ZeroDimCauchyAdaptivePrecisionTotalDegree(_square()).get_settings()
+    trk = AMPTracker(_square())            # a tracker has no 'tolerances' / 'zero_dim'
+    trk.set_settings(settings)             # non-strict: silently skips them
+    with pytest.raises(KeyError):
+        trk.set_settings(settings, strict=True)
+
+
+def test_set_settings_accepts_dict_of_fields():
+    a = ZeroDimCauchyAdaptivePrecisionTotalDegree(_square())
+    a.set_settings({'tolerances': {'final_tolerance': '1e-10'}})
+    assert a.get_config(TolerancesConfig).final_tolerance == 1e-10

--- a/python/test/tracking/config_test.py
+++ b/python/test/tracking/config_test.py
@@ -240,3 +240,43 @@ def test_set_and_get_algorithm_config(solver):
     tol = solver.get_config(TolerancesConfig).update(final_tolerance=1e-11)
     solver.set_config(tol)
     assert solver.get_config(TolerancesConfig) == tol
+
+
+# ------------------------------------------------ owner.update(**fields) field router
+
+def test_owner_update_routes_fields_by_name(solver):
+    # the headline ergonomic: set fields on the owner without naming the config struct -- each field
+    # goes to whichever config owns it.
+    from bertini.nag_algorithm import ZeroDimConfig
+    solver.update(final_tolerance="1e-11", max_num_crossed_path_resolve_attempts=3)
+    assert solver.get_config(TolerancesConfig).final_tolerance == 1e-11
+    assert solver.get_config(ZeroDimConfig).max_num_crossed_path_resolve_attempts == 3
+
+
+def test_owner_update_is_chainable(solver):
+    assert solver.update(final_tolerance="1e-9") is solver
+
+
+def test_owner_update_accepts_strings(solver):
+    # strings work through the router for every numeric field, same as the per-config update().
+    solver.update(final_tolerance="1e-12")
+    assert solver.get_config(TolerancesConfig).final_tolerance == 1e-12
+
+
+def test_tracker_update_routes_to_its_configs(tracker):
+    from bertini.tracking import SteppingConfig, NewtonConfig
+    tracker.update(max_step_size="0.05", max_num_newton_iterations=2)
+    assert tracker.get_config(SteppingConfig).max_step_size == pb.multiprec.Float("0.05")
+    assert tracker.get_config(NewtonConfig).max_num_newton_iterations == 2
+
+
+def test_owner_update_routes_only_across_this_owners_configs(solver):
+    # max_step_size lives on the tracker's SteppingConfig, not on the algorithm's configs -- the
+    # router refuses it on the algorithm rather than silently doing nothing.
+    with pytest.raises(AttributeError):
+        solver.update(max_step_size="0.05")
+
+
+def test_owner_update_rejects_unknown_field(solver):
+    with pytest.raises(AttributeError):
+        solver.update(finaltol="1e-9")

--- a/python/test/tracking/config_test.py
+++ b/python/test/tracking/config_test.py
@@ -124,6 +124,32 @@ def test_update_float_still_works_on_double_fields():
     assert TolerancesConfig().update(final_tolerance=1e-11).final_tolerance == 1e-11
 
 
+def test_zero_dim_config_is_precision_agnostic():
+    # ZeroDimConfig is no longer templated on the complex type: there is one config, keyed 'zero_dim'
+    # on every precision model (was zero_dim_config_double_prec / _multiprec).  This is what lets a
+    # carried settings bundle apply across a double, multiple, or adaptive solver unchanged.
+    from bertini.nag_algorithm import ZeroDimConfig
+    import bertini.nag_algorithm as na
+    assert not hasattr(na, 'ZeroDimConfigDoublePrec')
+    assert not hasattr(na, 'ZeroDimConfigMultiprec')
+
+    x, y = pb.Variable('x'), pb.Variable('y')
+    s = pb.System()
+    s.add_function(x * x + y * y - 1); s.add_function(x + y)
+    s.add_variable_group(pb.VariableGroup([x, y]))
+    for mptype in ('double', 'multiple', 'adaptive'):
+        names = pb.nag_algorithm.ZeroDim(s, mptype=mptype).config_names()
+        assert 'zero_dim' in names, names
+
+
+def test_zero_dim_config_times_accept_strings():
+    # the homotopy times are stored precision-free (mpq_rational) but exposed as real and take the
+    # same string spelling as every other numeric field.
+    from bertini.nag_algorithm import ZeroDimConfig
+    c = ZeroDimConfig().update(endgame_boundary="0.05", start_time="1", target_time="0")
+    assert c.endgame_boundary == pb.multiprec.Float("0.05")
+
+
 def test_regeneration_slice_tolerances_are_prefixed():
     # RegenerationConfig's tolerances are the slice-MOVING tracking tolerances (Bertini 1's SliceTol*
     # family), distinct from the main tracking tolerances in TolerancesConfig.  They carry a slice_

--- a/python/test/tracking/config_test.py
+++ b/python/test/tracking/config_test.py
@@ -124,6 +124,33 @@ def test_update_float_still_works_on_double_fields():
     assert TolerancesConfig().update(final_tolerance=1e-11).final_tolerance == 1e-11
 
 
+def test_regeneration_slice_tolerances_are_prefixed():
+    # RegenerationConfig's tolerances are the slice-MOVING tracking tolerances (Bertini 1's SliceTol*
+    # family), distinct from the main tracking tolerances in TolerancesConfig.  They carry a slice_
+    # prefix so every config field name is unique across structs -- the precondition for routing a
+    # field to its config without naming the struct.
+    from bertini.nag_algorithm import RegenerationConfig
+    c = RegenerationConfig().update(slice_newton_before_endgame="1e-7",
+                                    slice_newton_during_endgame="1e-8",
+                                    slice_final_tolerance="1e-12")
+    assert c.slice_newton_before_endgame == 1e-7
+    assert c.slice_final_tolerance == 1e-12
+    # the un-prefixed names belong only to TolerancesConfig now
+    assert not hasattr(c, 'newton_before_endgame')
+    assert not hasattr(c, 'final_tolerance')
+
+
+def test_no_field_name_collisions_across_configs():
+    # The slice_ rename leaves every config field name unique across all of an owner's configs, which
+    # is what lets a field be routed to its owning config unambiguously.
+    from bertini.nag_algorithm import (ZeroDimCauchyAdaptivePrecisionTotalDegree as ZD,
+                                       TolerancesConfig, RegenerationConfig)
+    from bertini.config import writable_fields
+    tol = set(writable_fields(TolerancesConfig))
+    regen = set(writable_fields(RegenerationConfig))
+    assert tol & regen == set(), "tolerances/regeneration still share field names: {}".format(tol & regen)
+
+
 def test_update_rejects_garbage_string():
     with pytest.raises(Exception):
         SteppingConfig().update(max_step_size="not a number")

--- a/python/test/tracking/config_test.py
+++ b/python/test/tracking/config_test.py
@@ -98,6 +98,32 @@ def test_update_rejects_python_float_for_mpfr_field():
         SteppingConfig().update(max_step_size=0.05)
 
 
+def test_update_accepts_string_for_double_tolerance_field():
+    # NumErrorT (tolerance) fields are plain doubles -- a high-precision number would have no value
+    # there -- but update() still takes the same noise-free string spelling as the exact fields, so
+    # the whole config surface is uniform.  (Regression: these used to throw Boost ArgumentError.)
+    assert TolerancesConfig().update(final_tolerance="1e-11").final_tolerance == 1e-11
+    assert TolerancesConfig().update(newton_before_endgame="1e-7").newton_before_endgame == 1e-7
+
+
+def test_update_accepts_string_for_min_step_size():
+    # min_step_size is a plain double (def_readwrite) where its siblings are mpq_rational; update()
+    # papers over that difference so a string works on every stepping field alike.
+    from bertini.tracking import SteppingConfig as SC
+    assert SC().update(min_step_size="1e-50").min_step_size == 1e-50
+
+
+def test_update_accepts_string_for_integer_field():
+    from bertini.tracking import NewtonConfig
+    assert NewtonConfig().update(max_num_newton_iterations="4").max_num_newton_iterations == 4
+
+
+def test_update_float_still_works_on_double_fields():
+    # the float-rejection policy is only for the exact (mpq/mpfr) fields; a plain double is the
+    # natural input for a NumErrorT tolerance and must keep working.
+    assert TolerancesConfig().update(final_tolerance=1e-11).final_tolerance == 1e-11
+
+
 def test_update_rejects_garbage_string():
     with pytest.raises(Exception):
         SteppingConfig().update(max_step_size="not a number")

--- a/python/test/zero_dim/crossed_paths_test.py
+++ b/python/test/zero_dim/crossed_paths_test.py
@@ -89,7 +89,7 @@ def _solve(resolve_attempts, predictor=pb.tracking.Predictor.Euler, step=COARSE_
     tol_cfg.newton_during_endgame = tol / 10
     solver.set_config(tol_cfg)
 
-    zd = solver.get_config(pb.nag_algorithm.ZeroDimConfigDoublePrec)
+    zd = solver.get_config(pb.nag_algorithm.ZeroDimConfig)
     zd.max_num_crossed_path_resolve_attempts = resolve_attempts
     solver.set_config(zd)
 

--- a/python_bindings/src/zero_dim_configs_export.cpp
+++ b/python_bindings/src/zero_dim_configs_export.cpp
@@ -54,12 +54,13 @@ namespace bertini{
 				"Whether to test for, and remove, points lying on higher-dimensional components during regeneration.")
 			.def_readwrite("start_level", &RegenerationConfig::start_level,
 				"The regeneration level at which to begin.")
-			.def_readwrite("newton_before_endgame", &RegenerationConfig::newton_before_endgame,
-				"Regeneration slice tracking tolerance before the endgame.")
-			.def_readwrite("newton_during_endgame", &RegenerationConfig::newton_during_endgame,
-				"Regeneration slice tracking tolerance during the endgame.")
-			.def_readwrite("final_tolerance", &RegenerationConfig::final_tolerance,
-				"Regeneration slice final tolerance, tracked to using the endgame.")
+			.def_readwrite("slice_newton_before_endgame", &RegenerationConfig::slice_newton_before_endgame,
+				"Slice-moving tracking tolerance before the endgame (Bertini 1 SliceTolBeforeEG). "
+				"Separate from TolerancesConfig.newton_before_endgame, which governs the main tracking.")
+			.def_readwrite("slice_newton_during_endgame", &RegenerationConfig::slice_newton_during_endgame,
+				"Slice-moving tracking tolerance during the endgame (Bertini 1 SliceTolDuringEG).")
+			.def_readwrite("slice_final_tolerance", &RegenerationConfig::slice_final_tolerance,
+				"Final tolerance to track the slice move to, using the endgame (Bertini 1 SliceFinalTol).")
 			;
 
 			class_<PostProcessingConfig>("PostProcessingConfig", init<>())

--- a/python_bindings/src/zero_dim_configs_export.cpp
+++ b/python_bindings/src/zero_dim_configs_export.cpp
@@ -81,26 +81,25 @@ namespace bertini{
 				"exceeds this value. Default 1e8.")
 			;
 
-			class_<ZeroDimConfig<dbl_complex>>("ZeroDimConfigDoublePrec", init<>())
-			.def_readwrite("start_time", &ZeroDimConfig<dbl_complex>::start_time,
+			// One ZeroDimConfig for every precision model -- the homotopy times are stored precision-free
+			// (mpq_rational) and converted to the tracking type at use, so the config is no longer
+			// templated on the complex type.  The times are real (the solve tracks the real t-axis);
+			// they are exposed as mpfr_float and round-trip exactly, the same way SteppingConfig exposes
+			// its mpq_rational step sizes.
+			class_<ZeroDimConfig>("ZeroDimConfig", init<>())
+			.add_property("start_time",
+				+[](ZeroDimConfig const& c) -> mpfr_float { return mpfr_float(c.start_time); },
+				+[](ZeroDimConfig& c, mpfr_float const& v) { c.start_time = mpq_rational(v); },
 				"The time value at which the homotopy starts (where the start solutions live).")
-			.def_readwrite("target_time", &ZeroDimConfig<dbl_complex>::target_time,
+			.add_property("target_time",
+				+[](ZeroDimConfig const& c) -> mpfr_float { return mpfr_float(c.target_time); },
+				+[](ZeroDimConfig& c, mpfr_float const& v) { c.target_time = mpq_rational(v); },
 				"The time value the homotopy tracks to (where the solutions of interest live).")
-			.def_readwrite("endgame_boundary", &ZeroDimConfig<dbl_complex>::endgame_boundary,
+			.add_property("endgame_boundary",
+				+[](ZeroDimConfig const& c) -> mpfr_float { return mpfr_float(c.endgame_boundary); },
+				+[](ZeroDimConfig& c, mpfr_float const& v) { c.endgame_boundary = mpq_rational(v); },
 				"The time value at which tracking stops and the endgame takes over.")
-			.def_readwrite("max_num_crossed_path_resolve_attempts", &ZeroDimConfig<dbl_complex>::max_num_crossed_path_resolve_attempts,
-				"How many times to re-track crossed paths (with tightened settings) at the endgame "
-				"boundary before giving up. 0 = detect and report only, do not re-track. Default 2.")
-			;
-
-			class_<ZeroDimConfig<mpfr_complex>>("ZeroDimConfigMultiprec", init<>())
-			.def_readwrite("start_time", &ZeroDimConfig<mpfr_complex>::start_time,
-				"The time value at which the homotopy starts (where the start solutions live).")
-			.def_readwrite("target_time", &ZeroDimConfig<mpfr_complex>::target_time,
-				"The time value the homotopy tracks to (where the solutions of interest live).")
-			.def_readwrite("endgame_boundary", &ZeroDimConfig<mpfr_complex>::endgame_boundary,
-				"The time value at which tracking stops and the endgame takes over.")
-			.def_readwrite("max_num_crossed_path_resolve_attempts", &ZeroDimConfig<mpfr_complex>::max_num_crossed_path_resolve_attempts,
+			.def_readwrite("max_num_crossed_path_resolve_attempts", &ZeroDimConfig::max_num_crossed_path_resolve_attempts,
 				"How many times to re-track crossed paths (with tightened settings) at the endgame "
 				"boundary before giving up. 0 = detect and report only, do not re-track. Default 2.")
 			;


### PR DESCRIPTION
Makes Bertini's configs **easy to set and to carry across related solves** — the pain point for any multi-stage workflow (a numerical irreducible decomposition, a parameter sweep, a pipeline). All green: C++ 10/10 suites, pytest 477 passed / 2 skipped, sphinx doctest 0 failures.

## Set fields painlessly
- **Every numeric field accepts a string** (the exact, noise-free spelling). Previously the `NumErrorT`/double fields (tolerances, AMP bounds, `min_step_size`) took a float but threw on a string, while the `mpq_rational` fields took a string but reject a float — opposite rules. Now `update(final_tolerance="1e-11")` and `update(min_step_size="1e-50")` both work, centrally, with the float-rejection policy on the exact fields unchanged.
- **`owner.update(**fields)`** — set fields right on a tracker or solver without naming the config struct: `solver.update(final_tolerance="1e-11", max_num_crossed_path_resolve_attempts=3)` routes each field to whichever config owns it. Owner-scoped and typo-safe (an unknown or cross-owner field raises with the valid names). Chainable.

## Carry settings across solves
- **`get_settings()` / `set_settings(d, strict=False)`** — lift an owner's whole configuration as a plain, picklable `{name: config}` dict and drop it onto the next solver. Build settings once, stamp every stage. By default applies only the configs the target has (so a bundle moves between precision models, or tracker↔solver); `strict=True` requires all to apply.

## The structural cleanups that make the above coherent
- **Slice tolerances renamed** `RegenerationConfig.{newton_before_endgame, newton_during_endgame, final_tolerance}` → `slice_*` (Bertini 1's `SliceTol*` family — they are the slice-moving tolerances). This removed the **only** field-name collision across configs, which is what makes the flat field router unambiguous.
- **`ZeroDimConfig` de-templated** — it was templated on the complex type solely for three time fields. The times are now precision-free `mpq_rational` (real; the solve tracks the real t-axis), converted at use. Result: **one** config keyed `zero_dim` on every precision model instead of `ZeroDimConfigDoublePrec`/`Multiprec` — so a settings bundle carries across double/multiple/adaptive unchanged. Also more correct under AMP (the endgame boundary 1/10 is materialized at working precision, not frozen at construction).

## Docs
Two tutorials, both run under `sphinx -b doctest`:
- **carrying_settings** — the field router + `get_settings`/`set_settings` carry story (the multi-stage / NID pattern).
- **precision_models** — how double/multiple/adaptive differ in the interface (solution types read via `complex()`, setting precision, the precision-agnostic config surface).

Owning configs is treated as a **capability**, not inheritance — trackers and solvers (and a future NID owner) get the whole interface by carrying configs, not by sharing a base class.

Deferred to their own PRs: `FixedPrecisionConfig.precision` + tracker re-precision wiring; tying `MaxPrecisionAllowed` to the AMP cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)