### PR TITLE
refactor(python): to_dataframe keeps the whole solution in one column

### DIFF
--- a/python/bertini/nag_algorithm/__init__.py
+++ b/python/bertini/nag_algorithm/__init__.py
@@ -75,12 +75,18 @@ _SOLUTION_METADATA_FIELDS = (
 def _zerodim_to_dataframe(self, *, user_coords=True, omit_infinite=True, merge_multiplicities=True):
     """The solve as a pandas DataFrame -- one row per solution, the "database of solutions".
 
-    Columns are the solution coordinates ``x0, x1, ...``, then every per-solution metadata field
-    (``is_finite``, ``is_real``, ``is_singular``, ``multiplicity``, ``condition_number``,
-    ``endgame_success``, ``max_precision_used``, ...), and finally ``system`` -- a reference to the
-    (target) system these solutions satisfy, so rows accumulated from several solves stay
-    identifiable.  Each category is then a one-line filter, e.g. ``df[df.is_real & ~df.is_singular]``
-    (nonsingular real) or ``df[~df.is_finite]`` (at infinity).
+    Columns are ``solution`` -- the whole solution point, kept in a single cell -- then every
+    per-solution metadata field (``is_finite``, ``is_real``, ``is_singular``, ``multiplicity``,
+    ``condition_number``, ``endgame_success``, ``max_precision_used``, ...), and finally ``system``,
+    a reference to the (target) system these solutions satisfy (so rows accumulated from several
+    solves stay identifiable).  Each category is then a one-line filter, e.g.
+    ``df[df.is_real & ~df.is_singular]`` (nonsingular real) or ``df[~df.is_finite]`` (at infinity).
+
+    The ``solution`` cell is an independent copy of the solution vector (a numpy array of Python
+    ``complex`` for a double solve, of :class:`bertini.multiprec.Complex` for a multiprecision one,
+    so no precision is lost).  Coordinates are deliberately **not** exploded into ``x0, x1, ...``
+    columns; split them yourself if you want them, e.g.
+    ``df['x'] = [v[0] for v in df.solution]``.
 
     Parameters
     ----------
@@ -101,9 +107,9 @@ def _zerodim_to_dataframe(self, *, user_coords=True, omit_infinite=True, merge_m
     Returns
     -------
     pandas.DataFrame
-        One row per solution; coordinate cells are Python ``complex`` for a double-precision solve
-        and :class:`bertini.multiprec.Complex` for a multiprecision one (kept native, so no
-        precision is lost).
+        One row per solution; the ``solution`` cell is a copied vector whose elements are Python
+        ``complex`` for a double-precision solve and :class:`bertini.multiprec.Complex` for a
+        multiprecision one (kept native, so no precision is lost).
 
     Notes
     -----
@@ -130,13 +136,12 @@ def _zerodim_to_dataframe(self, *, user_coords=True, omit_infinite=True, merge_m
             continue
         if merge_multiplicities and not m.multiplicity_representative:
             continue                    # a duplicate copy of an already-kept multiple solution
-        pt = points[i]
-        # COPY each coordinate as it is read.  Indexing the eigenpy vector returns a scalar that
-        # aliases a reused internal buffer; storing the live references and letting pandas read them
-        # later collapses every cell to one value.  type(c)(c) makes an independent copy of the
-        # right type -- a Python complex for a double solve, a bertini.multiprec.Complex for a
-        # multiprecision one (so no precision is lost) -- and must happen before the next index.
-        row = {'x{}'.format(k): (lambda c: type(c)(c))(pt[k]) for k in range(len(pt))}
+        # The whole solution lives in one cell.  .copy() snapshots the eigenpy vector's buffer --
+        # essential, because indexing that vector lazily returns scalars that alias a reused
+        # internal buffer, so storing the live vector (or its elements) and letting pandas read it
+        # later would collapse every cell to one value.  The copy keeps the native element type, so
+        # a multiprecision solve loses no precision.
+        row = {'solution': points[i].copy()}
         for field in _SOLUTION_METADATA_FIELDS:
             row[field] = getattr(m, field)
         row['system'] = system          # a reference, so rows from different solves stay identifiable

--- a/python/docs/source/tutorials/solution_database.rst
+++ b/python/docs/source/tutorials/solution_database.rst
@@ -44,8 +44,8 @@ One row per solution
 ====================
 
 :meth:`to_dataframe` lays the solve out as a table.  By default it keeps only the finite
-solutions (``omit_infinite=True``); each row is a solution, with a column per coordinate
-(``x0``, ``x1``) followed by every metadata field.
+solutions (``omit_infinite=True``); each row is a solution -- the whole point in a single
+``solution`` column, followed by every metadata field.
 
 .. testcode::
 
@@ -53,7 +53,12 @@ solutions (``omit_infinite=True``); each row is a solution, with a column per co
 
    df = solver.to_dataframe()
    assert len(df) == 5                         # five distinct finite solutions
-   assert {'x0', 'x1', 'is_real', 'is_singular', 'multiplicity'} <= set(df.columns)
+   assert {'solution', 'is_real', 'is_singular', 'multiplicity'} <= set(df.columns)
+   assert len(df['solution'].iloc[0]) == 2     # each cell is the whole (x, y) point
+
+The ``solution`` cell is the whole point (a copied vector), **not** exploded into ``x0``, ``x1``,
+... columns -- if you want per-coordinate columns, you split it yourself (we do exactly that for
+plotting, below).
 
 **One row per distinct solution.**  A multiplicity-:math:`m` solution arrives from the solver as
 :math:`m` coincident endpoints -- the node here is the end of *two* paths.  Carrying :math:`m`
@@ -98,13 +103,14 @@ of **complex** numbers -- four real numbers -- but the page has only two axes.  
 solutions are genuine points of the real :math:`(x, y)` plane; the complex ones are not there at
 all.  So we draw two different kinds of picture.
 
-To plot, lift each coordinate from a :class:`bertini.multiprec.Complex` to a Python ``complex`` and
-split it into real and imaginary parts -- pandas does this column-at-a-time:
+To plot, pull the two coordinates out of the ``solution`` cell -- each is a
+:class:`bertini.multiprec.Complex` -- and lift them to Python ``complex`` so we can take real and
+imaginary parts.  This is the "split it yourself" step: one column per coordinate, made on demand.
 
 .. testcode::
 
-   df['x'] = [complex(v) for v in df.x0]
-   df['y'] = [complex(v) for v in df.x1]
+   df['x'] = [complex(p[0]) for p in df.solution]
+   df['y'] = [complex(p[1]) for p in df.solution]
    df['x_re'], df['x_im'] = df.x.map(lambda z: z.real), df.x.map(lambda z: z.imag)
    df['y_re'], df['y_im'] = df.y.map(lambda z: z.real), df.y.map(lambda z: z.imag)
 

--- a/python/test/zero_dim/solution_access_test.py
+++ b/python/test/zero_dim/solution_access_test.py
@@ -75,8 +75,10 @@ def test_to_dataframe_finite_only_by_default(one_finite_one_infinite_solver):
     # omit_infinite defaults True: just the one genuine finite solution
     assert len(df) == 1
     assert bool(df['is_finite'].all())
-    # coordinates first, then metadata columns
-    assert 'x0' in df.columns and 'x1' in df.columns
+    # the whole point lives in one 'solution' column -- coordinates are NOT exploded into x0,x1,...
+    assert 'solution' in df.columns
+    assert 'x0' not in df.columns and 'x1' not in df.columns
+    assert len(df['solution'].iloc[0]) == 2          # a 2-vector for this 2-variable system
     for col in ('is_finite', 'is_real', 'is_singular', 'multiplicity', 'endgame_success'):
         assert col in df.columns
 
@@ -101,9 +103,9 @@ def test_to_dataframe_coords_match_points(two_circles_solver):
     df = two_circles_solver.to_dataframe()
     pts = two_circles_solver.finite_solutions()
     assert len(df) == len(pts)
-    # the x0 column reproduces each finite solution's first coordinate
+    # the solution column reproduces each finite solution's first coordinate
     key = lambda z: (z.real, z.imag)
-    df_x0 = sorted((complex(v) for v in df['x0']), key=key)
+    df_x0 = sorted((complex(v[0]) for v in df['solution']), key=key)
     pt_x0 = sorted((complex(p[0]) for p in pts), key=key)
     for a, b in zip(df_x0, pt_x0):
         assert a == pytest.approx(b)
@@ -122,14 +124,14 @@ def four_root_solver():
     return solver
 
 
-def test_to_dataframe_coordinates_are_independent_per_row(four_root_solver):
-    """Regression: the coordinate columns must hold each row's OWN value.
+def test_to_dataframe_solutions_are_independent_per_row(four_root_solver):
+    """Regression: the solution column must hold each row's OWN point.
 
     to_dataframe stored the value returned by indexing the eigenpy solution vector, which is a
     view aliasing a reused internal buffer; the live references then collapsed so every row showed
-    the same coordinate.  Two rows never triggered it -- it needs several distinct solutions.  The
-    four roots (+/-1, +/-1) have two distinct x-values and two distinct y-values, so an aliased
-    frame would show only one.  Assert the DataFrame reproduces all_solutions exactly.
+    the same point.  Two rows never triggered it -- it needs several distinct solutions.  The four
+    roots (+/-1, +/-1) have two distinct x-values and two distinct y-values, so an aliased frame
+    would show only one.  Assert the DataFrame reproduces all_solutions exactly.
     """
     pytest.importorskip("pandas")
     s = four_root_solver
@@ -137,13 +139,13 @@ def test_to_dataframe_coordinates_are_independent_per_row(four_root_solver):
     assert len(df) == 4
 
     key = lambda z: (round(z.real, 6), round(z.imag, 6))
-    for col, coord in (('x0', 0), ('x1', 1)):
-        from_df  = sorted((complex(v) for v in df[col]), key=key)
+    for coord in (0, 1):
+        from_df  = sorted((complex(v[coord]) for v in df['solution']), key=key)
         from_pts = sorted((complex(p[coord]) for p in s.finite_solutions()), key=key)
         for a, b in zip(from_df, from_pts):
             assert a == pytest.approx(b)
     # the x-coordinates really are both +1 and -1 (not one value repeated)
-    assert {round(complex(v).real) for v in df['x0']} == {-1, 1}
+    assert {round(complex(v[0]).real) for v in df['solution']} == {-1, 1}
 
 
 def test_to_dataframe_has_system_reference_column(four_root_solver):


### PR DESCRIPTION
## `to_dataframe`: keep the whole solution in one column

Follow-up to #30.  `to_dataframe` was exploding each solution into per-coordinate columns
`x0`, `x1`, … .  This puts the **whole point in a single `solution` column** instead.  If a user
wants a column per coordinate, that is their call:

```python
df = solver.to_dataframe()
df['x'] = [p[0] for p in df.solution]      # split it yourself, on demand
df['y'] = [p[1] for p in df.solution]
```

### Cell representation
The `solution` cell is `points[i].copy()` — an independent snapshot of the eigenpy solution
vector that keeps its **native element type** (Python `complex` for a double solve,
`bertini.multiprec.Complex` for a multiprecision one, so no precision is lost).  The `.copy()` is
essential: indexing the vector lazily aliases a reused internal buffer, so storing the live vector
and letting pandas read it later would collapse every cell — the same aliasing class fixed in #30
(and behind #259).  Verified alias-safe over a stress loop in the worst import order.

### Tests / docs
- Tests updated for the single column; the aliasing regression now reads `df.solution`.
- Tutorial revised: the solution is one column, and the plotting step pulls coordinates out of it
  on demand — which now *demonstrates* the "split it yourself" workflow.

Doctests (114) and the zero_dim suite (95) pass; pure-Python change, no rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
