### PR TITLE
FixedPrecisionConfig.precision: set fixed-multiple precision on the config

### DIFF
--- a/core/include/bertini2/nag_algorithms/zero_dim_solve.hpp
+++ b/core/include/bertini2/nag_algorithms/zero_dim_solve.hpp
@@ -1104,6 +1104,28 @@ std::ostream& operator<<(std::ostream & out, const SolveReport & r)
 
 			void PreSolveSetup()
 			{
+				// Fixed-multiple precision: FixedPrecisionConfig.precision (on the tracker) is the
+				// authoritative precision for the whole solve.  Lift the tracker, the ambient/thread
+				// precision, the start-point precision (via initial_ambient_precision), and the systems
+				// all to that one value -- TrackerLoopInitialization requires them to agree.  (Double is
+				// fixed at 16 and adaptive manages its own precision, so neither enters here.)
+				if constexpr (!tracking::TrackerTraits<TrackerType>::IsAdaptivePrec)
+				{
+					auto const& fp = GetTracker().template Get<PrecisionConfig>();
+					// Double validates (its PrecisionSetup throws on any precision other than 16);
+					// fixed-multiple adopts the value into precision_.
+					GetTracker().PrecisionSetup(fp);
+					if constexpr (!std::is_same<BaseComplexT, dbl>::value)
+						if (fp.precision != 0)
+						{
+							ZeroDimConf zdc = this->template Get<ZeroDimConf>();
+							zdc.initial_ambient_precision = fp.precision;  // -> thread + start-point precision
+							this->template Set<ZeroDimConf>(zdc);
+							TargetSystem().precision(fp.precision);
+							Homotopy().precision(fp.precision);
+						}
+				}
+
 				auto num_as_size_t = static_cast<SolnIndT>(num_start_points_);
 
 				solution_final_metadata_.resize(num_as_size_t);

--- a/core/include/bertini2/num_traits.hpp
+++ b/core/include/bertini2/num_traits.hpp
@@ -127,19 +127,19 @@ namespace bertini
 		return 10;
 	}
 
-	inline
+	constexpr
 	unsigned DoublePrecision()
 	{
 		return 16;
 	}
 
-	inline
+	constexpr
 	unsigned LowestMultiplePrecision()
 	{
 		return 20;
 	}
-		
-	inline
+
+	constexpr
 	unsigned MaxPrecisionAllowed()
 	{
 		return 1000;

--- a/core/include/bertini2/trackers/config.hpp
+++ b/core/include/bertini2/trackers/config.hpp
@@ -113,10 +113,22 @@ namespace tracking{
 		using RealT = double;
 
 		/**
+		\brief The number of digits to always work at.
+
+		For a double-precision tracker this is DoublePrecision() (16) and cannot be changed.  For a
+		fixed-multiple tracker it is the precision the whole solve runs at -- the tracker, the system,
+		the start points, and the working precision all sit at this one value.  A tracker keeps this
+		field in sync with its actual precision, so reading it tells you the precision in effect; set it
+		to choose a different fixed precision (the algorithm then lifts the system and start points to
+		match).  The sentinel 0 means "unset -- use the tracker's natural precision".
+		*/
+		unsigned precision = 0;
+
+		/**
 		\brief Construct a ready-to-go set of fixed precision settings from a system.
 		*/
 		explicit
-		FixedPrecisionConfig(System const& /*sys*/) 
+		FixedPrecisionConfig(System const& /*sys*/)
 		{ }
 
 		FixedPrecisionConfig() = default;

--- a/core/include/bertini2/trackers/fixed_precision_tracker.hpp
+++ b/core/include/bertini2/trackers/fixed_precision_tracker.hpp
@@ -425,7 +425,12 @@ namespace bertini{
 			\brief Construct a tracker, associating to it a System.
 			*/
 			DoublePrecisionTracker(class System const& sys) : FixedPrecisionTracker<DoublePrecisionTracker>(sys)
-			{	}
+			{
+				// Report the precision honestly: double tracking is always DoublePrecision() digits.
+				FixedPrecisionConfig c = this->template Get<FixedPrecisionConfig>();
+				c.precision = DoublePrecision();
+				this->template Set<FixedPrecisionConfig>(c);
+			}
 
 
 			DoublePrecisionTracker() = delete;
@@ -436,6 +441,20 @@ namespace bertini{
 			unsigned CurrentPrecision() const override
 			{
 				return DoublePrecision();
+			}
+
+			/**
+			\brief Double-precision tracking is fixed at DoublePrecision() digits.  Accept that value (or
+			the 0 sentinel), but reject any attempt to set a different precision -- use mptype 'multiple'
+			or 'adaptive' for more digits.
+			*/
+			void PrecisionSetup(FixedPrecisionConfig const& c)
+			{
+				if (c.precision != 0 && c.precision != DoublePrecision())
+					throw std::runtime_error("double-precision tracking is fixed at "
+						+ std::to_string(DoublePrecision())
+						+ " digits; cannot set precision to " + std::to_string(c.precision)
+						+ " (use mptype 'multiple' or 'adaptive')");
 			}
 
 
@@ -487,9 +506,11 @@ namespace bertini{
 			The precision of the tracker will be whatever the current default is.  The tracker cannot change its precision, and will require the default precision to be this precision whenever tracking is started.  That is, the precision is fixed.
 			*/
 			MultiplePrecisionTracker(class System const& sys) : FixedPrecisionTracker<MultiplePrecisionTracker>(sys), precision_(DefaultPrecision())
-			{	}
+			{
+				SyncPrecisionToConfig();
+			}
 
-			
+
 			MultiplePrecisionTracker() = delete;
 
 			virtual ~MultiplePrecisionTracker() = default;
@@ -498,6 +519,30 @@ namespace bertini{
 			unsigned CurrentPrecision() const override
 			{
 				return precision_;
+			}
+
+			/**
+			\brief Set the fixed precision this tracker works at.
+
+			The next TrackPath re-precisions all of the tracker's state to this value
+			(TrackerLoopInitialization does it).  The caller must also ensure the system, the working
+			(thread) precision, and the start points are at this precision -- the zero-dim algorithm
+			does this from FixedPrecisionConfig.precision.
+			*/
+			void SetPrecision(unsigned p)
+			{
+				precision_ = p;
+				SyncPrecisionToConfig();
+			}
+
+			/**
+			\brief Adopt the precision named in a FixedPrecisionConfig (its sentinel 0 means "leave as
+			is").  Replaces the base no-op so the fixed-multiple precision is configurable.
+			*/
+			void PrecisionSetup(FixedPrecisionConfig const& c)
+			{
+				if (c.precision != 0)
+					SetPrecision(c.precision);
 			}
 
 
@@ -578,6 +623,15 @@ namespace bertini{
 						        ;				
 			}
 		private:
+
+			// Keep the stored FixedPrecisionConfig.precision equal to the tracker's actual precision,
+			// so reading the config tells you the precision in effect (not the 0 sentinel).
+			void SyncPrecisionToConfig()
+			{
+				FixedPrecisionConfig c = this->template Get<FixedPrecisionConfig>();
+				c.precision = precision_;
+				this->template Set<FixedPrecisionConfig>(c);
+			}
 
 			unsigned precision_;
 		}; // re: MultiplePrecisionTracker

--- a/core/test/nag_algorithms/zero_dim.cpp
+++ b/core/test/nag_algorithms/zero_dim.cpp
@@ -539,6 +539,58 @@ BOOST_AUTO_TEST_CASE(fixed_multiple_precision_solves_uniformly)
 	BOOST_CHECK_EQUAL(solve_at(60), 2u);             // and a higher one -- still uniform, still solves
 }
 
+// FixedPrecisionConfig.precision sets a fixed-multiple solve's precision *after* construction -- no
+// DefaultPrecision()-before-construct dance.  This is the "real precision setter" ADR-0030 deferred:
+// the algorithm lifts the tracker, the systems, and the ambient/start-point precision to the config's
+// value at PreSolveSetup.
+BOOST_AUTO_TEST_CASE(fixed_multiple_precision_set_via_config)
+{
+	using namespace bertini;
+	using MPTracker = tracking::MultiplePrecisionTracker;
+
+	auto saved = DefaultPrecision();
+	DefaultPrecision(30);                            // construct at a modest default
+	auto x = node::Variable::Make("x");
+	System sys;
+	sys.AddFunction(pow(x, 2) - 1);
+	sys.AddVariableGroup(VariableGroup{x});
+	auto zd = algorithm::ZeroDim<MPTracker, endgame::EndgameSelector<MPTracker>::Cauchy,
+	                             System, start_system::TotalDegree>(sys);
+	zd.DefaultSetup();
+
+	// the tracker reports its precision honestly
+	BOOST_CHECK_EQUAL(zd.GetTracker().template Get<tracking::FixedPrecisionConfig>().precision, 30u);
+
+	// choose a different fixed precision via the config, then solve at it
+	auto fp = zd.GetTracker().template Get<tracking::FixedPrecisionConfig>();
+	fp.precision = 70;
+	zd.GetTracker().template Set<tracking::FixedPrecisionConfig>(fp);
+
+	zd.Solve();
+	BOOST_CHECK_EQUAL(zd.Report().num_finite_solutions, 2u);
+	BOOST_CHECK_EQUAL(zd.GetTracker().CurrentPrecision(), 70u);   // the solve ran at 70
+	DefaultPrecision(saved);
+}
+
+// Double-precision tracking is fixed at DoublePrecision(); asking the config for any other precision
+// is rejected (use mptype multiple/adaptive for more digits).
+BOOST_AUTO_TEST_CASE(double_precision_rejects_a_different_precision)
+{
+	using namespace bertini;
+	auto x = node::Variable::Make("x");
+	System sys;
+	sys.AddFunction(pow(x, 2) - 1);
+	sys.AddVariableGroup(VariableGroup{x});
+	tracking::DoublePrecisionTracker tracker(sys);
+
+	BOOST_CHECK_EQUAL(tracker.template Get<tracking::FixedPrecisionConfig>().precision, DoublePrecision());
+	tracking::FixedPrecisionConfig fp;
+	fp.precision = 50;
+	BOOST_CHECK_THROW(tracker.PrecisionSetup(fp), std::runtime_error);
+	fp.precision = DoublePrecision();
+	BOOST_CHECK_NO_THROW(tracker.PrecisionSetup(fp));   // the native precision is fine
+}
+
 // PROBE observer (branch perf/amp-block-precision-escalation): record, per successful step, the
 // |t|, working precision, and the tracker's condition-number estimate -- so we can SEE whether the
 // condition number (||J|| * ||J^{-1}||) spikes then RECOVERS along the actual seed-6 path, and at

--- a/python/test/tracking/config_test.py
+++ b/python/test/tracking/config_test.py
@@ -345,3 +345,33 @@ def test_set_settings_accepts_dict_of_fields():
     a = ZeroDimCauchyAdaptivePrecisionTotalDegree(_square())
     a.set_settings({'tolerances': {'final_tolerance': '1e-10'}})
     assert a.get_config(TolerancesConfig).final_tolerance == 1e-10
+
+
+# ------------------------------------------------ FixedPrecisionConfig.precision
+
+def test_fixed_multiple_precision_set_via_config():
+    # set a fixed-multiple solve's precision on the tracker's FixedPrecisionConfig -- no
+    # default_precision()-before-construct dance -- and it runs at that precision.
+    import bertini as b
+    from bertini.tracking import FixedPrecisionConfig
+    b.default_precision(30)
+    x = b.Variable('x'); s = b.System()
+    s.add_function(x * x - 1); s.add_variable_group(b.VariableGroup([x]))
+    solver = b.nag_algorithm.ZeroDim(s, mptype='multiple')
+    assert solver.get_tracker().get_config(FixedPrecisionConfig).precision == 30   # honest report
+    solver.get_tracker().update(precision=70)
+    solver.solve()
+    assert len(solver.finite_solutions()) == 2
+    assert solver.get_tracker().current_precision() == 70
+
+
+def test_double_precision_rejects_a_different_precision():
+    import bertini as b
+    from bertini.tracking import FixedPrecisionConfig
+    x = b.Variable('x'); s = b.System()
+    s.add_function(x * x - 1); s.add_variable_group(b.VariableGroup([x]))
+    solver = b.nag_algorithm.ZeroDim(s, mptype='double')
+    assert solver.get_tracker().get_config(FixedPrecisionConfig).precision == 16
+    solver.get_tracker().update(precision=50)
+    with pytest.raises(RuntimeError):
+        solver.solve()

--- a/python_bindings/src/tracker_config_export.cpp
+++ b/python_bindings/src/tracker_config_export.cpp
@@ -55,7 +55,14 @@ namespace bertini{
 				.def_readwrite("min_num_newton_iterations", &NewtonConfig::min_num_newton_iterations)
 				;
 
-			class_<FixedPrecisionConfig, std::shared_ptr<FixedPrecisionConfig> >("FixedPrecisionConfig", init<System const&>());
+			class_<FixedPrecisionConfig, std::shared_ptr<FixedPrecisionConfig> >("FixedPrecisionConfig", init<>())
+				.def(init<System const&>())
+				.def_readwrite("precision", &FixedPrecisionConfig::precision,
+					"The number of digits to always work at.  For a double-precision tracker this is "
+					"DoublePrecision() (16) and cannot be changed; for a fixed-multiple tracker it is the "
+					"precision the whole solve runs at -- set it to choose a different fixed precision.  "
+					"A tracker keeps this in sync with its actual precision, so reading it tells you the "
+					"precision in effect.");
 
 			class_<AdaptiveMultiplePrecisionConfig, std::shared_ptr<AdaptiveMultiplePrecisionConfig> >("AMPConfig", init<>())
 				.def(init<System const&>())


### PR DESCRIPTION
Makes `FixedPrecisionConfig.precision` the way to set a fixed-multiple solve's precision — replacing the `default_precision(N)`-before-construct dance that ADR-0030 documented as a workaround. All green: C++ `test_nag_algorithms`/`test_tracking_basics`, and the Python config/zero_dim/tracker suites.

## Why
`FixedPrecisionConfig` was empty. It is "supposed to indicate the precision to always work at," but carried nothing — so the only way to pin a fixed-multiple solve's precision was to call `default_precision(N)` *and* lift the system *before* constructing the solver.

## What
- **`FixedPrecisionConfig.precision`** — the number of digits to work at.
- **`MultiplePrecisionTracker`** gains a real `SetPrecision()` (the "precision setter" ADR-0030 deferred) and a `PrecisionSetup()` that adopts the config's value; it keeps the config in sync with its actual precision, so reading `FixedPrecisionConfig.precision` tells you the precision in effect.
- **`DoublePrecisionTracker`** reports `DoublePrecision()` (16) and **rejects any other precision** (use `mptype` `'multiple'`/`'adaptive'` for more digits).
- The **zero-dim algorithm**, in `PreSolveSetup`, lifts the tracker, the systems, and the ambient/start-point precision to `FixedPrecisionConfig.precision` for a fixed-multiple solve (and validates it for double). So:

```python
solver.get_tracker().update(precision=70)
solver.solve()          # runs the whole fixed-multiple solve at 70 digits
```

- `DoublePrecision()` / `LowestMultiplePrecision()` / `MaxPrecisionAllowed()` are now `constexpr`.

## Tests
C++ `fixed_multiple_precision_set_via_config` (solve at a config-set precision) and `double_precision_rejects_a_different_precision`; Python equivalents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)