### PR TITLE
fix: reject equations in the wrong block of a moving homotopy (#258)

### DIFF
--- a/core/src/system/system.cpp
+++ b/core/src/system/system.cpp
@@ -26,6 +26,9 @@
 #include "bertini2/system/system.hpp"
 #include "bertini2/function_tree/find.hpp"
 
+#include <algorithm>
+#include <sstream>
+
 template<typename NumT> using Vec = bertini::Vec<NumT>;
 template<typename NumT> using Mat = bertini::Mat<NumT>;
 using Nd = std::shared_ptr<bertini::node::Node>;
@@ -1567,6 +1570,45 @@ namespace bertini
 			throw std::runtime_error("MakeMovingHomotopy: fixed, start_moving and end_moving must share the same variable structure.");
 		if (start_moving.HavePathVariable() || end_moving.HavePathVariable() || fixed.HavePathVariable())
 			throw std::runtime_error("MakeMovingHomotopy: the fixed and moving systems must not already have a path variable.");
+
+		// Catch the equations being placed in the wrong block.  Compare top-level functions
+		// structurally (their serialized form, the same one the classic writer emits), expanding any
+		// structured block via NaturalFunctionsAsNodes so polynomial and slice/products rows alike are
+		// covered.  Two failure modes:
+		//   * a fixed equation also living in the moving rows -- the rows that move must be ONLY the
+		//     moving rows, so a fixed function appearing there is a duplicate (the typical cause:
+		//     concatenating the fixed system into start_moving/end_moving; see issue #258); and
+		//   * a moving row identical at both endpoints -- it does not actually move and belongs in
+		//     `fixed`.  The blend pairs the moving rows by position, so this check is positional.
+		auto function_strings = [](System const& s) {
+			std::vector<std::string> out;
+			for (auto const& f : s.NaturalFunctionsAsNodes())
+			{
+				std::ostringstream ss;
+				ss << f;
+				out.push_back(ss.str());
+			}
+			return out;
+		};
+		auto const fixed_funcs = function_strings(fixed);
+		auto const start_funcs = function_strings(start_moving);
+		auto const end_funcs   = function_strings(end_moving);
+
+		for (auto const& f : fixed_funcs)
+			if (std::find(start_funcs.begin(), start_funcs.end(), f) != start_funcs.end()
+			 || std::find(end_funcs.begin(),   end_funcs.end(),   f) != end_funcs.end())
+				throw std::runtime_error(
+					"MakeMovingHomotopy: the function `" + f + "` appears in both the fixed system and "
+					"the moving rows.  start_moving/end_moving must contain ONLY the rows that move "
+					"(e.g. the sliding slice), not the fixed system as well -- did you concatenate the "
+					"fixed system into them?");
+
+		for (size_t i = 0; i < start_funcs.size(); ++i)   // start/end agree in count (checked above)
+			if (start_funcs[i] == end_funcs[i])
+				throw std::runtime_error(
+					"MakeMovingHomotopy: moving row " + std::to_string(i) + " (`" + start_funcs[i]
+					+ "`) is identical in start_moving and end_moving, so it does not move; put "
+					"non-moving equations in `fixed` instead.");
 
 		auto t = node::Variable::Make(path_variable_name);
 		auto g = gamma ? gamma

--- a/core/test/classes/moving_homotopy_test.cpp
+++ b/core/test/classes/moving_homotopy_test.cpp
@@ -225,6 +225,48 @@ BOOST_AUTO_TEST_CASE(rejects_mismatched_endpoints)
 	BOOST_CHECK_THROW(MakeMovingHomotopy(fixed, sm, em, "t", Gamma()), std::runtime_error);
 }
 
+// Regression (b2 issue #258): concatenating the fixed system INTO the moving rows (instead of
+// passing only the rows that move) duplicates the fixed equations.  The count/structure checks pass
+// (both moving systems have 2 functions over the same variables), so the duplication is caught by
+// the structural top-level-function comparison instead.
+BOOST_AUTO_TEST_CASE(rejects_fixed_function_duplicated_in_moving_rows)
+{
+	DefaultPrecision(30);
+	auto x = Variable::Make("x"), y = Variable::Make("y");
+	auto circle = x*x + y*y - node::Integer::Make(1);
+	System fixed; fixed.AddVariableGroup(VariableGroup{x, y}); fixed.AddFunction(circle);
+
+	// the mistake: moving rows = fixed (circle) AND the slice, in both endpoints.
+	System sm; sm.AddVariableGroup(VariableGroup{x, y}); sm.AddFunction(circle); sm.AddFunction(y);
+	System em; em.AddVariableGroup(VariableGroup{x, y}); em.AddFunction(circle); em.AddFunction(y - x);
+	BOOST_CHECK_THROW(MakeMovingHomotopy(fixed, sm, em, "t", Gamma()), std::runtime_error);
+
+	// even a structurally-equal but independently-built copy of the fixed function is caught
+	// (comparison is by serialized form, not pointer identity).
+	System sm2; sm2.AddVariableGroup(VariableGroup{x, y}); sm2.AddFunction(x*x + y*y - node::Integer::Make(1)); sm2.AddFunction(y);
+	System em2; em2.AddVariableGroup(VariableGroup{x, y}); em2.AddFunction(x*x + y*y - node::Integer::Make(1)); em2.AddFunction(y - x);
+	BOOST_CHECK_THROW(MakeMovingHomotopy(fixed, sm2, em2, "t", Gamma()), std::runtime_error);
+
+	// the correct call (slice-only moving rows) still builds.
+	System sm_ok; sm_ok.AddVariableGroup(VariableGroup{x, y}); sm_ok.AddFunction(y);
+	System em_ok; em_ok.AddVariableGroup(VariableGroup{x, y}); em_ok.AddFunction(y - x);
+	BOOST_CHECK_NO_THROW(MakeMovingHomotopy(fixed, sm_ok, em_ok, "t", Gamma()));
+}
+
+// A "moving" row that is identical at both endpoints does not move; it belongs in `fixed`.  The
+// check is positional (the blend pairs start/end rows by index), so row 1 here trips it while the
+// genuinely-moving row 0 does not.
+BOOST_AUTO_TEST_CASE(rejects_non_moving_row_in_moving_block)
+{
+	DefaultPrecision(30);
+	auto x = Variable::Make("x"), y = Variable::Make("y");
+	System fixed; fixed.AddVariableGroup(VariableGroup{x, y}); fixed.AddFunction(x*x + y*y - node::Integer::Make(1));
+
+	System sm; sm.AddVariableGroup(VariableGroup{x, y}); sm.AddFunction(y);     sm.AddFunction(x);  // row 1: x
+	System em; em.AddVariableGroup(VariableGroup{x, y}); em.AddFunction(y - x); em.AddFunction(x);  // row 1: x (static!)
+	BOOST_CHECK_THROW(MakeMovingHomotopy(fixed, sm, em, "t", Gamma()), std::runtime_error);
+}
+
 // Regression: Clone(System) is now a Memory-isolating shallow copy --- it shares the
 // immutable node DAG and the compiled SLP Program, but copies the per-thread evaluation Memory at
 // every level, INCLUDING a BlendBlock's nested operand Systems (which are deep-copied via the


### PR DESCRIPTION
## What

Follow-up to #31 (the Python `user_homotopy` solver-arg guard, already merged). Same root issue [bertiniteam/b2#258](https://github.com/bertiniteam/b2/issues/258): the reporter's moving-homotopy slice move also mis-placed equations — they concatenated the fixed system *into* the moving rows, duplicating the fixed equations. `MakeMovingHomotopy` only checked function counts and variable structure, so it silently built a wrong homotopy.

## Change

Add a structural top-level-function comparison in `MakeMovingHomotopy` (serialized form, expanding structured blocks via `NaturalFunctionsAsNodes` so polynomial and slice/products rows alike are covered):

- **a fixed equation also present in the moving rows** → nice error naming the function, with the "did you concatenate the fixed system in?" hint;
- **a moving row identical at both endpoints (positionally)** → nice error, since it does not move and belongs in `fixed`.

Overdetermined-but-distinct moving homotopies remain valid — squareness is *not* required here (`Randomize()` squares them down later).

Adds C++ regression tests for both failure modes.

## Verification

- `test_classes` (`moving_homotopy_suite`) green, including the two new cases
- End-to-end through the binding, the issue's exact mistake now reports `the function ``x^4-x^2-y^2`` appears in both the fixed system and the moving rows …`, and the correct slices-only call still builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)