### PR TITLE
fix: friendly error when a solver is passed to user_homotopy (#258)

### DIFF
--- a/python/bertini/nag_algorithm/__init__.py
+++ b/python/bertini/nag_algorithm/__init__.py
@@ -217,6 +217,18 @@ def user_homotopy(homotopy, start_points, target, *, precision='adaptive', endga
             "precision in {{'adaptive','double','multiple'}}, endgame in {{'cauchy','powerseries'}}"
             .format(precision, endgame))
     solver_cls = getattr(_pybnalag, cls_name)
+    # A frequent mix-up (issue #258): passing the start-point *solver* instead of its
+    # start *points*.  A ZeroDim solver is not iterable, so list(start_points) below would
+    # raise a cryptic "object is not iterable" naming an opaque class.  Catch it here and
+    # say what to do.  (A list / numpy array / tuple of vectors has no .solutions/.get_tracker.)
+    if hasattr(start_points, 'solutions') and hasattr(start_points, 'get_tracker'):
+        raise TypeError(
+            "user_homotopy: start_points must be the actual start *points* (an iterable of "
+            "solution vectors), but a {} solver was passed.  Call its .solve() and then pass "
+            "its .solutions():\n"
+            "    start_solver.solve()\n"
+            "    nag_algorithm.user_homotopy(homotopy, start_solver.solutions(), target)"
+            .format(type(start_points).__name__))
     user_start = _pybnalag.UserStartSystem(target, list(start_points))
     solver = solver_cls(target, user_start, homotopy)
     return _UserHomotopySolver(solver, homotopy, target, user_start)

--- a/python/test/zero_dim/parameter_homotopy_test.py
+++ b/python/test/zero_dim/parameter_homotopy_test.py
@@ -54,6 +54,21 @@ def test_user_homotopy_rejects_bad_precision():
         pb.nag_algorithm.user_homotopy(H, [], target, precision='quadruple')
 
 
+def test_user_homotopy_rejects_solver_as_start_points():
+    # Regression for issue #258: passing the start-point *solver* (not its .solutions())
+    # used to fail with a cryptic "object is not iterable"; now it explains the mistake.
+    x, t = pb.Variable('x'), pb.Variable('t')
+    H = pb.System(); H.add_variable_group(pb.VariableGroup([x])); H.add_function(x * x - (4 - 3 * t)); H.add_path_variable(t)
+    target = pb.System(); target.add_variable_group(pb.VariableGroup([x])); target.add_function(x * x - 1)
+
+    generic = pb.System(); generic.add_variable_group(pb.VariableGroup([x])); generic.add_function(x * x - 4)
+    solver = pb.nag_algorithm.ZeroDim(generic, mptype='adaptive')   # a solver, not solutions
+
+    import pytest
+    with pytest.raises(TypeError, match="start_points must be"):
+        pb.nag_algorithm.user_homotopy(H, solver, target)
+
+
 def test_coefficient_parameter_homotopy_helper():
     # the coefficient_parameter_homotopy helper builds (1-t)*target + t*generic for you.
     x = pb.Variable('x')


### PR DESCRIPTION
## What

Fixes the cryptic error from [bertiniteam/b2#258](https://github.com/bertiniteam/b2/issues/258):

```
TypeError: 'ZeroDimCauchyAdaptivePrecisionTotalDegree' object is not iterable
```

The reporter passed a **ZeroDim solver object** as `start_points` to `user_homotopy(...)`, instead of the solver's `.solutions()`. `list(start_points)` then failed with an opaque message naming the solver class, giving no hint about the actual mistake.

## Change

In `user_homotopy`, detect a solver was passed (via its `.solutions`/`.get_tracker` fingerprint — a list/numpy array of vectors has neither) and raise a clear `TypeError` telling the user to call `.solve()` then pass `.solutions()`. Matches the existing friendly-error idiom in the same file.

Adds a regression test (`test_user_homotopy_rejects_solver_as_start_points`).

## Verification

- `pytest python/test/zero_dim/` — all pass
- Reproduced the issue's pattern and confirmed the new message replaces the cryptic one

🤖 Generated with [Claude Code](https://claude.com/claude-code)