### PR TITLE
Expose WitnessSet + a block-backed Slice (enable NID)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,8 +14,13 @@ Bertini 2 (b2) is a C++17 numerical algebraic geometry library with Python bindi
 # Configure (from repo root)
 cmake -DENABLE_UNIT_TESTING=ON -G Ninja -B build -S .
 
-# Build
+# Build everything (core library, bindings, exe, tests)
 cmake --build build --target all --config Release
+
+# For iterative C++ work, build just the core library first -- it's much faster, and
+# the heavy Boost.Python/eigenpy bindings (`_pybertini`) only need rebuilding when the
+# bindings themselves change:
+cmake --build build --target bertini2 --config Release
 
 # Run all C++ tests
 ctest --test-dir build/core
@@ -57,6 +62,7 @@ ctest --test-dir build/core
 ./build/core/test_generating
 ./build/core/test_nag_algorithms
 ./build/core/test_nag_datatypes
+./build/core/test_pool
 ./build/core/test_tracking_basics
 ./build/core/test_settings
 ```
@@ -86,13 +92,13 @@ cross-test state.
 The project has three layers, built in order:
 
 1. **`core/`** -- C++ shared library (`libbertini2`). Header-only-heavy design under `core/include/bertini2/`. Key subsystems:
-   - `function_tree/` -- Expression tree (nodes, operators, symbols) for representing polynomial systems
+   - `function_tree/` -- Expression tree (nodes, operators, symbols) for *building and representing* polynomial systems. Nodes no longer evaluate: node-level recursive evaluation was removed -- the **SLP (`straight_line_program`) is the sole evaluator** (compile a system once, evaluate the compiled program). `Function`/`Handle` are gone; `NamedExpression` is the sole root node. See ADR-0027 (SLP: immutable Program + per-thread Memory) and ADR-0028 (named-node taxonomy).
    - `system/` -- Polynomial system construction, start systems (`start/total_degree.hpp`, `start/mhom.hpp`), patches, slices
    - `trackers/` -- Path tracking (fixed-precision and adaptive-precision trackers, predictors, Newton correctors)
    - `endgames/` -- Power series and Cauchy endgames for singular endpoint handling
-   - `nag_algorithms/` -- Higher-level algorithms (zero-dim solve, numerical irreducible decomposition)
+   - `nag_algorithms/` -- Higher-level algorithms (zero-dim solve; numerical irreducible decomposition is *framework scaffolding* -- not yet implemented, its `Solve()` throws)
    - `io/parsing/` -- Boost.Spirit Qi parsers for classic Bertini input format
-   - `blackbox/` -- CLI executable entry point (`bertini2_exe`)
+   - `blackbox/` -- CLI executable entry point (CMake target `bertini2_exe`, binary named `bertini2`)
 
 2. **`python_bindings/`** -- Boost.Python + eigenpy bindings producing `_pybertini` native module. Each `*_export.cpp` wraps the corresponding C++ subsystem. Depends on `eigenpy` for NumPy/Eigen interop.
 
@@ -101,9 +107,9 @@ The project has three layers, built in order:
 ## Key Dependencies
 
 - **GMP/MPFR/MPC** -- Arbitrary-precision arithmetic (found via custom CMake modules in `cmake/`)
-- **Eigen 3.3** -- Linear algebra (pinned to v3.3)
-- **Boost** (serialization, filesystem, log, graph, regex, timer, chrono, thread, unit_test_framework, python) -- Boost >= 1.82 required; `boost_system` is conditionally linked for Boost < 1.89
-- **eigenpy** -- Eigen/NumPy bridge for Python bindings
+- **Eigen 3** -- Linear algebra. **Not** pinned in cmake (`find_package(Eigen3)`, no version floor). In practice the version is coupled to the eigenpy build: the wheel CI builds **eigen 3.4.0** and then builds eigenpy against it (a dev env may use newer, e.g. `eigen=5.0.1`). Newer Eigen is welcome -- we *want* upstream improvements -- but it must be matched by an eigenpy built against the same Eigen (they share Eigen types across the binding ABI).
+- **Boost** (serialization, filesystem, log, graph, regex, timer, chrono, thread, unit_test_framework, python) -- no minimum version pinned in cmake; `boost_system` is conditionally linked for Boost < 1.89 (header-only from 1.89). Boost.Python is ABI-locked to one CPython version, so CI rebuilds it per target Python.
+- **eigenpy** -- Eigen/NumPy bridge for Python bindings. Built **from source** in CI at a single pinned version (`EIGENPY_VERSION` in `build_and_test.yml`, currently `3.13.0`) against the chosen Eigen -- eigenpy and bertini must use the *same* Eigen. eigenpy >= 3.13 sets the Python floor (>= 3.10).
 - **jrl-cmakemodules** -- CMake helper macros (auto-fetched via FetchContent if not found)
 
 ## Build System Notes

--- a/core/include/bertini2/nag_datatypes/numerical_irreducible_decomposition.hpp
+++ b/core/include/bertini2/nag_datatypes/numerical_irreducible_decomposition.hpp
@@ -33,6 +33,7 @@
 
 #include <algorithm>
 #include <vector>
+#include <boost/serialization/vector.hpp>
 
 namespace bertini {
 
@@ -97,6 +98,18 @@ namespace bertini {
 						w_correct_dim.push_back(w);
 
 				return w_correct_dim;
+			}
+
+		private:
+
+			friend class boost::serialization::access;
+
+			/// Serialize the stored witness sets.  Each WitnessSet handles its own load-time fixup
+			/// (re-differentiating its system), so this is just the container.
+			template <typename Archive>
+			void serialize(Archive& ar, const unsigned /*version*/)
+			{
+				ar & finished_witness_sets_;
 			}
 
 		};

--- a/core/include/bertini2/nag_datatypes/witness_set.hpp
+++ b/core/include/bertini2/nag_datatypes/witness_set.hpp
@@ -74,7 +74,7 @@ namespace bertini {
 		class WitnessSet
 		{
 			using PointP = ObjManagementP<Vec<NumT>>;
-			using SliceP = ObjManagementP<LinearSlice>;
+			using SliceP = ObjManagementP<Slice>;
 			using SystemP = ObjManagementP<SystemT>;
 
 			using PointContT = PointCont<typename PointP::HeldT>;
@@ -216,7 +216,7 @@ public:
 			/**
 			Gets (a const reference to) the slice for the witness set.
 			*/
-			const LinearSlice & GetSlice() const
+			const Slice & GetSlice() const
 			{
 				return SliceP::AtGet(slice_);
 			}

--- a/core/include/bertini2/nag_datatypes/witness_set.hpp
+++ b/core/include/bertini2/nag_datatypes/witness_set.hpp
@@ -30,6 +30,8 @@
 #pragma once
 
 #include <deque>
+#include <boost/serialization/deque.hpp>
+#include <boost/serialization/split_member.hpp>
 #include "bertini2/eigen_extensions.hpp"
 #include "bertini2/nag_datatypes/common/policies.hpp"
 #include "bertini2/system/slice.hpp"
@@ -229,6 +231,38 @@ public:
 				return (GetSystem().NumVariables() - GetSystem().NumNaturalFunctions()) == GetSlice().Dimension();
 			}
 
+
+		private:
+
+			friend class boost::serialization::access;
+
+			/// Serialize the witness set's three parts (points, slice, system).  Save/load are split
+			/// so load can restore the system's differentiated form + working precision afterwards:
+			/// System::serialize persists neither, so without this a deserialized witness set's system
+			/// would be unusable for evaluation/tracking.  Doing it here (not just in the Python pickle
+			/// suite) makes the C++ deserialize path -- the one MPI and threading use -- correct too.
+			template <typename Archive>
+			void save(Archive& ar, const unsigned /*version*/) const
+			{
+				ar & points_;
+				ar & slice_;
+				ar & system_;
+			}
+
+			template <typename Archive>
+			void load(Archive& ar, const unsigned /*version*/)
+			{
+				ar & points_;
+				ar & slice_;
+				ar & system_;
+				// GetSystem() is const and returns a const System&; Differentiate()/precision() are
+				// const (they mutate only the system's mutable evaluation state), so this restores
+				// the held system in place regardless of object-management policy.
+				GetSystem().Differentiate();
+				GetSystem().precision(GetSystem().precision());
+			}
+
+			BOOST_SERIALIZATION_SPLIT_MEMBER()
 
 		};
 	}

--- a/core/include/bertini2/system/blocks/linear_forms_block.hpp
+++ b/core/include/bertini2/system/blocks/linear_forms_block.hpp
@@ -40,9 +40,9 @@ convention of ProductsOfLinearsBlock, but with one factor per function instead o
 product.  Evaluation is a single matrix-vector multiply; the Jacobian is the constant
 coefficient matrix (its variable columns).
 
-Mirrors the multiprecision-coefficient pattern of ProductsOfLinearsBlock / bertini::
-LinearSlice: an mpfr master plus per-type working copies, with Precision() recasting the
-mpfr copy.
+Mirrors the multiprecision-coefficient pattern of ProductsOfLinearsBlock: an mpfr master
+plus per-type working copies, with Precision() recasting the mpfr copy.  bertini::Slice
+(system/slice.hpp) is a thin wrapper around this block.
 */
 
 #pragma once

--- a/core/include/bertini2/system/blocks/products_of_linears_block.hpp
+++ b/core/include/bertini2/system/blocks/products_of_linears_block.hpp
@@ -35,8 +35,9 @@ evaluated augmented with a trailing 1).  Evaluation is matrix-multiplies followe
 row-wise products; the Jacobian is the product rule, done with prefix/suffix products.
 Nothing here is a function-tree node, so it never touches the SLP compiler.
 
-Mirrors the multiprecision-coefficient pattern of bertini::LinearSlice (system/slice.hpp):
-an mpfr master plus per-type working copies, with Precision() recasting the mpfr copy.
+Uses the multiprecision-coefficient pattern shared by the linear blocks (system/blocks/
+linear_forms_block.hpp): an mpfr master plus per-type working copies, with Precision()
+recasting the mpfr copy.
 */
 
 #pragma once

--- a/core/include/bertini2/system/slice.hpp
+++ b/core/include/bertini2/system/slice.hpp
@@ -15,67 +15,91 @@
 //
 // Copyright(C) Bertini2 Development Team
 //
-// See <http://www.gnu.org/licenses/> for a copy of the license, 
-// as well as COPYING.  Bertini2 is provided with permitted 
+// See <http://www.gnu.org/licenses/> for a copy of the license,
+// as well as COPYING.  Bertini2 is provided with permitted
 // additional terms in the b2/licenses/ directory.
 
 // individual authors of this file include:
 // silviana amethyst, university of wisconsin eau claire
 
 /**
-\file bertini2/system/slice.hpp 
+\file bertini2/system/slice.hpp
 
-\brief Provides the bertini::LinearSlice class.
+\brief Provides the bertini::Slice class -- a linear slice of affine or projective space.
+
+A Slice is the linear part of a witness set: a stack of linear forms whose common zero set
+cuts a positive-dimensional component down to isolated witness points.  It is backed by a
+bertini::blocks::LinearFormsBlock (the augmented coefficient matrix M, one row per linear
+form, the last column carrying each form's constant term), so a Slice evaluates, carries
+precision, and drops into a System exactly like any other evaluation block.  Because that
+augmented (num_vars+1)-column layout is shared with ProductsOfLinearsBlock, a Slice's rows
+are also ready-made factors for a product-of-linears block -- the composition regeneration
+needs.
+
+\see bertini::blocks::LinearFormsBlock
+\see bertini::blocks::ProductsOfLinearsBlock
 */
 
 
 #ifndef BERTINI_SLICE_HPP
 #define BERTINI_SLICE_HPP
 
+#include <vector>
+
 #include "bertini2/function_tree.hpp"
 #include "bertini2/num_traits.hpp"
 #include "bertini2/eigen_extensions.hpp"
+#include "bertini2/system/blocks/linear_forms_block.hpp"
 
 
 namespace bertini {
 
+	// Slice::AddTo hands the slice's linear-forms block to a System; we only need System's
+	// name here (the definition lives in slice.cpp, which includes system.hpp).
+	class System;
 
 	/**
-	\brief Base class for other Slices.  
+	\brief A linear slice of affine or projective space: a stack of linear forms, M [x ; 1].
 
-	\see LinearSlice
+	The slice is held as an augmented coefficient matrix (one row per linear form, the
+	trailing column being that form's constant term) inside a LinearFormsBlock.  A
+	homogeneous slice simply has a zero constant column.  Slices compose: Head / Tail / Rows
+	return a new Slice over the same variables built from a subset of the linear forms.
 	*/
 	class Slice
 	{
+		blocks::LinearFormsBlock block_;  ///< the linear forms M [x ; 1] -- eval / precision / coefficients
+		VariableGroup sliced_vars_;       ///< the variables this slice is a function of
+		bool is_homogeneous_ = false;     ///< whether the forms were authored without constant terms
 
-	};
-
-
-
-	/**
-	\brief Slice an affine or projective space with a LinearSlice today!
-	*/
-	class LinearSlice : public Slice
-	{
-
-
-		mutable std::tuple<Mat<dbl>, Mat<mpfr_complex> > coefficients_working_;
-		Mat< mpfr_complex > coefficients_highest_precision_; ///< the highest-precision coefficients for the patch
-
-		mutable std::tuple<Vec<dbl>, Vec<mpfr_complex> > constants_working_;
-		Vec< mpfr_complex > constants_highest_precision_; ///< the highest-precision coefficients for the patch
-
-		VariableGroup sliced_vars_;
-		unsigned num_dims_sliced_;
-		mutable unsigned precision_; ///< the current working precision of the patch.
-
-		bool is_homogeneous_;
 	public:
 
+		/// An empty slice (zero forms, zero variables).
+		Slice() = default;
+
 		/**
-		Produce a random real slice on a variable group, slicing a given number of dimensions.
+		\brief Build a slice directly from an augmented coefficient matrix.
+
+		\param v The variables the slice is a function of.
+		\param augmented_coefficients One row per linear form, (number-of-forms) x (v.size()+1);
+		       the trailing column is each form's constant term (zero, for a homogeneous slice).
+		\param homogeneous Whether the slice was authored without constant terms.
 		*/
-		static LinearSlice RandomReal(VariableGroup const& v, unsigned dim, bool homogeneous = false, bool orthogonal = true)
+		static Slice FromCoefficients(VariableGroup const& v, Mat<mpfr_complex> const& augmented_coefficients, bool homogeneous = false)
+		{
+			assert(static_cast<size_t>(augmented_coefficients.cols()) == v.size() + 1 &&
+			       "a slice coefficient matrix must have (num_variables + 1) columns");
+			Slice s;
+			s.sliced_vars_ = v;
+			s.is_homogeneous_ = homogeneous;
+			s.block_ = blocks::LinearFormsBlock(v.size(), augmented_coefficients);
+			return s;
+		}
+
+		/**
+		\brief Produce a random real slice on a variable group, slicing a given number of dimensions.
+		*/
+		static Slice RandomReal(VariableGroup const& v, unsigned dim, bool homogeneous = false, bool orthogonal = true)
 		{
 			typedef void (*funtype) (mpfr_complex&, unsigned); // the type for number generation
 			funtype gen = bertini::multiprecision::RandomRealAssign;
@@ -85,257 +109,246 @@ namespace bertini {
 		/**
 		\brief Generate a random complex slice.
 		*/
-		static LinearSlice RandomComplex(VariableGroup const& v, unsigned dim, bool homogeneous = false, bool orthogonal = true)
+		static Slice RandomComplex(VariableGroup const& v, unsigned dim, bool homogeneous = false, bool orthogonal = true)
 		{
 			typedef void (*funtype) (mpfr_complex&, unsigned); // the type for number generation
 			funtype gen = bertini::multiprecision::RandomComplexAssign;
 			return Make(v, dim, homogeneous, orthogonal, gen);
 		}
 
+		/**
+		\brief Factory for generating slices.  Generates the variable-coefficient block (optionally
+		orthonormalized by a QR factorization) and the constant column, then assembles the augmented
+		matrix the LinearFormsBlock holds.
+		*/
+		static Slice Make(VariableGroup const& v, unsigned dim, bool homogeneous, bool orthogonal, std::function<void(mpfr_complex&, unsigned)> gen)
+		{
+			const unsigned num_vars = static_cast<unsigned>(v.size());
+
+			Mat<mpfr_complex> coeffs(dim, num_vars); // the variable coefficients (one row per form)
+
+			if (orthogonal)
+			{
+				using std::min;
+				using std::max;
+
+				auto mindim = min(dim, num_vars);
+				auto maxdim = max(dim, num_vars);
+
+				bool need_transpose = dim < num_vars;
+
+				coeffs.resize(maxdim, mindim);
+
+				for (unsigned ii(0); ii < maxdim; ++ii)
+					for (unsigned jj(0); jj < mindim; ++jj)
+						gen(coeffs(ii, jj), MaxPrecisionAllowed());
+
+				auto prev_precision = DefaultPrecision();
+				DefaultPrecision(MaxPrecisionAllowed());
+
+				auto QR_factorization = Eigen::HouseholderQR<Mat<mpfr_complex> >(coeffs);
+				coeffs = QR_factorization.householderQ() * Mat<mpfr_complex>::Identity(maxdim, mindim);
+
+				if (need_transpose)
+					coeffs.transposeInPlace();
+
+				DefaultPrecision(prev_precision);
+			}
+			else
+			{
+				for (unsigned ii(0); ii < dim; ++ii)
+					for (unsigned jj(0); jj < num_vars; ++jj)
+						gen(coeffs(ii, jj), MaxPrecisionAllowed());
+			}
+
+			assert(static_cast<unsigned>(coeffs.rows()) == dim);
+			assert(static_cast<unsigned>(coeffs.cols()) == num_vars);
+
+			// Assemble the augmented matrix: [ coeffs | constants ].  A homogeneous slice's constant
+			// column is zero; otherwise it is freshly generated.
+			Mat<mpfr_complex> augmented(dim, num_vars + 1);
+			augmented.leftCols(num_vars) = coeffs;
+			if (homogeneous)
+				augmented.col(num_vars).setZero();
+			else
+				for (unsigned ii(0); ii < dim; ++ii)
+					gen(augmented(ii, num_vars), MaxPrecisionAllowed());
+
+			return FromCoefficients(v, augmented, homogeneous);
+		}
+
 
 		/**
-		\brief Evaluate the function values of the LinearSlice, in-place
+		\brief Evaluate the slice's linear-form values, in-place.
 		*/
 		template<typename NumT>
 		void Eval(Vec<NumT> & result, Vec<NumT> const& x) const
 		{
-			result = std::get<Mat<NumT> >(coefficients_working_) * x;
-
-			if (!is_homogeneous_)
-				result += std::get<Vec<NumT> >(constants_working_);
+			result.resize(Dimension());
+			NumT path_value(0); // ignored: linear forms are autonomous
+			block_.EvalInPlace<NumT>(result, x, path_value);
 		}
 
 		/**
-		\brief Evaluate the function values of the LinearSlice
+		\brief Evaluate the slice's linear-form values.
 		*/
 		template<typename NumT>
 		Vec<NumT> Eval(Vec<NumT> const& x) const
 		{
-			if (!is_homogeneous_)
-				return std::get<Mat<NumT> >(coefficients_working_) * x + std::get<Vec<NumT> >(constants_working_);
-			else
-				return std::get<Mat<NumT> >(coefficients_working_) * x;
+			Vec<NumT> result(Dimension());
+			Eval(result, x);
+			return result;
 		}
 
-
 		/**
-		\brief Evaluate the Jacobian of the LinearSlice, in-place
+		\brief The slice's Jacobian (its constant variable-coefficient matrix), in-place.
 		*/
 		template<typename NumT>
-		void Jacobian(Mat<NumT> & result, Mat<NumT> const& x) const
+		void Jacobian(Mat<NumT> & result, Vec<NumT> const& x) const
 		{
-			result = std::get<Mat<NumT> >(coefficients_working_);
+			result.resize(Dimension(), NumVariables());
+			NumT path_value(0);
+			block_.JacobianInPlace<NumT>(result, x, path_value);
 		}
 
 		/**
-		\brief Evaluate the Jacobian of the LinearSlice
+		\brief The slice's Jacobian (its constant variable-coefficient matrix).
 		*/
 		template<typename NumT>
-		Mat<NumT> Jacobian(Mat<NumT> const& x) const
+		Mat<NumT> Jacobian(Vec<NumT> const& x) const
 		{
-			return std::get<Mat<NumT> >(coefficients_working_);
+			Mat<NumT> result(Dimension(), NumVariables());
+			Jacobian(result, x);
+			return result;
 		}
 
 
+		/**
+		\brief The augmented coefficient matrix: one row per linear form, (Dimension) x (NumVariables+1),
+		the trailing column carrying each form's constant term.
+
+		These rows are also factor rows for a ProductsOfLinearsBlock, so a slice composes directly into
+		the product-of-linears form regeneration uses.
+		*/
+		Mat<mpfr_complex> const& Coefficients() const
+		{
+			return block_.Coefficients();
+		}
+
+		/// The underlying linear-forms block (eval / Jacobian / precision engine).
+		blocks::LinearFormsBlock const& AsLinearFormsBlock() const
+		{
+			return block_;
+		}
+
+		/// Add this slice's linear forms to a System as a LinearFormsBlock.  (Defined in slice.cpp.)
+		void AddTo(System & s) const;
 
 
 		/**
-		\brief Get the current precision of the slice.
-
-		\return The current precision, in digits.
+		\brief A new slice over the same variables built from the first \p m linear forms.
 		*/
-		unsigned Precision() const
+		Slice Head(unsigned m) const
 		{
-			return precision_;
+			if (m > Dimension())
+				throw std::runtime_error("Slice::Head asked for more forms than the slice has");
+			return FromCoefficients(sliced_vars_, Coefficients().topRows(m), is_homogeneous_);
 		}
 
 		/**
-		\brief Set the precision of the slice.
-	
-		Copies the slice coefficients into correct precision for subsequent precision.
-
-		\param new_precision The precision to change to.
+		\brief A new slice over the same variables built from the last \p m linear forms.
 		*/
-		void Precision(unsigned new_precision) const
+		Slice Tail(unsigned m) const
 		{
-			if (new_precision > DoublePrecision())
+			if (m > Dimension())
+				throw std::runtime_error("Slice::Tail asked for more forms than the slice has");
+			return FromCoefficients(sliced_vars_, Coefficients().bottomRows(m), is_homogeneous_);
+		}
+
+		/**
+		\brief A new slice over the same variables built from the chosen linear forms.
+		*/
+		Slice Rows(std::vector<unsigned> const& indices) const
+		{
+			Mat<mpfr_complex> const& C = Coefficients();
+			Mat<mpfr_complex> sub(static_cast<Eigen::Index>(indices.size()), C.cols());
+			for (size_t ii = 0; ii < indices.size(); ++ii)
 			{
-				Mat<mpfr_complex>& coefficients_mpfr = std::get<Mat<mpfr_complex> >(coefficients_working_);
-				Vec<mpfr_complex>& constants_mpfr = std::get<Vec<mpfr_complex> >(constants_working_);
-				for (unsigned ii = 0; ii < Dimension(); ++ii)
-				{
-					for (unsigned jj=0; jj<NumVariables(); ++jj)
-					{
-						coefficients_mpfr(ii,jj).precision(new_precision);
-						if (new_precision>precision_)
-							coefficients_mpfr(ii,jj) = coefficients_highest_precision_(ii,jj);
-					}
-					
-					if (!is_homogeneous_)
-					{
-						constants_mpfr(ii).precision(new_precision);
-						if (new_precision>precision_)
-							constants_mpfr(ii) = constants_highest_precision_(ii);
-					}
-				}
+				if (indices[ii] >= Dimension())
+					throw std::runtime_error("Slice::Rows asked for a form index outside the slice");
+				sub.row(static_cast<Eigen::Index>(ii)) = C.row(indices[ii]);
 			}
-			precision_ = new_precision;
+			return FromCoefficients(sliced_vars_, sub, is_homogeneous_);
 		}
 
+
 		/**
-		\brief Get the dimension of the slice
+		\brief The dimension of the slice -- the number of linear forms.
 		*/
 		unsigned Dimension() const
 		{
-			return num_dims_sliced_;
+			return static_cast<unsigned>(block_.NumFunctions());
 		}
 
 		/**
-		\brief Get the number of variables sliced.  
+		\brief The number of variables sliced.
 		*/
 		unsigned NumVariables() const
 		{
 			return static_cast<unsigned>(sliced_vars_.size());
 		}
 
-
-
-		/** 
-		\brief the default constructor for linear slices. 
-
-		Make an empty linear slice. 
-		*/
-		LinearSlice() : 
-			coefficients_highest_precision_(0, 0), 
-			constants_highest_precision_(static_cast<unsigned>(0)), 
-			sliced_vars_(), 
-			num_dims_sliced_(0), 
-			precision_(DefaultPrecision()), 
-			is_homogeneous_(false)
-		{ 
-			std::get<Mat<dbl> > (coefficients_working_).resize(Dimension(), NumVariables());
-			std::get<Mat<mpfr_complex> >(coefficients_working_).resize(Dimension(), NumVariables());
-
-			std::get<Vec<dbl> > (constants_working_).resize(Dimension());
-			std::get<Vec<mpfr_complex> >(constants_working_).resize(Dimension());
-		}
-
 		/**
-		\brief the constructor for linear slices.
+		\brief The variables the slice is a function of.
 		*/
-		LinearSlice(VariableGroup const& v, unsigned dim, bool homogeneous) : coefficients_highest_precision_(dim, v.size()), constants_highest_precision_(dim), sliced_vars_(v), num_dims_sliced_(dim), precision_(DefaultPrecision()), is_homogeneous_(homogeneous)
-		{ 
-			std::get<Mat<dbl> > (coefficients_working_).resize(Dimension(), NumVariables());
-			std::get<Mat<mpfr_complex> >(coefficients_working_).resize(Dimension(), NumVariables());
-
-			if (!homogeneous)
-			{
-				std::get<Vec<dbl> > (constants_working_).resize(Dimension());
-				std::get<Vec<mpfr_complex> >(constants_working_).resize(Dimension());
-			}
-		}
-
-
-		/**
-		\brief factory function for generating slices
-		*/
-		static
-		LinearSlice Make(VariableGroup const& v, unsigned dim, bool homogeneous, bool orthogonal, std::function<void(mpfr_complex&, unsigned)> gen)
+		VariableGroup const& Variables() const
 		{
-			LinearSlice s(v, dim, homogeneous);
+			return sliced_vars_;
+		}
 
-			
+		/**
+		\brief Whether the slice was authored without constant terms (passes through the origin).
+		*/
+		bool IsHomogeneous() const
+		{
+			return is_homogeneous_;
+		}
 
-			if (orthogonal)
-			{	
-				using std::min;
-				using std::max;
 
-				auto mindim = min(s.Dimension(),s.NumVariables());
-				auto maxdim = max(s.Dimension(),s.NumVariables());
+		/**
+		\brief Get the current working precision of the slice, in digits.
+		*/
+		unsigned Precision() const
+		{
+			return block_.Precision();
+		}
 
-				bool need_transpose = s.Dimension() < s.NumVariables();
-
-				s.coefficients_highest_precision_.resize(maxdim,mindim);
-
-				for (unsigned ii(0); ii<maxdim; ++ii)
-					for (unsigned jj(0); jj<mindim; ++jj)
-						gen(s.coefficients_highest_precision_(ii,jj), MaxPrecisionAllowed());
-
-				auto prev_precision = DefaultPrecision();
-				DefaultPrecision(MaxPrecisionAllowed());
-
-				auto QR_factorization = Eigen::HouseholderQR<Mat<mpfr_complex> >(s.coefficients_highest_precision_);
-				s.coefficients_highest_precision_ = QR_factorization.householderQ()*Mat<mpfr_complex>::Identity(maxdim, mindim);
-				
-				if (need_transpose)
-					s.coefficients_highest_precision_.transposeInPlace();
-
-				DefaultPrecision(prev_precision);
-			}
-			else
-			{
-				for (unsigned ii(0); ii<s.Dimension(); ++ii)
-					for (unsigned jj(0); jj<s.NumVariables(); ++jj)
-						gen(s.coefficients_highest_precision_(ii,jj), MaxPrecisionAllowed());
-			}
-
-			for (unsigned ii(0); ii<s.Dimension(); ++ii)
-				for (unsigned jj(0); jj<s.NumVariables(); ++jj)
-				{
-					std::get<Mat<dbl> >(s.coefficients_working_)(ii,jj) = dbl(s.coefficients_highest_precision_(ii,jj));
-					std::get<Mat<mpfr_complex> >(s.coefficients_working_)(ii,jj) = s.coefficients_highest_precision_(ii,jj);
-				}
-
-			if (!homogeneous)
-			{
-				s.constants_highest_precision_.resize(s.Dimension());
-				std::get<Vec<dbl> >(s.constants_working_).resize(s.Dimension());
-				std::get<Vec<mpfr_complex> >(s.constants_working_).resize(s.Dimension());
-
-				for (unsigned ii(0); ii<s.Dimension(); ++ii)
-				{
-					gen(s.constants_highest_precision_(ii), MaxPrecisionAllowed());
-					std::get<Vec<dbl> >(s.constants_working_)(ii) = dbl(s.constants_highest_precision_(ii));
-					std::get<Vec<mpfr_complex> >(s.constants_working_)(ii) = s.constants_highest_precision_(ii);
-				}
-			}
-
-			assert(s.coefficients_highest_precision_.rows()==s.Dimension());
-			assert(s.coefficients_highest_precision_.cols()==s.NumVariables());
-
-			if (!homogeneous)
-				assert(s.constants_highest_precision_.size()==s.Dimension());
-			else
-				assert(s.constants_highest_precision_.size()==0);
-
-			return s;
+		/**
+		\brief Set the working precision of the slice, in digits.
+		*/
+		void Precision(unsigned new_precision) const
+		{
+			block_.Precision(new_precision);
 		}
 
 	private:
-		
 
 		friend class boost::serialization::access;
 
 		template <typename Archive>
 		void serialize(Archive& ar, const unsigned /*version*/) {
-			ar & precision_;
-
-			ar & coefficients_highest_precision_;
-
-			ar & std::get<0>(coefficients_working_);
-			ar & std::get<1>(coefficients_working_);
+			ar & block_;
 			ar & sliced_vars_;
+			ar & is_homogeneous_;
 		}
 
-		friend std::ostream& operator<<(std::ostream&, LinearSlice const&);
+		friend std::ostream& operator<<(std::ostream&, Slice const&);
 	};
 
 	/**
-	\brief Provides output streaming for LinearSlice
+	\brief Provides output streaming for Slice
 	*/
-	std::ostream& operator<<(std::ostream& out, LinearSlice const& s);
-} // re: namespace bertini 
+	std::ostream& operator<<(std::ostream& out, Slice const& s);
+} // re: namespace bertini
 
 #endif
-

--- a/core/include/bertini2/system/slice.hpp
+++ b/core/include/bertini2/system/slice.hpp
@@ -244,6 +244,32 @@ namespace bertini {
 		/// Add this slice's linear forms to a System as a LinearFormsBlock.  (Defined in slice.cpp.)
 		void AddTo(System & s) const;
 
+		/// A standalone System whose functions are exactly this slice's linear forms (over the slice's
+		/// variable group).  Lets a slice be carried around and evaluated / tracked on its own.
+		/// (Defined in slice.cpp.)
+		System AsSystem() const;
+
+		/**
+		\brief A new slice stacking this slice's linear forms on top of \p other's.
+
+		Both slices must be on the same number of variables.  The result is homogeneous only if both
+		operands are.  This is how you build a higher-codimension slice from pieces (and the Python
+		`+` operator).
+		*/
+		Slice Concatenate(Slice const& other) const
+		{
+			if (NumVariables() != other.NumVariables())
+				throw std::runtime_error("Slice::Concatenate requires both slices to be on the same number of variables");
+
+			Mat<mpfr_complex> const& A = Coefficients();
+			Mat<mpfr_complex> const& B = other.Coefficients();
+			Mat<mpfr_complex> stacked(A.rows() + B.rows(), A.cols());
+			stacked.topRows(A.rows()) = A;
+			stacked.bottomRows(B.rows()) = B;
+
+			return FromCoefficients(sliced_vars_, stacked, is_homogeneous_ && other.is_homogeneous_);
+		}
+
 
 		/**
 		\brief A new slice over the same variables built from the first \p m linear forms.

--- a/core/src/system/slice.cpp
+++ b/core/src/system/slice.cpp
@@ -1,25 +1,24 @@
 #include "bertini2/system/slice.hpp"
+#include "bertini2/system/system.hpp"
 
 namespace bertini {
-	
-	std::ostream& operator<<(std::ostream& out, LinearSlice const& s)
+
+	void Slice::AddTo(System & s) const
+	{
+		s.AddBlock(block_);
+	}
+
+	std::ostream& operator<<(std::ostream& out, Slice const& s)
 	{
 		out << "linear slice on " << s.NumVariables() << " variables:\n";
 		for (auto& v : s.sliced_vars_)
 			out << *v << " ";
 
-		out << "\n\ncoefficient matrix:\n\n";
-		out << std::get<Mat<dbl> >(s.coefficients_working_) << "\n\n";
+		out << "\n\naugmented coefficient matrix (last column is the constant term):\n\n";
+		out << s.Coefficients() << "\n\n";
 
-		
-		if (s.is_homogeneous_)
-			out << "slice is homogeneous";
-		else
-		{
-			out << "slice is not homogeneous, with constants\n";
-			out << std::get<Vec<dbl> >(s.constants_working_) << "\n";
-		}
-		
+		out << (s.is_homogeneous_ ? "slice is homogeneous" : "slice is not homogeneous") << "\n";
+
 		return out;
 	}
 }

--- a/core/src/system/slice.cpp
+++ b/core/src/system/slice.cpp
@@ -8,6 +8,14 @@ namespace bertini {
 		s.AddBlock(block_);
 	}
 
+	System Slice::AsSystem() const
+	{
+		System s;
+		s.AddVariableGroup(sliced_vars_);
+		AddTo(s);
+		return s;
+	}
+
 	std::ostream& operator<<(std::ostream& out, Slice const& s)
 	{
 		out << "linear slice on " << s.NumVariables() << " variables:\n";

--- a/core/src/system/slice.cpp
+++ b/core/src/system/slice.cpp
@@ -1,3 +1,5 @@
+#include <sstream>
+
 #include "bertini2/system/slice.hpp"
 #include "bertini2/system/system.hpp"
 
@@ -5,6 +7,16 @@ namespace bertini {
 
 	void Slice::AddTo(System & s) const
 	{
+		// The block's columns are indexed by the system's variable ordering; if the counts disagree
+		// the matrix-vector product is meaningless.  Fail here with a clear message rather than
+		// producing a silently-wrong (or out-of-bounds) evaluation downstream.
+		if (NumVariables() != s.NumVariables())
+		{
+			std::stringstream ss;
+			ss << "cannot add a slice on " << NumVariables() << " variables to a system on "
+			   << s.NumVariables() << " variables; build the slice over the system's variables";
+			throw std::runtime_error(ss.str());
+		}
 		s.AddBlock(block_);
 	}
 

--- a/core/src/system/slice.cpp
+++ b/core/src/system/slice.cpp
@@ -7,17 +7,45 @@ namespace bertini {
 
 	void Slice::AddTo(System & s) const
 	{
-		// The block's columns are indexed by the system's variable ordering; if the counts disagree
-		// the matrix-vector product is meaningless.  Fail here with a clear message rather than
-		// producing a silently-wrong (or out-of-bounds) evaluation downstream.
-		if (NumVariables() != s.NumVariables())
+		// If the system has been homogenized (it has minted homogenizing variables), a freshly-added
+		// block is NOT homogenized by the system, so we must homogenize the slice ourselves to match
+		// -- folding its constant term onto the homogenizing variable, exactly as System::Homogenize
+		// did to the system's other blocks.  Otherwise (an affine system, or a born-projective system
+		// whose homogeneous variable group carries no separate homogenizing variable) the slice is
+		// added as authored.
+		if (s.NumHomVariables() == 0)
+		{
+			// The block's columns are indexed by the system's variable ordering; if the counts
+			// disagree the matrix-vector product is meaningless.  Fail with a clear message rather
+			// than a silently-wrong (or out-of-bounds) evaluation downstream.
+			if (NumVariables() != s.NumVariables())
+			{
+				std::stringstream ss;
+				ss << "cannot add a slice on " << NumVariables() << " variables to a system on "
+				   << s.NumVariables() << " variables; build the slice over the system's variables";
+				throw std::runtime_error(ss.str());
+			}
+			s.AddBlock(block_);
+			return;
+		}
+
+		// Homogenized system: fold the slice's constant onto the homogenizing variable, then add.
+		// LinearFormsBlock::Homogenize supports a single affine variable group, so mirror that limit.
+		if (s.NumVariableGroups() != 1)
+			throw std::runtime_error("adding a slice to a homogenized system with multiple affine "
+			                         "variable groups is not yet supported");
+		if (NumVariables() != s.NumNaturalVariables())
 		{
 			std::stringstream ss;
-			ss << "cannot add a slice on " << NumVariables() << " variables to a system on "
-			   << s.NumVariables() << " variables; build the slice over the system's variables";
+			ss << "cannot add a slice on " << NumVariables() << " variables to a homogenized system on "
+			   << s.NumNaturalVariables() << " natural variables; build the slice over the system's "
+			   << "(affine) variables before it was homogenized";
 			throw std::runtime_error(ss.str());
 		}
-		s.AddBlock(block_);
+
+		blocks::LinearFormsBlock homogenized_block = block_;
+		homogenized_block.Homogenize(s.VariableGroups()[0], s.HomogenizingVariables()[0]);
+		s.AddBlock(homogenized_block);
 	}
 
 	System Slice::AsSystem() const

--- a/core/src/system/system.cpp
+++ b/core/src/system/system.cpp
@@ -23,6 +23,9 @@
 // silviana amethyst, university of wisconsin eau claire
 
 
+#include <variant>
+#include <type_traits>
+
 #include "bertini2/system/system.hpp"
 #include "bertini2/function_tree/find.hpp"
 
@@ -1512,8 +1515,28 @@ namespace bertini
 			sys1.CopyPatches(sys2); // give the unpatched result sys2's patch
 		// the other cases are automatically covered.  sys1 already patched, or neither patched.
 
-		for (unsigned ii(0); ii<sys2.NumNaturalFunctions(); ++ii)
-			sys1.AddFunction(sys2.Function(ii));
+		// Append sys2's functions to sys1, block by block.  We cannot just iterate
+		// sys2.Function(ii): that reads only the PolynomialBlock (PolyBlockPtr()->Functions()),
+		// so a system whose rows live in a structured block -- a linear-forms slice, a
+		// products-of-linears block -- would be skipped (and null-deref if it has no polynomial
+		// block at all).  Instead merge sys2's polynomial functions into sys1's PolynomialBlock
+		// and copy each structured block verbatim (they are value-in and indexed by the shared
+		// variable ordering, which we have already checked matches).
+		for (auto const& blk : sys2.Blocks())
+		{
+			std::visit([&sys1](auto const& b) {
+				using B = std::decay_t<decltype(b)>;
+				if constexpr (std::is_same_v<B, blocks::PolynomialBlock>)
+				{
+					for (auto const& f : b.Functions())
+						sys1.AddFunction(f);
+				}
+				else
+				{
+					sys1.AddBlock(b);
+				}
+			}, blk);
+		}
 
 		return sys1;
 	}

--- a/core/test/classes/slice_test.cpp
+++ b/core/test/classes/slice_test.cpp
@@ -221,6 +221,20 @@ BOOST_AUTO_TEST_CASE(add_to_system_agrees_with_slice_eval)
 }
 
 
+BOOST_AUTO_TEST_CASE(add_to_system_rejects_variable_count_mismatch)
+{
+	Var x = Variable::Make("x"), y = Variable::Make("y"), z = Variable::Make("z");
+
+	// a slice on three variables cannot be added to a system on two.
+	auto s = Slice::RandomComplex(VariableGroup{x,y,z}, 1);
+
+	System sys;
+	sys.AddVariableGroup(VariableGroup{x,y});
+
+	BOOST_CHECK_THROW(s.AddTo(sys), std::runtime_error);
+}
+
+
 BOOST_AUTO_TEST_CASE(concatenate_stacks_forms)
 {
 	DefaultPrecision(30);

--- a/core/test/classes/slice_test.cpp
+++ b/core/test/classes/slice_test.cpp
@@ -29,7 +29,11 @@
 \file slice_test.cpp Unit testing for slicing
 */
 
+#include <sstream>
+
 #include <boost/test/unit_test.hpp>
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/archive/text_iarchive.hpp>
 
 #include "bertini2/system/slice.hpp"
 #include "bertini2/system/system.hpp"
@@ -214,6 +218,29 @@ BOOST_AUTO_TEST_CASE(add_to_system_agrees_with_slice_eval)
 
 	BOOST_CHECK_EQUAL(from_system.size(), from_slice.size());
 	BOOST_CHECK_SMALL((from_system - from_slice).norm(), 1e-11);
+}
+
+
+BOOST_AUTO_TEST_CASE(serialization_roundtrip)
+{
+	DefaultPrecision(30);
+	auto s = MakeKnownSlice();
+
+	std::stringstream ss;
+	{ boost::archive::text_oarchive oa(ss); oa << s; }
+
+	Slice s2;
+	{ boost::archive::text_iarchive ia(ss); ia >> s2; }
+
+	BOOST_CHECK_EQUAL(s2.Dimension(), 2);
+	BOOST_CHECK_EQUAL(s2.NumVariables(), 2);
+	BOOST_CHECK(!s2.IsHomogeneous());
+
+	// the deserialized slice evaluates exactly like the original.
+	Vec<dbl> p(2); p << dbl(1), dbl(1);
+	auto v = s2.Eval(p);
+	BOOST_CHECK_CLOSE(v(0).real(), 6.0, 1e-11);
+	BOOST_CHECK_CLOSE(v(1).real(), 4.0, 1e-11);
 }
 
 

--- a/core/test/classes/slice_test.cpp
+++ b/core/test/classes/slice_test.cpp
@@ -221,6 +221,37 @@ BOOST_AUTO_TEST_CASE(add_to_system_agrees_with_slice_eval)
 }
 
 
+BOOST_AUTO_TEST_CASE(add_to_homogenized_system_folds_constant_onto_hom_var)
+{
+	DefaultPrecision(30);
+	Var x = Variable::Make("x"), y = Variable::Make("y");
+	VariableGroup vars{x,y};
+
+	// an affine system, homogenized: it now has a homogenizing variable.
+	System sys;
+	sys.AddVariableGroup(vars);
+	sys.AddFunction(x*x + y*y - 1);
+	sys.Homogenize();
+	BOOST_CHECK_EQUAL(sys.NumHomVariables(), 1u);
+	BOOST_CHECK_EQUAL(sys.NumVariables(), 3u);
+
+	// an affine slice (built on the two natural variables) added to the homogenized system: AddTo
+	// folds its constant onto the homogenizing variable, so the added form is homogeneous degree 1.
+	Mat<mpfr_complex> M(1,3); M << mpfr_complex(2), mpfr_complex(3), mpfr_complex(1); // 2x + 3y + 1
+	auto s = Slice::FromCoefficients(vars, M);
+	s.AddTo(sys);
+
+	BOOST_CHECK_EQUAL(sys.NumNaturalFunctions(), 2u);
+	BOOST_CHECK(sys.IsHomogeneous());   // the whole system, slice form included, is homogeneous
+
+	// the slice form is now a*x + b*y + c*h with c the old constant (1): vanishes at the origin.
+	Vec<dbl> origin(3); origin << dbl(0), dbl(0), dbl(0);
+	auto v = sys.Eval(origin);
+	BOOST_CHECK_EQUAL(v.size(), 2);
+	BOOST_CHECK_SMALL(std::abs(v(1)), 1e-11);   // the homogeneous slice form is 0 at the origin
+}
+
+
 BOOST_AUTO_TEST_CASE(add_to_system_rejects_variable_count_mismatch)
 {
 	Var x = Variable::Make("x"), y = Variable::Make("y"), z = Variable::Make("z");

--- a/core/test/classes/slice_test.cpp
+++ b/core/test/classes/slice_test.cpp
@@ -15,8 +15,8 @@
 //
 // Copyright(C) Bertini2 Development Team
 //
-// See <http://www.gnu.org/licenses/> for a copy of the license, 
-// as well as COPYING.  Bertini2 is provided with permitted 
+// See <http://www.gnu.org/licenses/> for a copy of the license,
+// as well as COPYING.  Bertini2 is provided with permitted
 // additional terms in the b2/licenses/ directory.
 
 // individual authors of this file include:
@@ -25,9 +25,6 @@
 //  slice_test.cpp
 //
 
-// individual authors of this file include:
-// silviana amethyst, university of wisconsin-eau claire
-
 /**
 \file slice_test.cpp Unit testing for slicing
 */
@@ -35,6 +32,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include "bertini2/system/slice.hpp"
+#include "bertini2/system/system.hpp"
 
 BOOST_AUTO_TEST_SUITE(linear_slicing)
 
@@ -50,10 +48,13 @@ BOOST_AUTO_TEST_CASE(slice_basic_complex)
 
 	VariableGroup vars{x,y,z};
 
-	auto s = LinearSlice::RandomComplex(vars,2);
+	auto s = Slice::RandomComplex(vars,2);
 
 	BOOST_CHECK_EQUAL(s.Dimension(),2);
 	BOOST_CHECK_EQUAL(s.NumVariables(),3);
+	// the augmented coefficient matrix is (#forms) x (#vars + 1)
+	BOOST_CHECK_EQUAL(s.Coefficients().rows(),2);
+	BOOST_CHECK_EQUAL(s.Coefficients().cols(),4);
 }
 
 
@@ -63,7 +64,7 @@ BOOST_AUTO_TEST_CASE(slice_basic_crazy_overslice)
 
 	VariableGroup vars{x,y,z};
 
-	auto s = LinearSlice::RandomComplex(vars,6);
+	auto s = Slice::RandomComplex(vars,6);
 
 	BOOST_CHECK_EQUAL(s.Dimension(),6);
 	BOOST_CHECK_EQUAL(s.NumVariables(),3);
@@ -76,12 +77,144 @@ BOOST_AUTO_TEST_CASE(slice_basic_real)
 
 	VariableGroup vars{x,y,z};
 
-	auto s = LinearSlice::RandomReal(vars,2);
+	auto s = Slice::RandomReal(vars,2);
 
 	BOOST_CHECK_EQUAL(s.Dimension(),2);
 	BOOST_CHECK_EQUAL(s.NumVariables(),3);
 }
 
 
-BOOST_AUTO_TEST_SUITE_END()
+// f0 = 2x + 3y + 1,  f1 = x - y + 4   (augmented rows: [coef_x, coef_y, const])
+// at (x,y) = (1,1):  f0 = 6,  f1 = 4
+static Slice MakeKnownSlice()
+{
+	Var x = Variable::Make("x"), y = Variable::Make("y");
+	VariableGroup vars{x,y};
 
+	Mat<mpfr_complex> M(2,3);
+	M << mpfr_complex(2), mpfr_complex(3),  mpfr_complex(1),
+	     mpfr_complex(1), mpfr_complex(-1), mpfr_complex(4);
+
+	return Slice::FromCoefficients(vars, M);
+}
+
+
+BOOST_AUTO_TEST_CASE(from_coefficients_eval)
+{
+	DefaultPrecision(30);
+	auto s = MakeKnownSlice();
+
+	BOOST_CHECK_EQUAL(s.Dimension(),2);
+	BOOST_CHECK_EQUAL(s.NumVariables(),2);
+
+	Vec<dbl> p(2); p << dbl(1), dbl(1);
+	auto v = s.Eval(p);
+
+	BOOST_CHECK_EQUAL(v.size(),2);
+	BOOST_CHECK_CLOSE(v(0).real(), 6.0, 1e-11);
+	BOOST_CHECK_CLOSE(v(1).real(), 4.0, 1e-11);
+	BOOST_CHECK_SMALL(v(0).imag(), 1e-11);
+	BOOST_CHECK_SMALL(v(1).imag(), 1e-11);
+}
+
+
+BOOST_AUTO_TEST_CASE(jacobian_is_variable_coefficient_block)
+{
+	DefaultPrecision(30);
+	auto s = MakeKnownSlice();
+
+	Vec<dbl> p(2); p << dbl(1), dbl(1);
+	auto J = s.Jacobian(p);
+
+	BOOST_CHECK_EQUAL(J.rows(),2);
+	BOOST_CHECK_EQUAL(J.cols(),2);   // the constant column is dropped
+	BOOST_CHECK_CLOSE(J(0,0).real(),  2.0, 1e-11);
+	BOOST_CHECK_CLOSE(J(0,1).real(),  3.0, 1e-11);
+	BOOST_CHECK_CLOSE(J(1,0).real(),  1.0, 1e-11);
+	BOOST_CHECK_CLOSE(J(1,1).real(), -1.0, 1e-11);
+}
+
+
+BOOST_AUTO_TEST_CASE(head_tail_rows_subsetting)
+{
+	DefaultPrecision(30);
+	Var w = Variable::Make("w"), x = Variable::Make("x"), y = Variable::Make("y");
+	VariableGroup vars{w,x,y};
+
+	auto s = Slice::RandomComplex(vars,4);
+
+	auto h = s.Head(2);
+	BOOST_CHECK_EQUAL(h.Dimension(),2);
+	BOOST_CHECK_EQUAL(h.NumVariables(),3);
+	// the head's forms are exactly the slice's first two forms.
+	BOOST_CHECK((h.Coefficients() - s.Coefficients().topRows(2)).norm() < mpfr_float("1e-30"));
+
+	auto t = s.Tail(1);
+	BOOST_CHECK_EQUAL(t.Dimension(),1);
+	BOOST_CHECK((t.Coefficients() - s.Coefficients().bottomRows(1)).norm() < mpfr_float("1e-30"));
+
+	auto r = s.Rows(std::vector<unsigned>{0,3});
+	BOOST_CHECK_EQUAL(r.Dimension(),2);
+	BOOST_CHECK((r.Coefficients().row(0) - s.Coefficients().row(0)).norm() < mpfr_float("1e-30"));
+	BOOST_CHECK((r.Coefficients().row(1) - s.Coefficients().row(3)).norm() < mpfr_float("1e-30"));
+
+	BOOST_CHECK_THROW(s.Head(99), std::runtime_error);
+	BOOST_CHECK_THROW(s.Rows(std::vector<unsigned>{99}), std::runtime_error);
+}
+
+
+BOOST_AUTO_TEST_CASE(homogeneous_has_zero_constant_column)
+{
+	Var x = Variable::Make("x"), y = Variable::Make("y"), z = Variable::Make("z");
+	VariableGroup vars{x,y,z};
+
+	auto s = Slice::RandomComplex(vars, 2, /*homogeneous=*/true);
+
+	BOOST_CHECK(s.IsHomogeneous());
+	BOOST_CHECK(s.Coefficients().rightCols(1).norm() < mpfr_float("1e-30"));
+}
+
+
+BOOST_AUTO_TEST_CASE(precision_roundtrip)
+{
+	DefaultPrecision(30);
+	auto s = MakeKnownSlice();
+
+	s.Precision(50);
+	BOOST_CHECK_EQUAL(s.Precision(),50u);
+
+	Vec<mpfr_complex> p(2); p << mpfr_complex(1), mpfr_complex(1);
+	auto v = s.Eval(p);
+	BOOST_CHECK(abs(v(0) - mpfr_complex(6)) < mpfr_float("1e-25"));
+	BOOST_CHECK(abs(v(1) - mpfr_complex(4)) < mpfr_float("1e-25"));
+}
+
+
+// A slice added to a System evaluates identically through the System.
+BOOST_AUTO_TEST_CASE(add_to_system_agrees_with_slice_eval)
+{
+	DefaultPrecision(30);
+	Var x = Variable::Make("x"), y = Variable::Make("y");
+	VariableGroup vars{x,y};
+
+	Mat<mpfr_complex> M(2,3);
+	M << mpfr_complex(2), mpfr_complex(3),  mpfr_complex(1),
+	     mpfr_complex(1), mpfr_complex(-1), mpfr_complex(4);
+	auto s = Slice::FromCoefficients(vars, M);
+
+	System sys;
+	sys.AddVariableGroup(vars);
+	s.AddTo(sys);
+
+	BOOST_CHECK_EQUAL(sys.NumNaturalFunctions(), 2u);
+
+	Vec<dbl> p(2); p << dbl(1), dbl(1);
+	auto from_system = sys.Eval(p);
+	auto from_slice  = s.Eval(p);
+
+	BOOST_CHECK_EQUAL(from_system.size(), from_slice.size());
+	BOOST_CHECK_SMALL((from_system - from_slice).norm(), 1e-11);
+}
+
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/core/test/classes/slice_test.cpp
+++ b/core/test/classes/slice_test.cpp
@@ -221,6 +221,47 @@ BOOST_AUTO_TEST_CASE(add_to_system_agrees_with_slice_eval)
 }
 
 
+BOOST_AUTO_TEST_CASE(concatenate_stacks_forms)
+{
+	DefaultPrecision(30);
+	Var x = Variable::Make("x"), y = Variable::Make("y");
+	VariableGroup vars{x,y};
+
+	Mat<mpfr_complex> A(1,3); A << mpfr_complex(2), mpfr_complex(3),  mpfr_complex(1);  // 2x + 3y + 1
+	Mat<mpfr_complex> B(1,3); B << mpfr_complex(1), mpfr_complex(-1), mpfr_complex(4);  // x - y + 4
+	auto sa = Slice::FromCoefficients(vars, A);
+	auto sb = Slice::FromCoefficients(vars, B);
+
+	auto s = sa.Concatenate(sb);
+	BOOST_CHECK_EQUAL(s.Dimension(), 2);
+	BOOST_CHECK_EQUAL(s.NumVariables(), 2);
+
+	Vec<dbl> p(2); p << dbl(1), dbl(1);
+	auto v = s.Eval(p);
+	BOOST_CHECK_CLOSE(v(0).real(), 6.0, 1e-11);
+	BOOST_CHECK_CLOSE(v(1).real(), 4.0, 1e-11);
+
+	// slices on different numbers of variables cannot be concatenated.
+	Var z = Variable::Make("z");
+	auto sc = Slice::RandomComplex(VariableGroup{x,y,z}, 1);
+	BOOST_CHECK_THROW(sa.Concatenate(sc), std::runtime_error);
+}
+
+
+BOOST_AUTO_TEST_CASE(as_system_evaluates_like_slice)
+{
+	DefaultPrecision(30);
+	auto s = MakeKnownSlice();
+
+	auto sys = s.AsSystem();
+	BOOST_CHECK_EQUAL(sys.NumNaturalFunctions(), 2);
+	BOOST_CHECK_EQUAL(sys.NumVariables(), 2);
+
+	Vec<dbl> p(2); p << dbl(1), dbl(1);
+	BOOST_CHECK_SMALL((sys.Eval(p) - s.Eval(p)).norm(), 1e-11);
+}
+
+
 BOOST_AUTO_TEST_CASE(serialization_roundtrip)
 {
 	DefaultPrecision(30);

--- a/core/test/classes/system_test.cpp
+++ b/core/test/classes/system_test.cpp
@@ -39,6 +39,7 @@
 
 #include "bertini2/system/system.hpp"
 #include "bertini2/system/precon.hpp"
+#include "bertini2/system/slice.hpp"
 #include "bertini2/io/parsing/system_parsers.hpp"
 
 #include "externs.hpp"
@@ -1452,6 +1453,40 @@ BOOST_AUTO_TEST_CASE(concatenate_two_systems)
 	auto sys3 = Concatenate(sys1, sys2);
 
 	BOOST_CHECK_EQUAL(sys3.NumNaturalFunctions(),6);
+}
+
+/**
+\class bertini::System
+\test \b concatenate_accepts_a_structured_block_system  Concatenate must append the functions of a
+system whose rows live in a structured block (a linear-forms slice), not only PolynomialBlock rows.
+Regression: it iterated sys2.Function(ii) -- which reads only the PolynomialBlock -- so a structured
+operand was skipped (and null-deref/segfaulted when it had no polynomial block).
+*/
+BOOST_AUTO_TEST_CASE(concatenate_accepts_a_structured_block_system)
+{
+	Var x = Variable::Make("x"), y = Variable::Make("y");
+	bertini::VariableGroup vars{x,y};
+
+	bertini::System sys1;
+	sys1.AddVariableGroup(vars);
+	sys1.AddFunction(x*x + y*y - 1);          // a polynomial: f0 = x^2 + y^2 - 1
+
+	// a system whose two functions live in a LinearFormsBlock (a slice): f = 2x+3y+1, x-y+4
+	bertini::Mat<bertini::mpfr_complex> M(2,3);
+	M << bertini::mpfr_complex(2), bertini::mpfr_complex(3),  bertini::mpfr_complex(1),
+	     bertini::mpfr_complex(1), bertini::mpfr_complex(-1), bertini::mpfr_complex(4);
+	auto sys2 = bertini::Slice::FromCoefficients(vars, M).AsSystem();
+
+	auto sys3 = Concatenate(sys1, sys2);      // used to segfault on the structured operand
+	BOOST_CHECK_EQUAL(sys3.NumNaturalFunctions(), 3);
+
+	// at (x,y) = (1,1):  f0 = 1,  f1 = 6,  f2 = 4
+	bertini::Vec<bertini::dbl> p(2); p << bertini::dbl(1), bertini::dbl(1);
+	auto v = sys3.Eval(p);
+	BOOST_CHECK_EQUAL(v.size(), 3);
+	BOOST_CHECK_CLOSE(v(0).real(), 1.0, 1e-11);
+	BOOST_CHECK_CLOSE(v(1).real(), 6.0, 1e-11);
+	BOOST_CHECK_CLOSE(v(2).real(), 4.0, 1e-11);
 }
 
 /**

--- a/core/test/nag_datatypes/witness_set.cpp
+++ b/core/test/nag_datatypes/witness_set.cpp
@@ -53,7 +53,7 @@ BOOST_AUTO_TEST_SUITE(witness_set)
 		{
 			WitnessSet w;
 
-			bertini::LinearSlice ell;
+			bertini::Slice ell;
 
 			w.SetSlice(ell);
 
@@ -87,7 +87,7 @@ BOOST_AUTO_TEST_SUITE(witness_set)
 
 			const auto vars = sys.VariableGroups()[0];
 
-			auto slice = bertini::LinearSlice::RandomComplex(vars, 1);
+			auto slice = bertini::Slice::RandomComplex(vars, 1);
 
 
 			WitnessSet w{points, slice, sys};
@@ -99,6 +99,9 @@ BOOST_AUTO_TEST_SUITE(witness_set)
 			BOOST_CHECK(!w.IsConsistent());
 			// this w should be inconsistent because the griewank obsorn system is square to start, and a complete intersection, with no posdim components.  Hence, this witness set is BOGUS.
 
+			// the stored slice round-trips: same dimension, same variable count.
+			BOOST_CHECK_EQUAL(w.GetSlice().Dimension(), 1);
+			BOOST_CHECK_EQUAL(w.GetSlice().NumVariables(), slice.NumVariables());
 		}
 
 
@@ -115,7 +118,7 @@ BOOST_AUTO_TEST_SUITE(witness_set)
 
 			const auto vars = sys.Variables();
 
-			auto slice = bertini::LinearSlice::RandomComplex(vars, 2);
+			auto slice = bertini::Slice::RandomComplex(vars, 2);
 
 
 			WitnessSet w{points, slice, sys};
@@ -151,7 +154,7 @@ BOOST_AUTO_TEST_SUITE(witness_set)
 
 			const auto vars = sys.VariableGroups()[0];
 
-			auto slice = bertini::LinearSlice::RandomComplex(vars, 1);
+			auto slice = bertini::Slice::RandomComplex(vars, 1);
 
 
 			WitnessSet w{points, slice, sys};
@@ -192,7 +195,7 @@ BOOST_AUTO_TEST_SUITE(witness_set)
 				points.push_back(std::make_shared<Vec<mpfr_complex>>(n_vars));
 
 
-			auto slice = std::make_shared<LinearSlice>(LinearSlice::RandomComplex(vars, 1));
+			auto slice = std::make_shared<Slice>(Slice::RandomComplex(vars, 1));
 
 
 			WitnessSet w{points, slice, sys};

--- a/core/test/nag_datatypes/witness_set.cpp
+++ b/core/test/nag_datatypes/witness_set.cpp
@@ -26,7 +26,11 @@
 // individual authors of this file include:
 // silviana amethyst, university of notre dame
 
+#include <sstream>
+
 #include <boost/test/unit_test.hpp>
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/archive/text_iarchive.hpp>
 #include "bertini2/nag_datatypes/witness_set.hpp"
 #include "bertini2/system/precon.hpp"
 
@@ -128,6 +132,42 @@ BOOST_AUTO_TEST_SUITE(witness_set)
 			BOOST_CHECK_EQUAL(w.Dimension(), 2);
 
 			BOOST_CHECK(w.IsConsistent());
+		}
+
+
+		// A witness set round-trips through a boost archive (the C++ path MPI/threading use), and the
+		// deserialized system is immediately usable -- load() re-differentiated it.
+		BOOST_AUTO_TEST_CASE(serialization_roundtrip)
+		{
+			auto sys = bertini::system::Precon::Sphere();
+
+			bertini::Vec<bertini::mpfr_complex> p(sys.NumVariables());
+			for (unsigned ii = 0; ii < sys.NumVariables(); ++ii)
+				p(ii) = bertini::mpfr_complex(1);
+
+			bertini::nag_datatype::PointCont<bertini::Vec<bertini::mpfr_complex>> points;
+			points.push_back(p);
+			points.push_back(p);
+
+			const auto vars = sys.Variables();
+			auto slice = bertini::Slice::RandomComplex(vars, 2);
+
+			WitnessSet w{points, slice, sys};
+
+			std::stringstream ss;
+			{ boost::archive::text_oarchive oa(ss); oa << w; }
+
+			WitnessSet w2;
+			{ boost::archive::text_iarchive ia(ss); ia >> w2; }
+
+			BOOST_CHECK_EQUAL(w2.Degree(), 2);
+			BOOST_CHECK_EQUAL(w2.Dimension(), 2);
+			BOOST_CHECK(w2.IsConsistent());
+			BOOST_CHECK_EQUAL(w2.GetSlice().NumVariables(), slice.NumVariables());
+
+			// the deserialized system evaluates and differentiates without throwing.
+			BOOST_CHECK_NO_THROW(w2.GetSystem().Eval(p));
+			BOOST_CHECK_NO_THROW(w2.GetSystem().Jacobian(p));
 		}
 
 

--- a/docs/adr/0031-eigenpy-vec-index-returns-aliasing-view-copy-before-storing.md
+++ b/docs/adr/0031-eigenpy-vec-index-returns-aliasing-view-copy-before-storing.md
@@ -1,0 +1,85 @@
+# ADR-0031: Indexing an eigenpy Vec returns an aliasing view — copy before storing
+
+**Status:** Accepted
+**Date:** 2026-06-24
+
+## Context
+
+`ZeroDim.to_dataframe()` (the pandas "database of solutions") built each row by reading the
+solution out of the eigenpy solution vector and stashing it in a Python container that pandas
+reads later:
+
+```python
+points = self.all_solutions(user_coords)      # an eigenpy container of Vec<mpc_complex>
+row = {'x{}'.format(k): points[i][k] for k in range(len(points[i]))}   # WRONG — stores views
+```
+
+The resulting DataFrame was **silently wrong**: every row showed the *same* coordinate, as if one
+solution had been copied over all of them. The underlying `all_solutions()` was always correct
+(reading it directly, or re-reading it afterward, gave the right points); only the values *stored*
+into the DataFrame were corrupt.
+
+The cause is an eigenpy/NumPy detail. Indexing an eigenpy `Vec<mpc_complex>` from Python
+(`pt[k]`, and likewise `list(pt)`) does **not** return an independent value — it returns a scalar
+that **aliases a reused internal buffer**. While you read each element immediately the value is
+correct, but if you *store the reference and read it later*, by then the buffer has been reused by
+subsequent indexing, so all the stored references resolve to whatever was written last. Two
+solutions never tripped it (no buffer reuse between two reads); three or more reliably did.
+
+The same aliasing has a rarer, fatal face. When the reused buffer is not merely stale but *freed*,
+the stored `mpc` carries a garbage limb pointer, and the first real arithmetic on it makes GMP read
+a garbage limb count:
+
+```
+GNU MP: Cannot allocate memory (size=575897802350002184)   →  SIGABRT
+```
+
+This is the crash filed as **bertiniteam/b2 #259**. It was first mis-attributed to an
+uninitialized-numpy-slot residual (the [ADR-0006](0006-eigenpy-uninitialized-numpy-slot-guards.md)
+family) and to import order (numpy/pandas/matplotlib before bertini). Neither was the cause: import
+order only changed what garbage occupied the buffer, and the slot guards were already in place. The
+real cause is this aliasing, and #259 is closed by the fix below.
+
+This is the same *class* of eigenpy hazard as [ADR-0001](0001-eigenpy-writable-ref-scalar-by-value.md)
+(writable `Eigen::Ref` clobbering an adjacent scalar) and ADR-0006 (uninitialized `mpfr`/`mpc`
+numpy slots): a Python-visible `mpc` value that is not the stable, fully-owned object it appears to
+be.
+
+## Decision
+
+**Copy a value out of an eigenpy vector at the moment you read it, before you store it or read the
+next element.** Never store the result of indexing (or `list()`-ing) an eigenpy vector and read it
+later.
+
+Two equivalent copies, both proven correct and precision-preserving (the copy keeps the native
+element type — a Python `complex` for a double solve, a `bertini.multiprec.Complex` for a
+multiprecision one, so nothing is truncated):
+
+```python
+# per element — make an independent copy of the right type, immediately
+value = type(c)(c)            # where c = pt[k]
+
+# per vector — snapshot the whole vector's buffer in one C-level copy
+solution = points[i].copy()
+```
+
+`to_dataframe` uses the whole-vector form: each row's `solution` cell is `points[i].copy()`.
+
+## Consequences
+
+- **Correct and import-order independent.** Verified: pre-fix 15/15 runs silently corrupt and one
+  observed SIGABRT under the worst import order; post-fix 60/60 clean. Import order no longer
+  matters, because the hazard was never really about import order.
+- **No precision loss.** Copying via `type(c)(c)` / `Vec.copy()` keeps the multiprecision element
+  type; a multiprecision solve's coordinates round-trip exactly.
+- **Negligible cost.** One copy per coordinate (or per solution vector) at table-build time.
+- **Rule to follow:** any new Python code that pulls scalars or vectors out of an eigenpy
+  `Vec`/`Matrix` and **keeps** them — builds a DataFrame, caches a list, returns them past the
+  call — must copy at extraction. Reading-and-using-immediately (e.g. `complex(pt[k])` in a loop,
+  or summing on the spot) is fine; deferring the read is the trap.
+- **Regression test:** `python/test/zero_dim/solution_access_test.py::test_to_dataframe_solutions_are_independent_per_row`
+  uses four distinct roots `(±1, ±1)` — an aliased frame would collapse them to one — and asserts
+  the DataFrame reproduces `all_solutions()` exactly.
+- **Relation to prior ADRs:** ADR-0001/0006/0008 hardened the *C++ binding* side of eigenpy `mpc`
+  handling. This ADR is the *Python consumer* counterpart: even with correct bindings, a Python
+  caller must not treat an indexed eigenpy element as a durable owned value.

--- a/docs/adr/0032-slice-is-a-thin-wrapper-over-linear-forms-block.md
+++ b/docs/adr/0032-slice-is-a-thin-wrapper-over-linear-forms-block.md
@@ -62,8 +62,14 @@ mpfr master" types forever — exactly the kind of duplication that invites drif
 - The slice is numpy-native (coefficients round-trip through eigenpy) and authored by the existing
   `bertini.linalg` layer, so the Python NID prototype has an ergonomic, composable slice today, and
   the C++ `Slice` is the forward-investment for the later C++ NID port.
-- "Homogeneous" is currently **authoring metadata** (a zero constant column), not full patch
-  awareness. Genuine affine/projective patch handling for slices remains future work.
+- A slice does **not** own homogenization; the system does. "Homogeneous" on a slice is just
+  authoring metadata (a zero constant column). The relationship to homogenization is that an
+  affine slice's constant term, when the system homogenizes, becomes the coefficient on the
+  homogenizing variable (`LinearFormsBlock::Homogenize`). `Slice::AddTo` is homogenization-aware:
+  adding a slice to an already-homogenized system folds the slice's constant onto the hom var so
+  the appended forms stay consistent (single affine variable group for now). A slice that touches
+  only some variables simply has zero columns for the rest (no sparse representation -- not worth
+  optimizing yet).
 - A one-row coefficient matrix returns from eigenpy as a 1-D array (a general eigenpy convention);
   helpers that treat it as a matrix use `np.atleast_2d`.
 

--- a/docs/adr/0032-slice-is-a-thin-wrapper-over-linear-forms-block.md
+++ b/docs/adr/0032-slice-is-a-thin-wrapper-over-linear-forms-block.md
@@ -1,0 +1,72 @@
+# ADR-0032: A witness set's Slice is a thin wrapper over LinearFormsBlock, not a parallel type
+
+**Status:** Accepted
+**Date:** 2026-06-24
+
+## Context
+
+A witness set is a triple (system, slice, points). Exposing `WitnessSet` to Python (to *enable*
+a numerical irreducible decomposition (NID) being prototyped in Python, to be ported to C++ later)
+forced a decision about what the **slice** should be.
+
+The slice has three faces at once: it is a *variety* (it evaluates, it has a Jacobian, it can be
+added to a system), it is a *matrix of coefficients* (you want its rows, the first/last m of them),
+and it carries *affine/projective* concerns we mostly hide from the user. We want it easy to reason
+about, write code with, and carry around for further work — and, for regeneration, to compose with
+products of linear forms.
+
+There were already **two** representations of "a stack of linear forms" in the tree:
+
+- `bertini::LinearSlice` (`core/include/bertini2/system/slice.hpp`) — the original slice type. It
+  was **orphaned**: not a `System` evaluation block, used by no algorithm (its only "consumer",
+  `nag_algorithms/trace.hpp`, is a stub returning 0), and **not exposed to Python at all**. It
+  carried its own mpfr-master / per-type-working-copy / `Precision()` machinery, its own
+  QR-orthogonal random-slice factory, and a separate constants vector.
+
+- `bertini::blocks::LinearFormsBlock` (`core/include/bertini2/system/blocks/linear_forms_block.hpp`)
+  — the modern, integrated equivalent, written later. A member of the `Block` variant, evaluated
+  in-System, homogenization-aware, unit-tested, already authored from Python via
+  `bertini.linalg.add_linear` / `add_linear_forms`. Its augmented coefficient matrix `M` (rows =
+  forms, columns = num_vars+1, the last column the constant term) is the **same layout** that
+  `ProductsOfLinearsBlock` (the m-homogeneous start system and regeneration) uses for its factors.
+  Its own header even notes it "mirrors the pattern of `bertini::LinearSlice`."
+
+So `LinearFormsBlock` had already obviated `LinearSlice`; the block was simply written without going
+back to delete its predecessor. Keeping both means maintaining two parallel "linear forms with an
+mpfr master" types forever — exactly the kind of duplication that invites drift.
+
+## Decision
+
+**Retire `LinearSlice`. A witness set's slice is `bertini::Slice`, a thin wrapper that *holds* a
+`LinearFormsBlock` plus the slice-level metadata the block does not carry (the sliced
+`VariableGroup`, and whether the forms were authored homogeneous).**
+
+- `Slice` delegates eval / Jacobian / precision / coefficients to its `LinearFormsBlock`, and
+  salvages `LinearSlice`'s QR-orthogonal random factories (`RandomReal` / `RandomComplex` / `Make`).
+- The coefficient matrix is exposed directly (`Coefficients()`), and row-subsetting (`Head` / `Tail`
+  / `Rows`, plus Python `[]`) returns a new `Slice` — so the matrix face and the variety face are
+  the same object.
+- `Slice` is **not** added to the `Block` variant. Instead `AddTo(System&)` / `AsSystem()` hand its
+  block to a System, keeping the closed-set variant clean and avoiding the recursive-type machinery.
+- Because a slice's rows and a `ProductsOfLinearsBlock`'s factor rows share the augmented
+  `num_vars+1` layout, composing slices into a product-of-linears (the regeneration bridge,
+  `linalg.add_slices_as_products`) is matrix-row assembly, not new math.
+
+`WitnessSet`'s slice member is now a `Slice`. The wrapper is also where serialization,
+`Concatenate` (Python `+`), and a readable `repr` live.
+
+## Consequences
+
+- One representation of linear forms in the evaluation path; `LinearSlice` and its duplicate
+  precision/eval machinery are gone.
+- The slice is numpy-native (coefficients round-trip through eigenpy) and authored by the existing
+  `bertini.linalg` layer, so the Python NID prototype has an ergonomic, composable slice today, and
+  the C++ `Slice` is the forward-investment for the later C++ NID port.
+- "Homogeneous" is currently **authoring metadata** (a zero constant column), not full patch
+  awareness. Genuine affine/projective patch handling for slices remains future work.
+- A one-row coefficient matrix returns from eigenpy as a 1-D array (a general eigenpy convention);
+  helpers that treat it as a matrix use `np.atleast_2d`.
+
+See `core/include/bertini2/system/slice.hpp`, `core/include/bertini2/nag_datatypes/witness_set.hpp`,
+and `python_bindings/src/nid_datatypes_export.cpp`. Related: ADR-0025 (randomization as a first-class
+block), ADR-0001 (eigenpy writable-Ref hazard).

--- a/docs/adr/0033-slice-shape-contract-we-own-dimensionality.md
+++ b/docs/adr/0033-slice-shape-contract-we-own-dimensionality.md
@@ -1,0 +1,82 @@
+# ADR-0033: Slice shape is our accessors' contract, not eigenpy's (the 1-D collapse)
+
+**Status:** Accepted
+**Date:** 2026-06-24
+
+## Context
+
+eigenpy converts a dynamic `Eigen::Matrix` to numpy by **collapsing "vector-shaped" matrices to
+1-D**. The decision is hardcoded in `eigenpy/eigen-to-python.hpp` (`eigen_to_py_impl_matrix::convert`):
+
+```cpp
+if ( ( (!(C==1) != !(R==1)) && !MatrixDerived::IsVectorAtCompileTime )
+     || MatrixDerived::IsVectorAtCompileTime )
+{ npy_intp shape[1] = { C==1 ? R : C }; ... }   // 1-D
+else
+{ npy_intp shape[2] = { R, C }; ... }            // 2-D
+```
+
+`(!(C==1) != !(R==1))` is **`XOR(rows==1, cols==1)`** — *exactly one* extent is 1. Measured:
+
+| C++ matrix (runtime) | numpy shape |
+| --- | --- |
+| 2×3 | `(2, 3)` |
+| 1×3 | `(3,)` |
+| 2×1 | `(2,)` |
+| 1×1 | `(1, 1)` (not collapsed — both extents 1, XOR false) |
+
+So a `Mat<T>`'s Python shape depends on the **runtime data**: a one-row matrix is 1-D, a many-row
+matrix is 2-D, and 1×1 is a 2-D corner that contradicts the rule. This is **silent and
+data-dependent** — code written/tested against multi-row data (`M[i,j]`, `M.shape[1]`, `list(M)` for
+rows, `M @ v`) breaks the moment the data is a single row/column, with no error at the boundary.
+
+**For NID this is not a corner case.** A dimension-`d` component is cut by `d` hyperplanes, so a
+**curve (d=1) has a single-form slice** that collapses every time; curves are the most common
+positive-dimensional component. The d=2 surface you test on won't collapse and the d=1 curve in
+production will.
+
+There is **no eigenpy knob.** The condition above consults nothing mutable (no flag, template
+option, env, or macro); the only global state in eigenpy is `NumpyType::sharedMemory()` (copy vs
+view, not dimensionality); and the old np.matrix mode (which forced 2-D) has been removed in this
+version. Investigated and confirmed dead — see ADR-0001/0006/0031 for the other eigenpy hazards;
+this is the same *family* (eigenpy's Python view isn't the faithful object you'd assume) but a
+*shape/semantics* kind rather than a memory-corruption kind.
+
+A footgun within the footgun: the obvious `np.atleast_2d` fix is **orientation-specific** — it
+re-expands a collapsed *row* `(N,)` to `(1, N)` correctly, but a collapsed *column* `(N,)` to
+`(1, N)` *wrongly* (should be `(N, 1)`). Only the side that produced the matrix knows its orientation.
+
+## Decision
+
+**The shape contract belongs to *our* accessors, not to eigenpy (nor nanoeigenpy, nor any binding
+library). A `Slice` is a Python sequence of linear forms, with list semantics:**
+
+- `Slice.coefficients()` → **always 2-D**, `(num_forms, num_variables+1)`. We reshape using the
+  dimensions known in C++ (`dimension()`, `num_variables()`), so it is orientation-correct by
+  construction and never collapses.
+- `slice[i]` (integer) → an **element**: the i-th form's coefficient **vector** (1-D). Iterating a
+  slice yields these form vectors. "A single linear form *is* a vector" — but you get it by indexing
+  an element, explicitly, not because the form count happened to be 1.
+- `slice[i:j]` (and a list/tuple of indices) → a **sub-collection**: a new (sub-)`Slice`.
+
+Mental model: a slice is a *stack of form-vectors*; the matrix is the stack, a form is a vector. The
+vector-vs-matrix choice is **named** (element index vs collection slice vs matrix accessor), never an
+emergent property of the data size. The collapse you might *want* (one line = one vector) is still
+there — it is `slice[i]` — but it is a choice you ask for, not a surprise the data hands you.
+
+Implemented in `python/bertini/nag_algorithm/__init__.py` (the `Slice` ergonomics): a `coefficients`
+wrapper that reshapes to the known 2-D shape, and a `__getitem__` that returns a form vector for an
+integer index and a sub-`Slice` for a Python slice / index list.
+
+## Consequences
+
+- **Migration-proof.** When boost.python + eigenpy is eventually replaced (nanobind + nanoeigenpy,
+  per the team's plan), whatever collapse rule the new layer uses is absorbed by our wrapper. Slice
+  consumers — including the NID code — see no change. Owning the contract is what makes that swap a
+  non-event.
+- The raw hazard still lives in **un-wrapped** matrix-returning accessors: `System.eval_jacobian`
+  (a 1-function or 1-variable system gives a collapsed Jacobian), the randomization matrix, and patch
+  coefficients. These are **deliberate future retrofits** — changing their shape is an interface
+  change with its own test fallout. Until then, defend at the call site, remembering `atleast_2d` is
+  only correct for row-oriented results (`reshape(rows, cols)` with the known dims otherwise).
+- Supersedes the working note that prompted this (`eigenpy returns a 1-row matrix as 1-D`).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -48,3 +48,4 @@ Each ADR follows the template:
 | [0028](0028-named-node-taxonomy.md) | Named-node taxonomy — NameHolder, three named kinds, NamedExpression replaces Handle, Jacobian deleted | Core / function_tree |
 | [0029](0029-gamma-trick-max-precision-unit-modulus.md) | The gamma-trick constant is a unit-modulus complex generated at maximum precision | Numerics / system |
 | [0030](0030-fixed-multiple-uniform-ambient-precision-adaptive-default.md) | Fixed-multiple solves use one uniform ambient precision; ZeroDim defaults to adaptive | Numerics / nag_algorithms |
+| [0031](0031-eigenpy-vec-index-returns-aliasing-view-copy-before-storing.md) | Indexing an eigenpy Vec returns an aliasing view — copy values before storing them (fixes #259) | Python bindings |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -50,3 +50,4 @@ Each ADR follows the template:
 | [0030](0030-fixed-multiple-uniform-ambient-precision-adaptive-default.md) | Fixed-multiple solves use one uniform ambient precision; ZeroDim defaults to adaptive | Numerics / nag_algorithms |
 | [0031](0031-eigenpy-vec-index-returns-aliasing-view-copy-before-storing.md) | Indexing an eigenpy Vec returns an aliasing view — copy values before storing them (fixes #259) | Python bindings |
 | [0032](0032-slice-is-a-thin-wrapper-over-linear-forms-block.md) | A witness set's Slice is a thin wrapper over LinearFormsBlock; LinearSlice retired | Core / nag_datatypes |
+| [0033](0033-slice-shape-contract-we-own-dimensionality.md) | Slice shape is OUR accessors' contract, not eigenpy's: coefficients() always 2-D, slice[i] a form vector, slice[i:j] a sub-Slice | Python bindings |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -49,3 +49,4 @@ Each ADR follows the template:
 | [0029](0029-gamma-trick-max-precision-unit-modulus.md) | The gamma-trick constant is a unit-modulus complex generated at maximum precision | Numerics / system |
 | [0030](0030-fixed-multiple-uniform-ambient-precision-adaptive-default.md) | Fixed-multiple solves use one uniform ambient precision; ZeroDim defaults to adaptive | Numerics / nag_algorithms |
 | [0031](0031-eigenpy-vec-index-returns-aliasing-view-copy-before-storing.md) | Indexing an eigenpy Vec returns an aliasing view — copy values before storing them (fixes #259) | Python bindings |
+| [0032](0032-slice-is-a-thin-wrapper-over-linear-forms-block.md) | A witness set's Slice is a thin wrapper over LinearFormsBlock; LinearSlice retired | Core / nag_datatypes |

--- a/python/bertini/linalg.py
+++ b/python/bertini/linalg.py
@@ -67,9 +67,11 @@ _MP_VALUE_TYPES = tuple(
     if isinstance(t, type)
 )
 
+from bertini.function_tree import VariableGroup as _VariableGroup
+
 __all__ = ['variable_vector', 'variable_matrix', 'coefficient', 'as_coefficients',
            'add_functions', 'add_linear_forms', 'add_linear', 'add_products_of_linears',
-           'randomize']
+           'randomize', 'slice_from_coefficients', 'add_slices_as_products']
 
 
 def variable_vector(name, n, start=0):
@@ -466,3 +468,75 @@ def randomize(system, matrix=None):
         for j, entry in enumerate(row):
             M[i, j] = _exact_to_mpfr(entry)
     return system.randomize(M)
+
+
+def _coerce_mpfr_matrix(coefficients, context):
+    """Coerce a (possibly nested list / numpy) array of exact values to an mpfr_complex matrix.
+
+    Shared by the slice helpers; mirrors the per-entry coercion of :func:`add_linear_forms`.
+    Returns ``(numpy_object_matrix, num_rows, num_cols)``.  Refuses Python floats.
+    """
+    rows = [list(r) for r in coefficients]
+    if not rows:
+        raise ValueError(f"{context} must have at least one row")
+    ncol = len(rows[0])
+    M = np.empty((len(rows), ncol), dtype=_mp.Complex)
+    for i, row in enumerate(rows):
+        if len(row) != ncol:
+            raise ValueError(f"{context} is ragged (rows of differing length)")
+        for j, entry in enumerate(row):
+            M[i, j] = _exact_to_mpfr(entry)
+    return M, len(rows), ncol
+
+
+def slice_from_coefficients(coefficients, variables, homogeneous=False):
+    """Build a :class:`Slice` from an exact augmented coefficient matrix.
+
+    The linear part of a witness set.  ``coefficients`` is an ``(m x n+1)`` array/list of EXACT
+    values (see :func:`coefficient`; Python floats are refused) -- one row per linear form, the
+    trailing column being each form's constant term (give ``0`` there for a homogeneous slice).
+    ``variables`` is the length-``n`` vector of variables the slice is a function of (a numpy object
+    array of :class:`~bertini.function_tree.symbol.Variable`, e.g. from :func:`variable_vector`, or a
+    :class:`~bertini.container.VariableGroup`).
+
+    Returns a ``bertini.nag_algorithm.Slice``.  Its rows are also ready-made factors for a
+    products-of-linears block -- see :func:`add_slices_as_products`.
+
+    Examples
+    --------
+    The line ``2x + y - 1 = 0`` as a one-form slice on (x, y)::
+
+        >>> import bertini                                            # doctest: +SKIP
+        >>> from bertini import linalg                                # doctest: +SKIP
+        >>> x, y = bertini.Variable('x'), bertini.Variable('y')      # doctest: +SKIP
+        >>> s = linalg.slice_from_coefficients([[2, 1, -1]], [x, y]) # doctest: +SKIP
+        >>> s.dimension(), s.num_variables()                         # doctest: +SKIP
+        (1, 2)
+    """
+    from bertini.nag_algorithm import Slice  # local import: linalg loads before this is needed
+
+    vg = variables if isinstance(variables, _VariableGroup) else _VariableGroup(list(variables))
+    M, _, ncol = _coerce_mpfr_matrix(coefficients, "slice coefficients")
+    if ncol != len(vg) + 1:
+        raise ValueError(
+            f"slice coefficient matrix has {ncol} columns but needs num_variables+1 = {len(vg) + 1} "
+            "(one column per variable plus a trailing constant-term column)"
+        )
+    return Slice.from_coefficients(vg, M, homogeneous)
+
+
+def add_slices_as_products(system, slices):
+    """Add one products-of-linears function per slice to ``system`` (the regen bridge).
+
+    Each :class:`Slice` is a stack of linear forms; this turns each slice into a single function that
+    is the *product* of its forms -- a product of hyperplanes -- using the same first-class
+    ``ProductsOfLinearsBlock`` as :func:`add_products_of_linears`.  Slice rows and product-of-linears
+    factor rows share the augmented ``num_vars+1`` layout, so this is a direct hand-off.
+
+    The slices' coefficient columns must follow ``system``'s variable ordering (build each slice over
+    the system's variables).  Returns ``system`` for chaining.
+    """
+    # atleast_2d: a one-form slice's coefficients come back from eigenpy as a 1-D array; keep it a
+    # (1 x num_vars+1) factor matrix so a single-hyperplane slice is still one degree-1 product.
+    factors = [np.atleast_2d(np.asarray(s.coefficients())) for s in slices]
+    return add_products_of_linears(system, factors)

--- a/python/bertini/linalg.py
+++ b/python/bertini/linalg.py
@@ -536,7 +536,8 @@ def add_slices_as_products(system, slices):
     The slices' coefficient columns must follow ``system``'s variable ordering (build each slice over
     the system's variables).  Returns ``system`` for chaining.
     """
-    # atleast_2d: a one-form slice's coefficients come back from eigenpy as a 1-D array; keep it a
-    # (1 x num_vars+1) factor matrix so a single-hyperplane slice is still one degree-1 product.
-    factors = [np.atleast_2d(np.asarray(s.coefficients())) for s in slices]
+    # Slice.coefficients() is contractually 2-D (num_forms x num_vars+1), even for a one-form slice
+    # -- our accessor owns that shape, regardless of eigenpy's 1-D collapse -- so each slice maps
+    # straight to one products-of-linears factor matrix.
+    factors = [np.asarray(s.coefficients()) for s in slices]
     return add_products_of_linears(system, factors)

--- a/python/bertini/nag_algorithm/__init__.py
+++ b/python/bertini/nag_algorithm/__init__.py
@@ -67,6 +67,46 @@ if hasattr(_pybnalag, 'Slice'):
     _pybnalag.Slice.__len__ = lambda self: self.dimension()
 
 
+# --- Bertini 1 / classic emission -----------------------------------------------------------
+#
+# A slice's linear forms are ordinary System functions (the classic writer expands the
+# LinearFormsBlock), so a slice emits to a Bertini 1 input file via its standalone system.  A
+# witness set emits its SQUARE system -- the witness set's system with the slice's forms appended
+# (concatenate) -- which is what you would track in Bertini 1 for cross-validation.
+def _slice_to_classic_input(self, **kwargs):
+    """Emit this slice's linear forms as a Bertini 1 classic input file (see System.to_classic_input)."""
+    return self.as_system().to_classic_input(**kwargs)
+
+
+def _witness_system(self):
+    """The square system whose isolated solutions are the witness points: this witness set's system
+    with the slice's linear forms appended.  Requires the slice and system to share variables.
+
+    Built by cloning the witness set's system (a copy that shares the variable nodes, so it is left
+    unmutated) and adding the slice's linear-forms block to the clone -- not concatenate(), which
+    assumes polynomial blocks and cannot append a structured linear-forms block."""
+    from bertini.system import clone
+    sys = clone(self.get_system())
+    self.get_slice().add_to(sys)
+    return sys
+
+
+def _witness_to_classic_input(self, **kwargs):
+    """Emit the witness (square) system as a Bertini 1 classic input file (see System.to_classic_input)."""
+    return self.witness_system().to_classic_input(**kwargs)
+
+
+if hasattr(_pybnalag, 'Slice'):
+    _pybnalag.Slice.to_classic_input = _slice_to_classic_input
+
+for _ws_name in dir(_pybnalag):
+    if _ws_name.startswith('WitnessSet'):
+        _ws_cls = getattr(_pybnalag, _ws_name)
+        if isinstance(_ws_cls, type):
+            _ws_cls.witness_system = _witness_system
+            _ws_cls.to_classic_input = _witness_to_classic_input
+
+
 # --- to_dataframe: a ZeroDim solve as a pandas DataFrame -- the "database of solutions" ---
 #
 # One ROW per solution (per tracked path), columns = the coordinates (x0, x1, ...) followed by

--- a/python/bertini/nag_algorithm/__init__.py
+++ b/python/bertini/nag_algorithm/__init__.py
@@ -100,12 +100,47 @@ def _witness_to_classic_input(self, **kwargs):
 if hasattr(_pybnalag, 'Slice'):
     _pybnalag.Slice.to_classic_input = _slice_to_classic_input
 
+
+def _plural(n, noun):
+    return f"{n} {noun}" if n == 1 else f"{n} {noun}s"
+
+
+def _witness_repr(self):
+    """A concise summary: the component's dimension and degree, and a one-line description of the
+    system and slice it carries.  (The slice and system have their own detailed reprs.)"""
+    try:
+        consistent = 'consistent' if self.is_consistent() else 'INCONSISTENT'
+    except Exception:
+        consistent = 'consistency unknown'
+
+    lines = ["WitnessSet -- dimension {}, degree {} ({})".format(
+        self.dimension(), self.degree(), consistent)]
+
+    try:
+        s = self.get_slice()
+        lines.append("  slice:  {} on {}".format(
+            _plural(s.dimension(), 'linear form'), _plural(s.num_variables(), 'variable')))
+    except Exception:
+        lines.append("  slice:  <none>")
+
+    try:
+        sysm = self.get_system()
+        lines.append("  system: {} on {}".format(
+            _plural(sysm.num_functions(), 'function'), _plural(sysm.num_variables(), 'variable')))
+    except Exception:
+        lines.append("  system: <none>")
+
+    return "\n".join(lines)
+
+
 for _ws_name in dir(_pybnalag):
     if _ws_name.startswith('WitnessSet'):
         _ws_cls = getattr(_pybnalag, _ws_name)
         if isinstance(_ws_cls, type):
             _ws_cls.witness_system = _witness_system
             _ws_cls.to_classic_input = _witness_to_classic_input
+            _ws_cls.__repr__ = _witness_repr
+            _ws_cls.__str__ = _witness_repr
 
 
 # --- to_dataframe: a ZeroDim solve as a pandas DataFrame -- the "database of solutions" ---

--- a/python/bertini/nag_algorithm/__init__.py
+++ b/python/bertini/nag_algorithm/__init__.py
@@ -48,23 +48,115 @@ _enhance_all(_pybnalag)
 _enhance_owners(_pybnalag)
 
 
-# --- Slice: numpy-style row subsetting via [] and len(), on top of head()/tail()/rows() ---
+# --- Slice: a Python sequence of linear forms ----------------------------------------------
 #
-# A Slice is a stack of linear forms; indexing/slicing it selects forms and returns a new (sub-)Slice
-# over the same variables, so s[:k], s[-k:], s[[0, 2]], s[1] all compose.
+# A Slice is a stack of linear forms; treat it as a Python sequence, following list semantics:
+#   * an integer index selects an ELEMENT -- the i-th form's coefficient VECTOR (a 1-D array);
+#     "a single linear form is a vector".  Iterating the slice yields these form vectors.
+#   * a Python slice (s[i:j]) selects a SUB-COLLECTION -- a new (sub-)Slice (same type).  A list /
+#     tuple of indices likewise selects a sub-Slice (a numpy-flavoured multi-select).
+# The whole coefficient matrix is `coefficients()` (always 2-D); see the coefficients wrapper below.
+#
+# The vector-vs-matrix distinction is thus explicit (element index vs collection slice / matrix
+# accessor), never an emergent property of the form count -- which is exactly the eigenpy 1-D
+# "collapse" footgun we are insulating callers from.  See docs/adr for the eigenpy shape rule.
+
+# eigenpy collapses a 1-row Eigen matrix to a 1-D numpy array, so the bound coefficients() is 1-D for
+# a single-form slice and 2-D otherwise -- a data-dependent shape.  Wrap it to ALWAYS return 2-D,
+# reshaped to (num_forms, num_variables+1) using the dimensions we know in C++ (orientation-correct).
+_slice_coefficients_native = _pybnalag.Slice.coefficients if hasattr(_pybnalag, 'Slice') else None
+
+
+def _slice_coefficients(self):
+    """The augmented coefficient matrix of the slice's linear forms -- **always 2-D**.
+
+    Shape ``(num_forms, num_variables + 1)``: one row per linear form, the trailing column carrying
+    each form's constant term.  This holds even for a single-form slice, where the underlying
+    binding library would otherwise hand back a 1-D array (eigenpy collapses a one-row matrix).  The
+    2-D shape is part of *this* accessor's contract -- ours, not the binding's -- so it is stable
+    across binding libraries; see ``docs/adr/0033``.  For one form's coefficient *vector*, index an
+    element: ``slice[i]``.
+
+    Examples
+    --------
+    >>> from bertini import linalg                                       # doctest: +SKIP
+    >>> import bertini                                                   # doctest: +SKIP
+    >>> x, y = bertini.Variable('x'), bertini.Variable('y')             # doctest: +SKIP
+    >>> linalg.slice_from_coefficients([[2, 3, 1]], [x, y]).coefficients().shape  # doctest: +SKIP
+    (1, 3)
+    """
+    import numpy as np
+    raw = np.asarray(_slice_coefficients_native(self))
+    return raw.reshape(self.dimension(), self.num_variables() + 1)
+
+
 def _slice_getitem(self, key):
+    """Index a slice like a Python sequence of its linear forms.
+
+    * ``slice[i]`` (an integer) -> the i-th form's coefficient **vector**, a 1-D array of length
+      ``num_variables + 1`` (trailing entry = constant term).  Iterating (``for form in slice``)
+      yields these vectors.  "A single linear form is a vector."
+    * ``slice[i:j]`` (a Python slice) -> a **sub-Slice**, a new Slice of those forms.  A list/tuple
+      of indices (``slice[[0, 2]]``) likewise -> a sub-Slice.
+
+    So the vector view and the matrix view are *named* (element index vs slice / :meth:`coefficients`),
+    never inferred from the form count.  See ``docs/adr/0033``.
+
+    Examples
+    --------
+    >>> from bertini import linalg                                       # doctest: +SKIP
+    >>> import bertini                                                   # doctest: +SKIP
+    >>> x, y = bertini.Variable('x'), bertini.Variable('y')             # doctest: +SKIP
+    >>> s = linalg.slice_from_coefficients([[2, 3, 1], [1, -1, 4]], [x, y])  # doctest: +SKIP
+    >>> s[0]                       # an ELEMENT: the first form's vector  # doctest: +SKIP
+    array([2, 3, 1], dtype=object)
+    >>> s[:1].dimension()          # a SUB-COLLECTION: a one-form Slice   # doctest: +SKIP
+    1
+    """
     n = self.dimension()
     if isinstance(key, slice):
-        return self.rows(list(range(*key.indices(n))))
+        return self.rows(list(range(*key.indices(n))))                 # sub-Slice (a sub-collection)
     if isinstance(key, (list, tuple)):
-        return self.rows([int(k) + n if int(k) < 0 else int(k) for k in key])
+        return self.rows([int(k) + n if int(k) < 0 else int(k) for k in key])   # sub-Slice
     k = int(key)
-    return self.rows([k + n if k < 0 else k])
+    if k < 0:
+        k += n
+    if not (0 <= k < n):
+        raise IndexError("slice form index {!r} out of range [0, {})".format(key, n))
+    return self.coefficients()[k]                                      # element: the form's vector
 
+
+_SLICE_DOC = """A linear slice: a stack of linear forms M [x ; 1] that cuts a positive-dimensional
+component down to witness points.  The linear part of a witness set.
+
+A slice is a Python **sequence of its linear forms**:
+
+* ``len(slice)`` -- the number of forms (the slice's dimension).
+* ``slice[i]`` (integer) -- the i-th form's coefficient **vector** (1-D, length num_variables+1).
+  Iterating yields these vectors.  A single linear form is a vector.
+* ``slice[i:j]`` / ``slice[[i, j]]`` -- a **sub-Slice** (a sub-collection of forms).
+* ``slice.coefficients()`` -- the whole augmented coefficient matrix, **always 2-D**
+  ``(num_forms, num_variables+1)``.
+
+The vector view vs the matrix view is named (element index vs slice / coefficients), never inferred
+from the form count -- so it is stable regardless of the binding library's shape conventions
+(docs/adr/0033).
+
+A slice does NOT own homogenization -- the system does.  ``slice.add_to(system)`` appends the forms
+to a system (folding the constant onto the homogenizing variable if the system was homogenized);
+``slice.as_system()`` returns a standalone System of just the forms.  Build slices with
+``Slice.random_complex`` / ``Slice.random_real`` / ``Slice.from_coefficients`` (or
+``bertini.linalg.slice_from_coefficients`` for exact numpy/list coefficients).
+"""
 
 if hasattr(_pybnalag, 'Slice'):
+    _pybnalag.Slice.coefficients = _slice_coefficients
     _pybnalag.Slice.__getitem__ = _slice_getitem
     _pybnalag.Slice.__len__ = lambda self: self.dimension()
+    try:
+        _pybnalag.Slice.__doc__ = _SLICE_DOC
+    except (AttributeError, TypeError):
+        pass   # some Boost.Python builds make the class docstring read-only; the methods carry docs
 
 
 # --- Bertini 1 / classic emission -----------------------------------------------------------

--- a/python/bertini/nag_algorithm/__init__.py
+++ b/python/bertini/nag_algorithm/__init__.py
@@ -48,6 +48,25 @@ _enhance_all(_pybnalag)
 _enhance_owners(_pybnalag)
 
 
+# --- Slice: numpy-style row subsetting via [] and len(), on top of head()/tail()/rows() ---
+#
+# A Slice is a stack of linear forms; indexing/slicing it selects forms and returns a new (sub-)Slice
+# over the same variables, so s[:k], s[-k:], s[[0, 2]], s[1] all compose.
+def _slice_getitem(self, key):
+    n = self.dimension()
+    if isinstance(key, slice):
+        return self.rows(list(range(*key.indices(n))))
+    if isinstance(key, (list, tuple)):
+        return self.rows([int(k) + n if int(k) < 0 else int(k) for k in key])
+    k = int(key)
+    return self.rows([k + n if k < 0 else k])
+
+
+if hasattr(_pybnalag, 'Slice'):
+    _pybnalag.Slice.__getitem__ = _slice_getitem
+    _pybnalag.Slice.__len__ = lambda self: self.dimension()
+
+
 # --- to_dataframe: a ZeroDim solve as a pandas DataFrame -- the "database of solutions" ---
 #
 # One ROW per solution (per tracked path), columns = the coordinates (x0, x1, ...) followed by

--- a/python/bertini/nag_algorithm/__init__.py
+++ b/python/bertini/nag_algorithm/__init__.py
@@ -80,15 +80,10 @@ def _slice_to_classic_input(self, **kwargs):
 
 def _witness_system(self):
     """The square system whose isolated solutions are the witness points: this witness set's system
-    with the slice's linear forms appended.  Requires the slice and system to share variables.
-
-    Built by cloning the witness set's system (a copy that shares the variable nodes, so it is left
-    unmutated) and adding the slice's linear-forms block to the clone -- not concatenate(), which
-    assumes polynomial blocks and cannot append a structured linear-forms block."""
-    from bertini.system import clone
-    sys = clone(self.get_system())
-    self.get_slice().add_to(sys)
-    return sys
+    with the slice's linear forms appended (concatenate, which handles the slice's structured
+    linear-forms block).  Requires the slice and system to share variables."""
+    from bertini.system import concatenate
+    return concatenate(self.get_system(), self.get_slice().as_system())
 
 
 def _witness_to_classic_input(self, **kwargs):

--- a/python/bertini/nag_algorithm/__init__.py
+++ b/python/bertini/nag_algorithm/__init__.py
@@ -80,10 +80,16 @@ def _slice_to_classic_input(self, **kwargs):
 
 def _witness_system(self):
     """The square system whose isolated solutions are the witness points: this witness set's system
-    with the slice's linear forms appended (concatenate, which handles the slice's structured
-    linear-forms block).  Requires the slice and system to share variables."""
-    from bertini.system import concatenate
-    return concatenate(self.get_system(), self.get_slice().as_system())
+    with the slice's linear forms appended.  Requires the slice and system to share variables.
+
+    Built by cloning the system (a copy sharing the variable nodes, so the witness set is left
+    unmutated) and slice.add_to()-ing the clone.  add_to is homogenization-aware -- if the system was
+    homogenized, it folds the slice's constant onto the homogenizing variable so the appended forms
+    match the rest of the system -- which plain concatenate (a generic same-structure append) is not."""
+    from bertini.system import clone
+    sys = clone(self.get_system())
+    self.get_slice().add_to(sys)
+    return sys
 
 
 def _witness_to_classic_input(self, **kwargs):

--- a/python/docs/source/tutorials/intro_to_slices.rst
+++ b/python/docs/source/tutorials/intro_to_slices.rst
@@ -1,0 +1,208 @@
+✂️ Intro to slices
+*********************************************
+
+.. testsetup:: *
+
+   import numpy as np
+   import bertini
+   from bertini import linalg
+   from bertini import multiprec as mp
+   from bertini.nag_algorithm import Slice, WitnessSetMultiplePrecision
+
+A **witness set** is how numerical algebraic geometry represents a positive-dimensional component
+of a variety -- a curve, a surface, and so on. It is a triple:
+
+* a **system** (the equations whose solution set contains the component),
+* a generic linear **slice** (enough hyperplanes to cut the component down to points), and
+* the **points** where the component meets that slice.
+
+The two headline invariants fall straight out: the **dimension** of the component is the number of
+hyperplanes in the slice, and the **degree** is the number of witness points.
+
+The system and the points are ordinary objects you already know. The **slice** is the new one, and
+it carries a fair amount of semantics -- so most of this tutorial is about slices.
+
+The slice: a stack of linear forms
+==================================
+
+A :class:`~bertini.nag_algorithm.Slice` is a stack of linear forms :math:`M\,[x ; 1]` -- one row per
+form, the trailing column of each row holding that form's constant term. You build one from exact
+coefficients with :func:`~bertini.linalg.slice_from_coefficients`:
+
+.. testcode::
+
+   x, y = bertini.Variable('x'), bertini.Variable('y')
+
+   # two linear forms on (x, y):  2x + 3y + 1   and   x - y + 4
+   s = linalg.slice_from_coefficients([[2, 3, 1], [1, -1, 4]], [x, y])
+
+   assert s.dimension() == 2        # two forms -> cuts a 2-dimensional component
+   assert s.num_variables() == 2
+
+or generate a generic one (the usual case in practice -- a witness set's slice is random):
+
+.. testcode::
+
+   x0, x1, x2 = bertini.Variable('x0'), bertini.Variable('x1'), bertini.Variable('x2')
+   vg = bertini.VariableGroup([x0, x1, x2])
+
+   generic = Slice.random_complex(vg, 2)    # two random hyperplanes in 3-space
+   assert generic.dimension() == 2
+   assert generic.num_variables() == 3
+
+.. note::
+
+   Coefficients must be **exact** (ints, ``fractions.Fraction``, exact strings like ``'3/4'``, or
+   ``bertini.multiprec`` values). A Python ``float`` is refused -- its ~16 digits would cap the
+   precision of the arbitrary-precision tree. See :func:`~bertini.linalg.coefficient`.
+
+A slice is a sequence of forms -- and the shape rules matter
+============================================================
+
+This is the part with "lots of semantics running around," so it is worth being precise. A slice
+behaves like a **Python sequence of its linear forms**, with the usual list semantics:
+
+* an **integer index** selects an *element* -- the i-th form's coefficient **vector**;
+* a **slice** ``[i:j]`` (or a list of indices) selects a *sub-collection* -- a new (sub-)``Slice``;
+* the whole coefficient matrix is :meth:`~bertini.nag_algorithm.Slice.coefficients`, **always 2-D**.
+
+.. testcode::
+
+   # an ELEMENT: slice[i] is the i-th form's coefficient VECTOR (1-D), "a line is a vector"
+   v = np.asarray(s[0])
+   assert v.shape == (3,)
+   assert [complex(c).real for c in v] == [2.0, 3.0, 1.0]      # 2x + 3y + 1
+
+   # iterating yields the form vectors
+   assert len(list(s)) == 2
+
+   # a SUB-COLLECTION: slice[i:j] is a new Slice
+   first = s[:1]
+   assert first.dimension() == 1
+
+   # the whole matrix: always 2-D, (num_forms, num_variables + 1)
+   assert s.coefficients().shape == (2, 3)
+
+The "always 2-D" is the important guarantee. The underlying binding library (eigenpy today) returns
+a *one-row* matrix to Python as a **1-D** array -- a data-dependent shape that silently breaks code
+written for the many-row case. This bites constantly in practice: a **curve** (dimension 1) has a
+**single-form** slice, so its coefficient matrix is exactly the one that would collapse.
+
+bertini owns the shape so you do not have to think about it: ``coefficients()`` is **always** 2-D,
+even for one form, and the 1-D "vector" view is something you *ask for* by indexing an element
+(``s[i]``) -- never something the form count hands you by surprise.
+
+.. testcode::
+
+   one_form = linalg.slice_from_coefficients([[2, 3, 1]], [x, y])
+   assert one_form.coefficients().shape == (1, 3)     # NOT (3,) -- it never collapses
+   assert np.asarray(one_form[0]).shape == (3,)       # the vector view is explicit
+
+(The "why" -- and the list of accessors that still carry the raw hazard -- is recorded in
+``docs/adr/0033``.)
+
+A slice rides along with a system
+=================================
+
+A slice does **not** know about homogenization or patches; the *system* owns those. A slice is just
+linear forms, meant to be carried alongside a system. Two ways to put them together:
+
+.. testcode::
+
+   # as_system(): a standalone System of just the slice's forms
+   only_slice = s.as_system()
+   assert only_slice.num_functions() == 2
+
+   # add_to(): append the slice's forms to an existing system (over the same variables)
+   sphere = bertini.System()
+   sphere.add_variable_group(vg)
+   sphere.add_function(x0*x0 + x1*x1 + x2*x2 - 1)      # the unit sphere: a surface in 3-space
+   generic.add_to(sphere)
+   assert sphere.num_functions() == 3                  # 1 sphere equation + 2 slice forms
+
+.. note::
+
+   ``add_to`` is homogenization-aware. If the system has already been homogenized, the slice's
+   constant term is folded onto the homogenizing variable (exactly as the system did to its own
+   functions), so the appended forms stay consistent. You never homogenize the slice yourself.
+
+The witness set
+===============
+
+Now assemble the triple. You can build a witness set all at once, or incrementally -- add points as
+you find them:
+
+.. testcode::
+
+   def pt(*entries):
+       return np.array([mp.Complex(str(e)) for e in entries], dtype=mp.Complex)
+
+   sys = bertini.System()
+   sys.add_variable_group(vg)
+   sys.add_function(x0*x0 + x1*x1 + x2*x2 - 1)         # the sphere again (a 2-dim component)
+   slice2 = Slice.random_complex(vg, 2)
+
+   # all at once: points + slice + system
+   w = WitnessSetMultiplePrecision([pt(1, 0, 0), pt(0, 1, 0)], slice2, sys)
+   assert w.degree() == 2          # two witness points
+   assert w.dimension() == 2       # a surface
+   assert w.is_consistent()        # 3 variables - 1 equation == slice dimension 2
+
+   # or incrementally
+   w2 = WitnessSetMultiplePrecision()
+   w2.set_system(sys)
+   w2.set_slice(slice2)
+   w2.add_point(pt(1, 0, 0))
+   w2.add_point(pt(0, 1, 0))
+   assert w2.degree() == 2
+
+A witness set prints a readable summary:
+
+.. testcode::
+
+   print(repr(w))
+
+.. testoutput::
+
+   WitnessSet -- dimension 2, degree 2 (consistent)
+     slice:  2 linear forms on 3 variables
+     system: 1 function on 3 variables
+
+Carrying it around, and emitting to Bertini 1
+=============================================
+
+A witness set (and a slice) serializes, so you can pickle one, send it to another process, or
+checkpoint it -- the deserialized system is restored ready to evaluate:
+
+.. testcode::
+
+   import pickle
+   w_again = pickle.loads(pickle.dumps(w))
+   assert w_again.degree() == 2
+   assert w_again.is_consistent()
+
+You can also emit the **witness (square) system** -- the system with the slice's forms appended --
+as a Bertini 1 classic input file, for cross-validation against the original solver:
+
+.. testcode::
+
+   square = w.witness_system()          # system + slice, the square system to track
+   assert square.num_functions() == 3
+   text = w.to_classic_input()
+   assert 'CONFIG' in text and 'INPUT' in text
+
+Building start systems from slices (regeneration)
+=================================================
+
+Because a slice's rows share their layout with a products-of-linears block, a list of slices drops
+straight into a product-of-linears start system -- the bridge regeneration is built on. Each slice
+becomes one function that is the product of its hyperplanes:
+
+.. testcode::
+
+   start = bertini.System()
+   start.add_variable_group(bertini.VariableGroup([x, y]))
+   sa = linalg.slice_from_coefficients([[1, 0, -1], [1, 0, 1]], [x, y])    # (x - 1)(x + 1)
+   sb = linalg.slice_from_coefficients([[0, 1, -1], [0, 1, -2]], [x, y])   # (y - 1)(y - 2)
+   linalg.add_slices_as_products(start, [sa, sb])
+   assert list(start.degrees()) == [2, 2]

--- a/python/docs/source/tutorials/tutorials.rst
+++ b/python/docs/source/tutorials/tutorials.rst
@@ -16,6 +16,7 @@
    parameter_homotopy
    user_product_of_linears
    randomize
+   intro_to_slices
    moving_slice
    real_points
    solving_at_scale

--- a/python/test/nid/slice_witness_test.py
+++ b/python/test/nid/slice_witness_test.py
@@ -259,6 +259,23 @@ def test_slice_to_classic_input():
     assert 'f0' in text
 
 
+def test_concatenate_accepts_a_slice_system():
+    # concatenate must append a slice's structured linear-forms block, not just polynomial rows.
+    from bertini.system import concatenate
+    x, y = pb.Variable('x'), pb.Variable('y')
+    poly = pb.System()
+    poly.add_variable_group(pb.VariableGroup([x, y]))
+    poly.add_function(x * x + y * y - 1)
+
+    slice_sys = linalg.slice_from_coefficients([[2, 3, 1], [1, -1, 4]], [x, y]).as_system()
+    combined = concatenate(poly, slice_sys)
+    assert combined.num_functions() == 3
+    v = combined.eval(_mpvec(1, 1))     # f0=1, f1=6, f2=4 at (1,1)
+    assert abs(complex(v[0]) - 1) < 1e-12
+    assert abs(complex(v[1]) - 6) < 1e-12
+    assert abs(complex(v[2]) - 4) < 1e-12
+
+
 def test_witness_set_classic_emission():
     x, y, z = pb.Variable('x'), pb.Variable('y'), pb.Variable('z')
     vg = pb.VariableGroup([x, y, z])

--- a/python/test/nid/slice_witness_test.py
+++ b/python/test/nid/slice_witness_test.py
@@ -276,6 +276,74 @@ def test_concatenate_accepts_a_slice_system():
     assert abs(complex(v[2]) - 4) < 1e-12
 
 
+def test_witness_system_preserves_patch_on_a_projective_system():
+    # A slice rides along with a system; it owns no homogenization.  For an already-projective,
+    # patched system the witness (square) system must keep the system's patch and stay evaluable.
+    x0, x1, x2 = pb.Variable('x0'), pb.Variable('x1'), pb.Variable('x2')
+    vg = pb.VariableGroup([x0, x1, x2])
+
+    sys = pb.System()
+    sys.add_hom_variable_group(vg)                 # projective P^2
+    sys.add_function(x0 * x0 + x1 * x1 - x2 * x2)  # a homogeneous conic
+    sys.auto_patch()
+    assert sys.is_patched()
+
+    s = Slice.random_complex(vg, 1, True)          # one homogeneous hyperplane (no constant term)
+    w = WitnessSetMultiplePrecision([], s, sys)
+
+    wsys = w.witness_system()
+    assert wsys.is_patched()                       # the patch carried through concatenate
+    assert wsys.eval(_mpvec(1, 1, 1)) is not None  # the combined projective system still evaluates
+
+
+def test_witness_system_homogenizes_an_affine_slice_for_a_homogenized_system():
+    # Adding a slice to an already-homogenized system folds the slice's constant onto the
+    # homogenizing variable (Slice.add_to is homogenization-aware), so witness_system stays
+    # consistent even when the witness set's system was homogenized and patched.
+    x, y = pb.Variable('x'), pb.Variable('y')
+    vg = pb.VariableGroup([x, y])
+
+    sys = pb.System()
+    sys.add_variable_group(vg)
+    sys.add_function(x * x + y * y - 1)
+    sys.homogenize()                 # mints a homogenizing variable -> 3 variables
+    sys.auto_patch()
+    assert sys.is_patched()
+    assert sys.num_variables() == 3
+
+    s = linalg.slice_from_coefficients([[2, 3, 1]], [x, y])   # an affine slice over the 2 natural vars
+    w = WitnessSetMultiplePrecision([], s, sys)
+
+    wsys = w.witness_system()        # clone + add_to: the slice's constant folds onto the hom var
+    assert wsys.is_patched()         # the system's patch carried through
+    assert wsys.is_homogeneous()     # the appended slice form is homogeneous too -- it was folded
+    assert wsys.eval(_mpvec(1, 1, 1)) is not None
+
+
+def test_affine_slice_constant_rides_on_hom_var_after_homogenize():
+    # The slice does not homogenize itself; the system does.  When a system carrying an affine slice
+    # form is homogenized, the form's constant term becomes the coefficient on the homogenizing
+    # variable (LinearFormsBlock::Homogenize) -- so the slice stays unaware of homogenization.
+    x, y = pb.Variable('x'), pb.Variable('y')
+    sys = linalg.slice_from_coefficients([[2, 3, 1]], [x, y]).as_system()   # 2x + 3y + 1
+
+    # affine: at the origin the form is its constant term, 1.
+    assert abs(complex(sys.eval(_mpvec(0, 0))[0]) - 1) < 1e-12
+
+    sys.homogenize()
+    assert sys.num_variables() == 3                # a homogenizing variable was added
+
+    # now homogeneous of degree 1: a*x + b*y + c*h with c the old constant (1).  Across the three
+    # coordinate axes the form takes the values {2, 3, 1}: the hom-var axis yields the old constant.
+    axis_vals = [complex(sys.eval(_mpvec(*([1 if i == k else 0 for i in range(3)])))[0])
+                 for k in range(3)]
+    assert any(abs(v - 1) < 1e-12 for v in axis_vals)     # the constant rode onto the hom var
+    assert any(abs(v - 2) < 1e-12 for v in axis_vals)     # x coefficient
+    assert any(abs(v - 3) < 1e-12 for v in axis_vals)     # y coefficient
+    # and the standalone constant is gone: the homogeneous form vanishes at the origin.
+    assert abs(complex(sys.eval(_mpvec(0, 0, 0))[0])) < 1e-12
+
+
 def test_witness_set_classic_emission():
     x, y, z = pb.Variable('x'), pb.Variable('y'), pb.Variable('z')
     vg = pb.VariableGroup([x, y, z])

--- a/python/test/nid/slice_witness_test.py
+++ b/python/test/nid/slice_witness_test.py
@@ -247,6 +247,37 @@ def test_witness_set_from_parts_and_consistency():
     assert w.get_system().num_functions() == 1
 
 
+# ---- Bertini 1 / classic emission ----------------------------------------------------------
+
+def test_slice_to_classic_input():
+    x, y = pb.Variable('x'), pb.Variable('y')
+    s = linalg.slice_from_coefficients([[2, 3, 1]], [x, y])     # 2x + 3y + 1
+    text = s.to_classic_input()
+    assert 'CONFIG' in text and 'INPUT' in text
+    assert text.count('END;') == 2
+    assert 'x' in text and 'y' in text
+    assert 'f0' in text
+
+
+def test_witness_set_classic_emission():
+    x, y, z = pb.Variable('x'), pb.Variable('y'), pb.Variable('z')
+    vg = pb.VariableGroup([x, y, z])
+    sys = pb.System()
+    sys.add_variable_group(vg)
+    sys.add_function(x * x + y * y + z * z - 1)
+
+    s = Slice.random_complex(vg, 2)
+    w = WitnessSetMultiplePrecision([_mpvec(1, 0, 0), _mpvec(0, 1, 0)], s, sys)
+
+    # the witness (square) system: 1 sphere function + 2 slice forms in 3 variables.
+    wsys = w.witness_system()
+    assert wsys.num_functions() == 3
+
+    text = w.to_classic_input()
+    assert 'CONFIG' in text and 'INPUT' in text
+    assert text.count('END;') == 2
+
+
 # ---- serialization (pickle / deepcopy) -----------------------------------------------------
 
 def test_slice_pickle_roundtrip():

--- a/python/test/nid/slice_witness_test.py
+++ b/python/test/nid/slice_witness_test.py
@@ -27,6 +27,7 @@ import copy
 import pickle
 
 import numpy as np
+import pytest
 
 import bertini as pb
 from bertini import linalg
@@ -100,23 +101,48 @@ def test_random_real_slice():
 
 # ---- row subsetting / composition ----------------------------------------------------------
 
-def test_slice_len_and_getitem_slice():
+def test_slice_getitem_slice_is_a_subcollection():
+    # s[i:j] selects a SUB-COLLECTION -> a (sub-)Slice (Python list semantics).
     s = _known_slice()
     assert len(s) == 2
     head = s[:1]
     assert head.dimension() == 1
-    # a one-form slice's coefficients come back from eigenpy as a 1-D array (numpy convention).
-    assert np.atleast_2d(np.asarray(head.coefficients())).shape == (1, 3)
+    assert head.coefficients().shape == (1, 3)   # coefficients() is always 2-D
     tail = s[-1:]
     assert tail.dimension() == 1
 
 
-def test_slice_getitem_list_and_int():
+def test_slice_getitem_list_is_a_subcollection():
     s = _known_slice()
     reordered = s[[1, 0]]
     assert reordered.dimension() == 2
-    single = s[0]
-    assert single.dimension() == 1
+    rows = np.asarray(reordered.coefficients())
+    assert [complex(rows[0, j]).real for j in range(3)] == [1.0, -1.0, 4.0]   # form 1 came first
+
+
+def test_slice_int_index_is_a_form_vector():
+    # s[i] selects an ELEMENT -> the i-th form's coefficient VECTOR (1-D), "a line is a vector".
+    s = _known_slice()
+    v0 = np.asarray(s[0])
+    assert v0.shape == (3,)
+    assert [complex(c).real for c in v0] == [2.0, 3.0, 1.0]
+    v_last = np.asarray(s[-1])
+    assert [complex(c).real for c in v_last] == [1.0, -1.0, 4.0]
+    with pytest.raises(IndexError):
+        _ = s[5]
+
+
+def test_iterating_slice_yields_form_vectors():
+    s = _known_slice()
+    forms = list(s)               # iteration yields elements = form vectors
+    assert len(forms) == 2
+    assert all(np.asarray(f).shape == (3,) for f in forms)
+
+
+def test_coefficients_always_2d_even_for_one_form():
+    x, y = pb.Variable('x'), pb.Variable('y')
+    one = linalg.slice_from_coefficients([[2, 3, 1]], [x, y])
+    assert one.coefficients().shape == (1, 3)     # NOT (3,): coefficients() never collapses
 
 
 def test_slice_concatenate_and_add_operator():
@@ -162,7 +188,8 @@ def test_head_tail_rows_methods():
 def test_subslice_rows_match_parent():
     s = _known_slice()
     C = np.asarray(s.coefficients())
-    sub = np.atleast_2d(np.asarray(s[[1]].coefficients()))   # one-form slice -> 1-D from eigenpy
+    sub = np.asarray(s[[1]].coefficients())   # a sub-Slice; coefficients() is always 2-D (1, 3)
+    assert sub.shape == (1, 3)
     assert all(abs(complex(C[1, j]) - complex(sub[0, j])) < 1e-25 for j in range(3))
 
 
@@ -184,7 +211,6 @@ def test_slice_add_to_system_agrees_with_slice_eval():
 
 
 def test_add_to_rejects_variable_count_mismatch():
-    import pytest
     x, y, z = pb.Variable('x'), pb.Variable('y'), pb.Variable('z')
     s = Slice.random_complex(pb.VariableGroup([x, y, z]), 1)   # three variables
     sys = pb.System()

--- a/python/test/nid/slice_witness_test.py
+++ b/python/test/nid/slice_witness_test.py
@@ -1,0 +1,202 @@
+# This file is part of Bertini 2.
+#
+# python/test/nid/slice_witness_test.py is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# python/test/nid/slice_witness_test.py is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this file.  If not, see <http://www.gnu.org/licenses/>.
+#
+#  Copyright(C) Bertini2 Development Team
+#
+#  See <http://www.gnu.org/licenses/> for a copy of the license,
+#  as well as COPYING.  Bertini2 is provided with permitted
+#  additional terms in the b2/licenses/ directory.
+
+"""The block-backed Slice and the WitnessSet exposure: building, evaluating, row-subsetting,
+adding a slice to a System, the regen products-of-linears bridge, and constructing a witness
+set both incrementally and all-at-once."""
+
+import numpy as np
+
+import bertini as pb
+from bertini import linalg
+from bertini import multiprec as mp
+from bertini.nag_algorithm import Slice, WitnessSetMultiplePrecision
+
+
+def _mpvec(*entries):
+    return np.array([mp.Complex(str(e)) for e in entries], dtype=mp.Complex)
+
+
+def _known_slice():
+    # f0 = 2x + 3y + 1,  f1 = x - y + 4   on (x, y)
+    x, y = pb.Variable('x'), pb.Variable('y')
+    return linalg.slice_from_coefficients([[2, 3, 1], [1, -1, 4]], [x, y])
+
+
+# ---- Slice ---------------------------------------------------------------------------------
+
+def test_slice_from_coefficients_shape():
+    s = _known_slice()
+    assert s.dimension() == 2
+    assert s.num_variables() == 2
+    assert not s.is_homogeneous()
+    assert np.asarray(s.coefficients()).shape == (2, 3)
+
+
+def test_slice_eval_mp():
+    s = _known_slice()
+    v = s.eval(_mpvec(1, 1))            # f0 = 6, f1 = 4
+    assert abs(complex(v[0]) - 6) < 1e-12
+    assert abs(complex(v[1]) - 4) < 1e-12
+
+
+def test_slice_eval_double():
+    s = _known_slice()
+    v = s.eval(np.array([1 + 0j, 1 + 0j]))
+    assert abs(v[0] - 6) < 1e-12
+    assert abs(v[1] - 4) < 1e-12
+
+
+def test_slice_coefficients_match_first_row():
+    s = _known_slice()
+    C = np.asarray(s.coefficients())
+    assert [complex(C[0, j]).real for j in range(3)] == [2.0, 3.0, 1.0]
+
+
+def test_random_complex_slice():
+    x, y, z = pb.Variable('x'), pb.Variable('y'), pb.Variable('z')
+    vg = pb.VariableGroup([x, y, z])
+    s = Slice.random_complex(vg, 2)
+    assert s.dimension() == 2
+    assert s.num_variables() == 3
+    assert not s.is_homogeneous()
+
+
+def test_homogeneous_slice_has_zero_constant_column():
+    x, y, z = pb.Variable('x'), pb.Variable('y'), pb.Variable('z')
+    vg = pb.VariableGroup([x, y, z])
+    s = Slice.random_complex(vg, 2, True)
+    assert s.is_homogeneous()
+    C = np.asarray(s.coefficients())
+    assert all(abs(complex(C[i, 3])) < 1e-25 for i in range(2))
+
+
+def test_random_real_slice():
+    x, y, z = pb.Variable('x'), pb.Variable('y'), pb.Variable('z')
+    s = Slice.random_real(pb.VariableGroup([x, y, z]), 2)
+    assert s.dimension() == 2
+
+
+# ---- row subsetting / composition ----------------------------------------------------------
+
+def test_slice_len_and_getitem_slice():
+    s = _known_slice()
+    assert len(s) == 2
+    head = s[:1]
+    assert head.dimension() == 1
+    # a one-form slice's coefficients come back from eigenpy as a 1-D array (numpy convention).
+    assert np.atleast_2d(np.asarray(head.coefficients())).shape == (1, 3)
+    tail = s[-1:]
+    assert tail.dimension() == 1
+
+
+def test_slice_getitem_list_and_int():
+    s = _known_slice()
+    reordered = s[[1, 0]]
+    assert reordered.dimension() == 2
+    single = s[0]
+    assert single.dimension() == 1
+
+
+def test_head_tail_rows_methods():
+    x, y, z = pb.Variable('x'), pb.Variable('y'), pb.Variable('z')
+    s = Slice.random_complex(pb.VariableGroup([x, y, z]), 4)
+    assert s.head(2).dimension() == 2
+    assert s.tail(1).dimension() == 1
+    assert s.rows([0, 3]).dimension() == 2
+
+
+def test_subslice_rows_match_parent():
+    s = _known_slice()
+    C = np.asarray(s.coefficients())
+    sub = np.atleast_2d(np.asarray(s[[1]].coefficients()))   # one-form slice -> 1-D from eigenpy
+    assert all(abs(complex(C[1, j]) - complex(sub[0, j])) < 1e-25 for j in range(3))
+
+
+# ---- a slice as a System block -------------------------------------------------------------
+
+def test_slice_add_to_system_agrees_with_slice_eval():
+    x, y = pb.Variable('x'), pb.Variable('y')
+    sys = pb.System()
+    sys.add_variable_group(pb.VariableGroup([x, y]))
+    s = linalg.slice_from_coefficients([[2, 3, 1], [1, -1, 4]], [x, y])
+    s.add_to(sys)
+    assert sys.num_functions() == 2
+
+    pt = _mpvec(1, 1)
+    from_sys = sys.eval(pt)
+    from_slice = s.eval(pt)
+    assert abs(complex(from_sys[0]) - complex(from_slice[0])) < 1e-12
+    assert abs(complex(from_sys[1]) - complex(from_slice[1])) < 1e-12
+
+
+def test_add_slices_as_products_is_the_regen_bridge():
+    x, y = pb.Variable('x'), pb.Variable('y')
+    sys = pb.System()
+    sys.add_variable_group(pb.VariableGroup([x, y]))
+    s1 = linalg.slice_from_coefficients([[1, 0, -1], [1, 0, 1]], [x, y])    # (x - 1)(x + 1)
+    s2 = linalg.slice_from_coefficients([[0, 1, -1], [0, 1, -2]], [x, y])   # (y - 1)(y - 2)
+    linalg.add_slices_as_products(sys, [s1, s2])
+    assert list(sys.degrees()) == [2, 2]
+    # at (x, y) = (1, 1):  f0 = (0)(2) = 0,  f1 = (0)(-1) = 0
+    v = sys.eval(_mpvec(1, 1))
+    assert abs(complex(v[0])) < 1e-12
+    assert abs(complex(v[1])) < 1e-12
+
+
+# ---- WitnessSet ----------------------------------------------------------------------------
+
+def test_witness_set_built_incrementally():
+    x, y, z = pb.Variable('x'), pb.Variable('y'), pb.Variable('z')
+    vg = pb.VariableGroup([x, y, z])
+
+    w = WitnessSetMultiplePrecision()
+    assert w.degree() == 0
+
+    w.add_point(_mpvec(1, 0, 0))
+    w.add_point(_mpvec(0, 1, 0))
+    assert w.degree() == 2
+
+    w.set_slice(Slice.random_complex(vg, 1))
+    assert w.dimension() == 1
+
+    assert len(w.get_points()) == 2
+    assert abs(complex(w.get_point(0)[0]) - 1) < 1e-12
+    assert w.get_slice().dimension() == 1
+
+
+def test_witness_set_from_parts_and_consistency():
+    x, y, z = pb.Variable('x'), pb.Variable('y'), pb.Variable('z')
+    vg = pb.VariableGroup([x, y, z])
+
+    sys = pb.System()
+    sys.add_variable_group(vg)
+    sys.add_function(x * x + y * y + z * z - 1)   # the sphere: a dim-2 component in 3-space
+
+    s = Slice.random_complex(vg, 2)
+    pts = [_mpvec(1, 0, 0), _mpvec(0, 1, 0)]
+    w = WitnessSetMultiplePrecision(pts, s, sys)
+
+    assert w.degree() == 2
+    assert w.dimension() == 2
+    # 3 variables - 1 natural function == slice dimension 2
+    assert w.is_consistent()
+    assert w.get_system().num_functions() == 1

--- a/python/test/nid/slice_witness_test.py
+++ b/python/test/nid/slice_witness_test.py
@@ -183,6 +183,16 @@ def test_slice_add_to_system_agrees_with_slice_eval():
     assert abs(complex(from_sys[1]) - complex(from_slice[1])) < 1e-12
 
 
+def test_add_to_rejects_variable_count_mismatch():
+    import pytest
+    x, y, z = pb.Variable('x'), pb.Variable('y'), pb.Variable('z')
+    s = Slice.random_complex(pb.VariableGroup([x, y, z]), 1)   # three variables
+    sys = pb.System()
+    sys.add_variable_group(pb.VariableGroup([x, y]))           # two variables
+    with pytest.raises(RuntimeError):
+        s.add_to(sys)
+
+
 def test_add_slices_as_products_is_the_regen_bridge():
     x, y = pb.Variable('x'), pb.Variable('y')
     sys = pb.System()

--- a/python/test/nid/slice_witness_test.py
+++ b/python/test/nid/slice_witness_test.py
@@ -363,6 +363,32 @@ def test_witness_set_classic_emission():
     assert text.count('END;') == 2
 
 
+def test_witness_set_repr_is_readable():
+    x, y, z = pb.Variable('x'), pb.Variable('y'), pb.Variable('z')
+    vg = pb.VariableGroup([x, y, z])
+    sys = pb.System()
+    sys.add_variable_group(vg)
+    sys.add_function(x * x + y * y + z * z - 1)
+    s = Slice.random_complex(vg, 2)
+    w = WitnessSetMultiplePrecision([_mpvec(1, 0, 0), _mpvec(0, 1, 0)], s, sys)
+
+    text = repr(w)
+    assert 'WitnessSet' in text
+    assert 'dimension 2' in text
+    assert 'degree 2' in text
+    assert 'consistent' in text
+    assert 'slice' in text and 'system' in text
+    # single vs plural: 1 function reads "1 function", not "1 functions"
+    assert '1 function ' in text and '2 linear forms' in text
+
+
+def test_empty_witness_set_repr():
+    w = WitnessSetMultiplePrecision()
+    text = repr(w)
+    assert 'WitnessSet' in text
+    assert 'degree 0' in text
+
+
 # ---- serialization (pickle / deepcopy) -----------------------------------------------------
 
 def test_slice_pickle_roundtrip():

--- a/python/test/nid/slice_witness_test.py
+++ b/python/test/nid/slice_witness_test.py
@@ -119,6 +119,38 @@ def test_slice_getitem_list_and_int():
     assert single.dimension() == 1
 
 
+def test_slice_concatenate_and_add_operator():
+    x, y = pb.Variable('x'), pb.Variable('y')
+    sa = linalg.slice_from_coefficients([[2, 3, 1]], [x, y])    # 2x + 3y + 1
+    sb = linalg.slice_from_coefficients([[1, -1, 4]], [x, y])   # x - y + 4
+
+    combined = sa.concatenate(sb)
+    assert combined.dimension() == 2
+    v = combined.eval(_mpvec(1, 1))
+    assert abs(complex(v[0]) - 6) < 1e-12 and abs(complex(v[1]) - 4) < 1e-12
+
+    # the + operator is concatenation
+    plus = sa + sb
+    assert plus.dimension() == 2
+
+
+def test_slice_as_system_matches_eval():
+    x, y = pb.Variable('x'), pb.Variable('y')
+    s = linalg.slice_from_coefficients([[2, 3, 1], [1, -1, 4]], [x, y])
+    sys = s.as_system()
+    assert sys.num_functions() == 2
+    pt = _mpvec(1, 1)
+    from_sys, from_slice = sys.eval(pt), s.eval(pt)
+    assert all(abs(complex(from_sys[i]) - complex(from_slice[i])) < 1e-12 for i in range(2))
+
+
+def test_slice_repr_is_readable():
+    s = _known_slice()
+    text = repr(s)
+    assert 'slice' in text.lower()
+    assert 'coefficient' in text.lower()
+
+
 def test_head_tail_rows_methods():
     x, y, z = pb.Variable('x'), pb.Variable('y'), pb.Variable('z')
     s = Slice.random_complex(pb.VariableGroup([x, y, z]), 4)

--- a/python/test/nid/slice_witness_test.py
+++ b/python/test/nid/slice_witness_test.py
@@ -23,6 +23,9 @@
 adding a slice to a System, the regen products-of-linears bridge, and constructing a witness
 set both incrementally and all-at-once."""
 
+import copy
+import pickle
+
 import numpy as np
 
 import bertini as pb
@@ -200,3 +203,51 @@ def test_witness_set_from_parts_and_consistency():
     # 3 variables - 1 natural function == slice dimension 2
     assert w.is_consistent()
     assert w.get_system().num_functions() == 1
+
+
+# ---- serialization (pickle / deepcopy) -----------------------------------------------------
+
+def test_slice_pickle_roundtrip():
+    s = _known_slice()
+    s2 = pickle.loads(pickle.dumps(s))
+    assert s2.dimension() == 2
+    assert s2.num_variables() == 2
+    C, C2 = np.asarray(s.coefficients()), np.asarray(s2.coefficients())
+    assert all(abs(complex(C[i, j]) - complex(C2[i, j])) < 1e-25
+               for i in range(2) for j in range(3))
+    v = s2.eval(_mpvec(1, 1))
+    assert abs(complex(v[0]) - 6) < 1e-12 and abs(complex(v[1]) - 4) < 1e-12
+
+
+def test_slice_deepcopy():
+    s = _known_slice()
+    s2 = copy.deepcopy(s)
+    assert s2.dimension() == 2
+    assert np.asarray(s2.coefficients()).shape == (2, 3)
+
+
+def test_witness_set_pickle_roundtrip():
+    x, y, z = pb.Variable('x'), pb.Variable('y'), pb.Variable('z')
+    vg = pb.VariableGroup([x, y, z])
+
+    sys = pb.System()
+    sys.add_variable_group(vg)
+    sys.add_function(x * x + y * y + z * z - 1)
+
+    s = Slice.random_complex(vg, 2)
+    w = WitnessSetMultiplePrecision([_mpvec(1, 0, 0), _mpvec(0, 1, 0)], s, sys)
+
+    w2 = pickle.loads(pickle.dumps(w))
+    assert w2.degree() == 2
+    assert w2.dimension() == 2
+    assert w2.is_consistent()
+    assert w2.get_slice().dimension() == 2
+    assert len(w2.get_points()) == 2
+
+    # the deserialized system is usable: its load() re-differentiated it.
+    pt = _mpvec(1, 1, 1)
+    v = w2.get_system().eval(pt)
+    assert abs(complex(v[0]) - 2) < 1e-12     # 1 + 1 + 1 - 1 = 2
+    # a 1-function Jacobian comes back from eigenpy as a 1-D array (see other tests); the point is
+    # that differentiating the deserialized system works at all -- load() restored it.
+    assert np.atleast_2d(np.asarray(w2.get_system().eval_jacobian(pt))).shape == (1, 3)

--- a/python_bindings/src/nid_datatypes_export.cpp
+++ b/python_bindings/src/nid_datatypes_export.cpp
@@ -78,6 +78,9 @@ namespace bertini{
 				+[](Slice const& s, bertini::Vec<mpfr_complex> const& x){ return s.Eval(x); },
 				(arg("self"), arg("x")), "evaluate the linear forms at x, in multiple precision")
 			.def("add_to", &Slice::AddTo, (arg("self"), arg("system")), "add this slice's linear forms to a System as a linear-forms block")
+			.def("as_system", &Slice::AsSystem, (arg("self")), "a standalone System whose functions are exactly this slice's linear forms")
+			.def("concatenate", &Slice::Concatenate, (arg("self"), arg("other")), "a new slice stacking this slice's forms on top of other's (both on the same variables)")
+			.def("__add__", &Slice::Concatenate, "stack two slices' linear forms into one slice")
 			.def("head", &Slice::Head, (arg("self"), arg("m")), "a new slice over the same variables, built from the first m linear forms")
 			.def("tail", &Slice::Tail, (arg("self"), arg("m")), "a new slice over the same variables, built from the last m linear forms")
 			.def("rows",
@@ -90,6 +93,8 @@ namespace bertini{
 				(arg("self"), arg("indices")), "a new slice over the same variables, built from the chosen linear forms")
 			.def("precision", +[](Slice const& s){ return s.Precision(); }, (arg("self")), "get the current working precision of the slice")
 			.def("precision", +[](Slice const& s, unsigned p){ s.Precision(p); }, (arg("self"), arg("precision")), "set the working precision of the slice")
+			.def("__str__", +[](Slice const& s){ std::ostringstream oss; oss << s; return oss.str(); })
+			.def("__repr__", +[](Slice const& s){ std::ostringstream oss; oss << s; return oss.str(); })
 			.def_pickle(BoostSerializePickle<Slice>())
 			;
 		}

--- a/python_bindings/src/nid_datatypes_export.cpp
+++ b/python_bindings/src/nid_datatypes_export.cpp
@@ -1,21 +1,113 @@
-// python/nid_datatypes_export.cpp — NID result data type registrations (WitnessSet, NIDResult).
+// python/nid_datatypes_export.cpp — NID result data type registrations (Slice, WitnessSet, NIDResult).
 // These are pure data types; no algorithm class_<> instantiations needed.
 
 #include "numerical_irreducible_decomposition_export.hpp"
 #include <boost/python/copy_const_reference.hpp>
+#include <boost/python/stl_iterator.hpp>
 
 namespace bertini{
 	namespace python{
 
+		using dbl = std::complex<double>;
+
+		// ---- Slice: the linear part of a witness set -----------------------------------------
+		// A Slice is a stack of linear forms M [x ; 1] (one row per form, the trailing column the
+		// constant term), backed by a LinearFormsBlock.  Read-mostly: the factories build one,
+		// then it is carried around, evaluated, row-subset, and dropped into a System.
+		void ExportSlice(){
+			class_<Slice>("Slice", "A linear slice of affine/projective space: a stack of linear forms M [x ; 1].", init<>())
+			.def("from_coefficients",
+				+[](VariableGroup const& v, bertini::Mat<mpfr_complex> const& aug, bool homogeneous){
+					return Slice::FromCoefficients(v, aug, homogeneous);
+				},
+				(arg("variables"), arg("coefficients"), arg("homogeneous")=false),
+				"Build a slice from an augmented coefficient matrix: one row per linear form, num_variables+1 columns, the trailing column carrying each form's constant term (zero, for a homogeneous slice).")
+			.staticmethod("from_coefficients")
+			.def("random_complex",
+				+[](VariableGroup const& v, unsigned dim, bool homogeneous, bool orthogonal){
+					return Slice::RandomComplex(v, dim, homogeneous, orthogonal);
+				},
+				(arg("variables"), arg("dim"), arg("homogeneous")=false, arg("orthogonal")=true),
+				"A random complex linear slice of `dim` dimensions (forms) on the given variables.")
+			.staticmethod("random_complex")
+			.def("random_real",
+				+[](VariableGroup const& v, unsigned dim, bool homogeneous, bool orthogonal){
+					return Slice::RandomReal(v, dim, homogeneous, orthogonal);
+				},
+				(arg("variables"), arg("dim"), arg("homogeneous")=false, arg("orthogonal")=true),
+				"A random real linear slice of `dim` dimensions (forms) on the given variables.")
+			.staticmethod("random_real")
+			.def("coefficients",
+				+[](Slice const& s){ return bertini::Mat<mpfr_complex>(s.Coefficients()); },
+				(arg("self")),
+				"The augmented coefficient matrix (one row per linear form, num_variables+1 columns; the trailing column is the constant term).  These rows are ready-made factors for a products-of-linears block.")
+			.def("dimension", &Slice::Dimension, (arg("self")), "the dimension of the slice -- the number of linear forms")
+			.def("num_variables", &Slice::NumVariables, (arg("self")), "the number of variables the slice is a function of")
+			.def("is_homogeneous", &Slice::IsHomogeneous, (arg("self")), "whether the slice was authored without constant terms")
+			.def("eval",
+				+[](Slice const& s, bertini::Vec<dbl> const& x){ return s.Eval(x); },
+				(arg("self"), arg("x")), "evaluate the linear forms at x, in double precision")
+			.def("eval",
+				+[](Slice const& s, bertini::Vec<mpfr_complex> const& x){ return s.Eval(x); },
+				(arg("self"), arg("x")), "evaluate the linear forms at x, in multiple precision")
+			.def("add_to", &Slice::AddTo, (arg("self"), arg("system")), "add this slice's linear forms to a System as a linear-forms block")
+			.def("head", &Slice::Head, (arg("self"), arg("m")), "a new slice over the same variables, built from the first m linear forms")
+			.def("tail", &Slice::Tail, (arg("self"), arg("m")), "a new slice over the same variables, built from the last m linear forms")
+			.def("rows",
+				+[](Slice const& s, boost::python::list const& indices){
+					std::vector<unsigned> idx{
+						boost::python::stl_input_iterator<unsigned>(indices),
+						boost::python::stl_input_iterator<unsigned>() };
+					return s.Rows(idx);
+				},
+				(arg("self"), arg("indices")), "a new slice over the same variables, built from the chosen linear forms")
+			.def("precision", +[](Slice const& s){ return s.Precision(); }, (arg("self")), "get the current working precision of the slice")
+			.def("precision", +[](Slice const& s, unsigned p){ s.Precision(p); }, (arg("self"), arg("precision")), "set the working precision of the slice")
+			;
+		}
+
+		// ---- WitnessSet ----------------------------------------------------------------------
 		template<typename NumT>
 		void ExportWitnessSet(std::string const& class_name){
 			using WS = nag_datatype::WitnessSet<NumT>;
+			using PointContT = nag_datatype::PointCont<bertini::Vec<NumT>>;
+
 			class_<WS>(class_name.c_str(), init<>())
+			// build all-at-once from points + slice + system, or incrementally (default ctor + add_point/set_*).
+			.def("__init__", make_constructor(
+				+[](boost::python::list const& pts, Slice const& slc, bertini::System const& sys){
+					PointContT points{
+						boost::python::stl_input_iterator<bertini::Vec<NumT>>(pts),
+						boost::python::stl_input_iterator<bertini::Vec<NumT>>() };
+					return new WS(points, slc, sys);
+				}),
+				"construct a witness set from a list of witness points, a slice, and a system")
 			.def("degree", &WS::Degree, "the degree of the component, i.e. the number of witness points")
 			.def("dimension", &WS::Dimension, "the dimension of the component")
 			.def("is_consistent", &WS::IsConsistent, "whether the slice dimension matches the system's underdeterminedness")
 			.def("get_point", &WS::GetPoint, return_value_policy<copy_const_reference>(), "get the i-th witness point")
+			.def("get_points",
+				+[](WS const& w){
+					boost::python::list out;
+					for (auto const& p : w.GetPoints())
+						out.append(p);
+					return out;
+				},
+				"the witness points, as a list")
+			.def("get_slice", &WS::GetSlice, return_internal_reference<>(), "the linear slice of this witness set")
 			.def("get_system", &WS::GetSystem, return_internal_reference<>(), "the system this witness set is for")
+			// mutators -- build a witness set as you go
+			.def("add_point", &WS::AddPoint, (arg("self"), arg("point")), "append a witness point")
+			.def("set_points",
+				+[](WS& w, boost::python::list const& pts){
+					PointContT points{
+						boost::python::stl_input_iterator<bertini::Vec<NumT>>(pts),
+						boost::python::stl_input_iterator<bertini::Vec<NumT>>() };
+					w.SetPoints(points);
+				},
+				(arg("self"), arg("points")), "replace the witness points with the given list")
+			.def("set_slice", &WS::SetSlice, (arg("self"), arg("slice")), "set the linear slice")
+			.def("set_system", &WS::SetSystem, (arg("self"), arg("system")), "set the system")
 			;
 		}
 
@@ -30,6 +122,7 @@ namespace bertini{
 		}
 
 		void ExportNIDDataTypes(){
+			ExportSlice();
 			ExportWitnessSet<dbl_complex>("WitnessSetDoublePrecision");
 			ExportWitnessSet<mpfr_complex>("WitnessSetMultiplePrecision");
 			ExportNIDResult<dbl_complex>("NumericalIrreducibleDecompositionDoublePrecision");

--- a/python_bindings/src/nid_datatypes_export.cpp
+++ b/python_bindings/src/nid_datatypes_export.cpp
@@ -4,11 +4,38 @@
 #include "numerical_irreducible_decomposition_export.hpp"
 #include <boost/python/copy_const_reference.hpp>
 #include <boost/python/stl_iterator.hpp>
+#include <sstream>
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/archive/text_iarchive.hpp>
 
 namespace bertini{
 	namespace python{
 
 		using dbl = std::complex<double>;
+
+		// pickle via boost serialization -- so Slice / WitnessSet / NID result round-trip through
+		// pickle, copy, and deepcopy (and, in C++, through MPI / threads).  Mirrors the suites in
+		// system_export.cpp and mpfr_export.cpp.  WitnessSet restores its system's differentiated
+		// state in its own serialization load(), so setstate needs no extra fixup here.
+		template<typename T>
+		struct BoostSerializePickle : boost::python::pickle_suite
+		{
+			static boost::python::tuple getinitargs(T const&){ return boost::python::make_tuple(); }
+
+			static boost::python::object getstate(T const& obj)
+			{
+				std::ostringstream oss;
+				{ boost::archive::text_oarchive oa(oss); oa << obj; }
+				return boost::python::str(oss.str());
+			}
+
+			static void setstate(T& obj, boost::python::object state)
+			{
+				std::string s = boost::python::extract<std::string>(state)();
+				std::istringstream iss(s);
+				{ boost::archive::text_iarchive ia(iss); ia >> obj; }
+			}
+		};
 
 		// ---- Slice: the linear part of a witness set -----------------------------------------
 		// A Slice is a stack of linear forms M [x ; 1] (one row per form, the trailing column the
@@ -63,6 +90,7 @@ namespace bertini{
 				(arg("self"), arg("indices")), "a new slice over the same variables, built from the chosen linear forms")
 			.def("precision", +[](Slice const& s){ return s.Precision(); }, (arg("self")), "get the current working precision of the slice")
 			.def("precision", +[](Slice const& s, unsigned p){ s.Precision(p); }, (arg("self"), arg("precision")), "set the working precision of the slice")
+			.def_pickle(BoostSerializePickle<Slice>())
 			;
 		}
 
@@ -108,6 +136,7 @@ namespace bertini{
 				(arg("self"), arg("points")), "replace the witness points with the given list")
 			.def("set_slice", &WS::SetSlice, (arg("self"), arg("slice")), "set the linear slice")
 			.def("set_system", &WS::SetSystem, (arg("self"), arg("system")), "set the system")
+			.def_pickle(BoostSerializePickle<WS>())
 			;
 		}
 
@@ -118,6 +147,7 @@ namespace bertini{
 			.def("nonempty_codimensions", &R::NonEmptyCodimensions, "the distinct codimensions which contain at least one component")
 			.def("num_witness_sets", &R::NumWitnessSets, "the number of stored witness sets")
 			.def("get_witness_set", &R::GetWitnessSet, return_internal_reference<>(), "get the i-th stored witness set")
+			.def_pickle(BoostSerializePickle<R>())
 			;
 		}
 


### PR DESCRIPTION
Enables NID (a Python prototype is in progress, to be ported to C++ later) by exposing a usable `WitnessSet` and, above all, a usable **slice**.

## What changed

- **Retire `LinearSlice`; `Slice` wraps `LinearFormsBlock`.** The old `LinearSlice` was orphaned (not a System block, used by no algorithm, unexposed) and a duplicate of the integrated `LinearFormsBlock`. `bertini::Slice` now holds a `LinearFormsBlock` + the sliced `VariableGroup`, salvages the QR random-slice factories, and adds the composition surface (`Coefficients`, `Head`/`Tail`/`Rows`, `AsLinearFormsBlock`, `AddTo`, `AsSystem`, `Concatenate`). See **ADR-0032**.
- **Python exposure.** `Slice` (factories, `coefficients`, `eval`, `head`/`tail`/`rows`, `[]`/`len`, `add_to`, `as_system`, `concatenate`/`+`, `repr`) and `WitnessSet` (`get_slice`/`get_points`, building mutators, from-parts ctor — build incrementally or all at once). Plus `linalg.slice_from_coefficients`, `linalg.add_slices_as_products` (the regeneration bridge).
- **Serialization + pickle** for `Slice`, `WitnessSet`, and the NID result — the substrate MPI/threading need. `WitnessSet` load() re-differentiates its system so a deserialized witness set is immediately usable (in C++ too, not just Python pickle).
- **B1 / classic emission.** `Slice.to_classic_input()`, and `WitnessSet.witness_system()` / `to_classic_input()` emit the square (system + slice) system for cross-validation in Bertini 1.
- **Fix `Concatenate`** to append structured blocks (it read only the `PolynomialBlock` via `Function(ii)`, skipping/segfaulting on a structured operand like a slice's `LinearFormsBlock`).
- **Homogenization-aware `add_to`.** A slice doesn't own homogenization — the system does. Adding a slice to an already-homogenized system folds the slice's constant onto the homogenizing variable (as `System::Homogenize` does to the other blocks), so the appended forms stay consistent.

## Tests

C++ regression tests per behavior (`slice_test`, `witness_set`, `system_test` concatenate) and a Python suite (`python/test/nid/slice_witness_test.py`, 28 cases). Full C++ `test_classes`/`test_nag_datatypes` clean; full Python suite 525 passed, 1 skipped.

## Deliberately out of scope (future)

- Multi-affine-group homogenize-on-add (throws clearly for now, matching `LinearFormsBlock`'s own single-group limit).
- Coordinate-moving on slices (dehomogenize/rehomogenize points) — "if there's need later."

🤖 Generated with [Claude Code](https://claude.com/claude-code)