### PR TITLE
Feature/macos compiler warnings

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -435,6 +435,13 @@ target_include_directories(bertini2
     ${GMP_INCLUDES}
     ${MPFR_INCLUDES}
     ${MPC_INCLUDES}
+    # Treat Boost/Eigen headers as system so their (and their template
+    # instantiations') warnings stay out of our build output. Boost is linked
+    # below via raw ${Boost_LIBRARIES} (no include propagation), so its include
+    # dir must be added here explicitly. Eigen3::Eigen is an imported target
+    # (already SYSTEM by default), but we mark it explicitly to be robust.
+    ${Boost_INCLUDE_DIRS}
+    $<TARGET_PROPERTY:Eigen3::Eigen,INTERFACE_INCLUDE_DIRECTORIES>
 )
 
 target_include_directories(bertini2 PUBLIC

--- a/core/include/bertini2/double_extensions.hpp
+++ b/core/include/bertini2/double_extensions.hpp
@@ -103,7 +103,7 @@ std::mt19937& ThreadEngine();
 			return z*z*z;
 		else
 		{
-			unsigned int p(power);
+			unsigned int p(static_cast<unsigned int>(power));
 			dbl result(1,0), z_to_the_current_power_of_two = z;
 			// have copy of p in memory, can freely modify it.
 			do {

--- a/core/include/bertini2/eigen_extensions.hpp
+++ b/core/include/bertini2/eigen_extensions.hpp
@@ -93,7 +93,7 @@ namespace Eigen {
 
 		static inline int digits10()
 		{
-			return bertini::ThreadPrecision();
+			return static_cast<int>(bertini::ThreadPrecision());
 			// return internal::default_digits10_impl<T>::run();
 		}
 		//http://www.manpagez.com/info/mpfr/mpfr-2.3.2/mpfr_31.php
@@ -505,7 +505,7 @@ namespace bertini {
 	inline
 	Mat<NumberType> RandomOfUnits(unsigned int rows, unsigned int cols)
 	{
-		return Mat<NumberType>(rows,cols).unaryExpr([](NumberType const& x) { return RandomUnit<NumberType>(); });
+		return Mat<NumberType>(rows,cols).unaryExpr([](NumberType const& /*x*/) { return RandomUnit<NumberType>(); });
 	}
 
 	/**

--- a/core/include/bertini2/endgames/cauchy.hpp
+++ b/core/include/bertini2/endgames/cauchy.hpp
@@ -955,7 +955,7 @@ public:
 
 		Precision(result, Precision(cau_samples.back()));
 
-		result = Vec<ComplexT>::Zero(this->GetSystem().NumVariables());
+		result = Vec<ComplexT>::Zero(static_cast<Eigen::Index>(this->GetSystem().NumVariables()));
 		for(unsigned int ii = 0; ii < total_num_pts; ++ii)
 			result += cau_samples[ii];
 		result /= this->CycleNumber() * this->EndgameSettings().num_sample_points;

--- a/core/include/bertini2/endgames/powerseries.hpp
+++ b/core/include/bertini2/endgames/powerseries.hpp
@@ -414,7 +414,7 @@ public:
 		{			
 			using std::pow;
 
-			std::tie(s_times, s_derivatives) = TransformToSPlane(candidate, t0, num_pts, ContStart::Front);
+			std::tie(s_times, s_derivatives) = TransformToSPlane(static_cast<int>(candidate), t0, num_pts, ContStart::Front);
 			RealT cand_power{1/static_cast<RealT>(candidate)};
 			RealT curr_diff = (HermiteInterpolateAndSolve<ComplexT>(
 								  pow((most_recent_time-t0)/(times[0]-t0),cand_power), // the target time
@@ -545,7 +545,7 @@ public:
 		TimeCont<ComplexT> s_times;
 		SampCont<ComplexT> s_derivatives;
 
-		std::tie(s_times, s_derivatives) = TransformToSPlane(c, t0, num_pts, ContStart::Back);
+		std::tie(s_times, s_derivatives) = TransformToSPlane(static_cast<int>(c), t0, num_pts, ContStart::Back);
 		// the data was transformed to be on the interval [0 1] so we can hard-code the time-to-solve as 0 here.
 
 		Precision(result, Precision(s_derivatives.back()));

--- a/core/include/bertini2/io/parsing/settings_parsers/algorithm.hpp
+++ b/core/include/bertini2/io/parsing/settings_parsers/algorithm.hpp
@@ -483,15 +483,15 @@ namespace bertini {
 
 					root_rule_.name("config::Sharpening");
 					
-					root_rule_ = ((sharpen_digits_[phx::bind( [this](algorithm::SharpeningConfig & S, unsigned num)
+					root_rule_ = ((sharpen_digits_[phx::bind( [](algorithm::SharpeningConfig & S, unsigned num)
 														   {
 															   S.sharpendigits = num;
 														   }, _val, _1 )]
-								   ^ func_res_tol_[phx::bind( [this](algorithm::SharpeningConfig & S, T num)
+								   ^ func_res_tol_[phx::bind( [](algorithm::SharpeningConfig & S, T num)
 															 {
 																 S.function_residual_tolerance = num;
 															 }, _val, _1 )]
-								   ^ ratio_tol_[phx::bind( [this](algorithm::SharpeningConfig & S, T num)
+								   ^ ratio_tol_[phx::bind( [](algorithm::SharpeningConfig & S, T num)
 															 {
 																 S.ratio_tolerance = num;
 															 }, _val, _1 )]
@@ -504,7 +504,7 @@ namespace bertini {
 								 ;
 					
 
-					auto str_to_T = [this](T & num, std::string str)
+					auto str_to_T = [](T & num, std::string str)
 									   {
 										   num = bertini::NumTraits<T>::FromString(str);
 									   };
@@ -588,27 +588,27 @@ namespace bertini {
 
 					root_rule_.name("config::Regeneration");
 					
-					root_rule_ = ((regen_remove_inf_[phx::bind( [this](algorithm::RegenerationConfig & S, int num)
+					root_rule_ = ((regen_remove_inf_[phx::bind( [](algorithm::RegenerationConfig & S, int num)
 														   {
 															   S.remove_infinite_endpoints = static_cast<bool>(num);
 														   }, _val, _1 )]
-								   ^ higher_dim_check_[phx::bind( [this](algorithm::RegenerationConfig & S, int num)
+								   ^ higher_dim_check_[phx::bind( [](algorithm::RegenerationConfig & S, int num)
 															 {
 																 S.higher_dimension_check = static_cast<bool>(num);
 															 }, _val, _1 )]
-								   ^ start_level_[phx::bind( [this](algorithm::RegenerationConfig & S, int num)
+								   ^ start_level_[phx::bind( [](algorithm::RegenerationConfig & S, int num)
 															 {
 																 S.start_level = static_cast<unsigned int>(num);
 															 }, _val, _1 )]
-								   ^ slice_before_[phx::bind( [this](algorithm::RegenerationConfig & S, T num)
+								   ^ slice_before_[phx::bind( [](algorithm::RegenerationConfig & S, T num)
 															 {
 																 S.slice_newton_before_endgame = num;
 															 }, _val, _1 )]
-								   ^ slice_during_[phx::bind( [this](algorithm::RegenerationConfig & S, T num)
+								   ^ slice_during_[phx::bind( [](algorithm::RegenerationConfig & S, T num)
 															 {
 																 S.slice_newton_during_endgame = num;
 															 }, _val, _1 )]
-								   ^ slice_final_[phx::bind( [this](algorithm::RegenerationConfig & S, T num)
+								   ^ slice_final_[phx::bind( [](algorithm::RegenerationConfig & S, T num)
 															 {
 																 S.slice_final_tolerance = num;
 															 }, _val, _1 )]
@@ -624,7 +624,7 @@ namespace bertini {
 								 ;
 					
 
-					auto str_to_T = [this](T & num, std::string str)
+					auto str_to_T = [](T & num, std::string str)
 									   {
 										   num = bertini::NumTraits<T>::FromString(str);
 									   };

--- a/core/include/bertini2/io/parsing/settings_parsers/algorithm.hpp
+++ b/core/include/bertini2/io/parsing/settings_parsers/algorithm.hpp
@@ -72,19 +72,19 @@ namespace bertini {
 					
 					root_rule_.name("config::Tolerances");
 					
-					root_rule_ = ((newton_before_endgame_[phx::bind( [this](algorithm::TolerancesConfig & S, T l)
+					root_rule_ = ((newton_before_endgame_[phx::bind( [](algorithm::TolerancesConfig & S, T l)
 																	{
 																		S.newton_before_endgame = l;
 																	}, _val, _1 )]
-								   ^ newton_during_endgame_[phx::bind( [this](algorithm::TolerancesConfig & S, T num)
+								   ^ newton_during_endgame_[phx::bind( [](algorithm::TolerancesConfig & S, T num)
 																	  {
 																		  S.newton_during_endgame = num;
 																	  }, _val, _1 )]
-								   ^ final_tol_[phx::bind( [this](algorithm::TolerancesConfig & S, T num)
+								   ^ final_tol_[phx::bind( [](algorithm::TolerancesConfig & S, T num)
 														  {
 															  S.final_tolerance = num;
 														  }, _val, _1 )]
-								   ^ path_trunc_threshold_[phx::bind( [this](algorithm::TolerancesConfig & S, T num)
+								   ^ path_trunc_threshold_[phx::bind( [](algorithm::TolerancesConfig & S, T num)
 																	 {
 																		 S.path_truncation_threshold = num;
 																	 }, _val, _1 )])
@@ -98,28 +98,28 @@ namespace bertini {
 					
 					newton_before_endgame_.name("newton_before_endgame_");
 					newton_before_endgame_ = *(char_ - all_names_) >> (no_case[newton_before_name] >> ':')
-					>> mpfr_rules.number_string_[phx::bind( [this](T & num, std::string str)
+					>> mpfr_rules.number_string_[phx::bind( [](T & num, std::string str)
 														   {
 															   num = bertini::NumTraits<T>::FromString(str);
 														   }, _val, _1 )] >> ';';
 					
 					newton_during_endgame_.name("newton_during_endgame_");
 					newton_during_endgame_ = *(char_ - all_names_) >> (no_case[newton_during_name] >>':')
-					>> mpfr_rules.number_string_[phx::bind( [this](T & num, std::string str)
+					>> mpfr_rules.number_string_[phx::bind( [](T & num, std::string str)
 														   {
 															   num = bertini::NumTraits<T>::FromString(str);
 														   }, _val, _1 )] >> ';';
 					
 					final_tol_.name("final_tol_");
 					final_tol_ = *(char_ - all_names_) >> (no_case[final_tol_name] >> ':')
-					>> mpfr_rules.number_string_[phx::bind( [this](T & num, std::string str)
+					>> mpfr_rules.number_string_[phx::bind( [](T & num, std::string str)
 														   {
 															   num = bertini::NumTraits<T>::FromString(str);
 														   }, _val, _1 )] >> ';';
 					
 					path_trunc_threshold_.name("path_trunc_threshold_");
 					path_trunc_threshold_ = *(char_ - all_names_) >> (no_case[path_trunc_name] >> ':')
-					>> mpfr_rules.number_string_[phx::bind( [this](T & num, std::string str)
+					>> mpfr_rules.number_string_[phx::bind( [](T & num, std::string str)
 														   {
 															   num = bertini::NumTraits<T>::FromString(str);
 														   }, _val, _1 )] >> ';';
@@ -195,27 +195,27 @@ namespace bertini {
 
 					root_rule_.name("config::ZeroDim");
 					
-					root_rule_ = ((init_prec_[phx::bind( [this](algorithm::ZeroDimConfig & S, int num)
+					root_rule_ = ((init_prec_[phx::bind( [](algorithm::ZeroDimConfig & S, int num)
 														   {
-															   S.initial_ambient_precision = num;
+															   S.initial_ambient_precision = static_cast<unsigned int>(num);
 														   }, _val, _1 )]
-								   ^ path_variable_name_[phx::bind( [this](algorithm::ZeroDimConfig & S, std::string omnom)
+								   ^ path_variable_name_[phx::bind( [](algorithm::ZeroDimConfig & S, std::string omnom)
 															 {
 																 S.path_variable_name = omnom;
 															 }, _val, _1 )]
-								   ^ max_cross_resolve_[phx::bind( [this](algorithm::ZeroDimConfig & S, int num)
+								   ^ max_cross_resolve_[phx::bind( [](algorithm::ZeroDimConfig & S, int num)
 															 {
-																 S.max_num_crossed_path_resolve_attempts = num;
+																 S.max_num_crossed_path_resolve_attempts = static_cast<unsigned int>(num);
 															 }, _val, _1 )]
-								   ^ start_time_[phx::bind( [this](algorithm::ZeroDimConfig & S, mpq_rational num)
+								   ^ start_time_[phx::bind( [](algorithm::ZeroDimConfig & S, mpq_rational num)
 															 {
 																 S.start_time = num;
 															 }, _val, _1 )]
-								   ^ endgame_boundary_[phx::bind( [this](algorithm::ZeroDimConfig & S, mpq_rational num)
+								   ^ endgame_boundary_[phx::bind( [](algorithm::ZeroDimConfig & S, mpq_rational num)
 															 {
 																 S.endgame_boundary = num;
 															 }, _val, _1 )]
-								   ^ target_time_[phx::bind( [this](algorithm::ZeroDimConfig & S, mpq_rational num)
+								   ^ target_time_[phx::bind( [](algorithm::ZeroDimConfig & S, mpq_rational num)
 															 {
 																 S.target_time = num;
 															 }, _val, _1 )]
@@ -233,7 +233,7 @@ namespace bertini {
 
 					// The times are stored as exact, precision-free mpq_rational.  Parse the number
 					// string to a multiprecision real, then to a rational (the homotopy times are real).
-					auto str_to_rational = [this](mpq_rational & num, std::string str)
+					auto str_to_rational = [](mpq_rational & num, std::string str)
 									   {
 										   num = mpq_rational(mpfr_float(str));
 									   };
@@ -329,7 +329,7 @@ namespace bertini {
 					
 					root_rule_.name("config::MidPath");
 					
-					root_rule_ = ((same_point_tol_[phx::bind( [this](algorithm::MidPathConfig & S, T num)
+					root_rule_ = ((same_point_tol_[phx::bind( [](algorithm::MidPathConfig & S, T num)
 														   {
 															   S.same_point_tolerance = num;
 														   }, _val, _1 )]
@@ -338,7 +338,7 @@ namespace bertini {
 					
 					all_names_ = (no_case[same_point_tol_name] >> ':');
 					
-					auto str_to_T = [this](T & num, std::string str)
+					auto str_to_T = [](T & num, std::string str)
 									   {
 										   num = bertini::NumTraits<T>::FromString(str);
 									   };
@@ -405,7 +405,7 @@ namespace bertini {
 					
 					root_rule_.name("config::AutoRetrack");
 					
-					root_rule_ = ((decrease_factor[phx::bind( [this](algorithm::AutoRetrackConfig & S, T num)
+					root_rule_ = ((decrease_factor[phx::bind( [](algorithm::AutoRetrackConfig & S, T num)
 														   {
 															   S.midpath_decrease_tolerance_factor = num;
 														   }, _val, _1 )]
@@ -414,7 +414,7 @@ namespace bertini {
 					
 					all_names_ = (no_case[decrease_factor_name] >> ':');
 					
-					auto str_to_T = [this](T & num, std::string str)
+					auto str_to_T = [](T & num, std::string str)
 									   {
 										   num = bertini::NumTraits<T>::FromString(str);
 									   };
@@ -598,7 +598,7 @@ namespace bertini {
 															 }, _val, _1 )]
 								   ^ start_level_[phx::bind( [this](algorithm::RegenerationConfig & S, int num)
 															 {
-																 S.start_level = num;
+																 S.start_level = static_cast<unsigned int>(num);
 															 }, _val, _1 )]
 								   ^ slice_before_[phx::bind( [this](algorithm::RegenerationConfig & S, T num)
 															 {
@@ -720,19 +720,19 @@ namespace bertini {
 
 					root_rule_.name("config::PostProcessing");
 					
-					root_rule_ = ((real_threshold_[phx::bind( [this](algorithm::PostProcessingConfig & S, T num)
+					root_rule_ = ((real_threshold_[phx::bind( [](algorithm::PostProcessingConfig & S, T num)
 															 {
 																 S.real_threshold = num;
 															 }, _val, _1 )]
-								   ^ endpoint_finite_[phx::bind( [this](algorithm::PostProcessingConfig & S, T num)
+								   ^ endpoint_finite_[phx::bind( [](algorithm::PostProcessingConfig & S, T num)
 															 {
 																 S.endpoint_finite_threshold = num;
 															 }, _val, _1 )]
-								   ^ same_point_[phx::bind( [this](algorithm::PostProcessingConfig & S, T num)
+								   ^ same_point_[phx::bind( [](algorithm::PostProcessingConfig & S, T num)
 															 {
 																 S.same_point_tolerance_multiplier = num;
 															 }, _val, _1 )]
-								   ^ cond_num_[phx::bind( [this](algorithm::PostProcessingConfig & S, T num)
+								   ^ cond_num_[phx::bind( [](algorithm::PostProcessingConfig & S, T num)
 															 {
 																 S.condition_number_threshold = num;
 															 }, _val, _1 )]
@@ -746,7 +746,7 @@ namespace bertini {
 								 ;
 					
 
-					auto str_to_T = [this](T & num, std::string str)
+					auto str_to_T = [](T & num, std::string str)
 									   {
 										   num = bertini::NumTraits<T>::FromString(str);
 									   };

--- a/core/include/bertini2/io/parsing/settings_parsers/endgames.hpp
+++ b/core/include/bertini2/io/parsing/settings_parsers/endgames.hpp
@@ -427,15 +427,15 @@ namespace bertini {
 
 					root_rule_.name("bertini::endgame::TrackBackConfig");
 					
-					root_rule_ = root_rule_ = ((min_cycle_[phx::bind( [this](bertini::endgame::TrackBackConfig & S, unsigned num)
+					root_rule_ = root_rule_ = ((min_cycle_[phx::bind( [](bertini::endgame::TrackBackConfig & S, unsigned num)
 																	   {
 																		   S.minimum_cycle = num;
 																	   }, _val, _1 )]
-											   ^ junk_removal_[phx::bind( [this](bertini::endgame::TrackBackConfig & S, int num)
+											   ^ junk_removal_[phx::bind( [](bertini::endgame::TrackBackConfig & S, int num)
 																		 {
 																			 S.junk_removal_test = static_cast<bool>(num);
 																		 }, _val, _1 )]
-											   ^ max_depth_[phx::bind( [this](bertini::endgame::TrackBackConfig & S, unsigned num)
+											   ^ max_depth_[phx::bind( [](bertini::endgame::TrackBackConfig & S, unsigned num)
 																	   {
 																		   S.max_depth_LDT = num;
 																	   }, _val, _1 )]

--- a/core/include/bertini2/io/parsing/settings_parsers/endgames.hpp
+++ b/core/include/bertini2/io/parsing/settings_parsers/endgames.hpp
@@ -72,11 +72,11 @@ namespace bertini {
 					
 					root_rule_.name("config::Security");
 					
-					root_rule_ = ((security_level_[phx::bind( [this](bertini::endgame::SecurityConfig & S, int l)
+					root_rule_ = ((security_level_[phx::bind( [](bertini::endgame::SecurityConfig & S, int l)
 															 {
 																 S.level = l;
 															 }, _val, _1 )]
-								   ^ security_max_norm_[phx::bind( [this](bertini::endgame::SecurityConfig & S, T norm)
+								   ^ security_max_norm_[phx::bind( [](bertini::endgame::SecurityConfig & S, T norm)
 																  {
 																	  S.max_norm = norm;
 																  }, _val, _1 )])
@@ -89,7 +89,7 @@ namespace bertini {
 					
 					security_max_norm_.name("security_max_norm_");
 					security_max_norm_ = *(char_ - all_names_) >> (no_case[maxnorm_name] >> ':')
-					>> mpfr_rules.number_string_[phx::bind( [this](T & num, std::string str)
+					>> mpfr_rules.number_string_[phx::bind( [](T & num, std::string str)
 														   {
 															   num = bertini::NumTraits<T>::FromString(str);
 														   }, _val, _1 )] >> ';';
@@ -163,15 +163,15 @@ namespace bertini {
 
 					root_rule_.name("config::Endgame");
 
-					root_rule_ = ((sample_factor_[phx::bind( [this](bertini::endgame::EndgameConfig & S, R num)
+					root_rule_ = ((sample_factor_[phx::bind( [](bertini::endgame::EndgameConfig & S, R num)
 															{
 																S.sample_factor = num;
 															}, _val, _1 )]
-								   ^ min_track_[phx::bind( [this](bertini::endgame::EndgameConfig & S, T num)
+								   ^ min_track_[phx::bind( [](bertini::endgame::EndgameConfig & S, T num)
 														  {
 															  S.min_track_time = num;
 														  }, _val, _1 )]
-								   ^ num_sample_[phx::bind( [this](bertini::endgame::EndgameConfig & S, unsigned num)
+								   ^ num_sample_[phx::bind( [](bertini::endgame::EndgameConfig & S, unsigned num)
 															  {
 																  S.num_sample_points = num;
 															  }, _val, _1 )])
@@ -191,7 +191,7 @@ namespace bertini {
 					
 					min_track_.name("min_track_");
 					min_track_ = *(char_ - all_names_) >> (no_case[mintrack_name] >> ':')
-					>> mpfr_rules.number_string_[phx::bind( [this](T & num, std::string str)
+					>> mpfr_rules.number_string_[phx::bind( [](T & num, std::string str)
 														   {
 															   num = bertini::NumTraits<T>::FromString(str);
 														   }, _val, _1 )] >> ';';
@@ -264,7 +264,7 @@ namespace bertini {
 					
 					root_rule_.name("bertini::endgame::PowerSeriesConfig");
 					
-					root_rule_ = (max_cycle_[phx::bind( [this](bertini::endgame::PowerSeriesConfig & S, unsigned num)
+					root_rule_ = (max_cycle_[phx::bind( [](bertini::endgame::PowerSeriesConfig & S, unsigned num)
 													   {
 														   S.max_cycle_number = num;
 													   }, _val, _1 )]
@@ -341,11 +341,11 @@ namespace bertini {
 					
 					root_rule_.name("config::Cauchy");
 					
-					root_rule_ = ((cycle_cutoff_[phx::bind( [this](bertini::endgame::CauchyConfig & S, T num)
+					root_rule_ = ((cycle_cutoff_[phx::bind( [](bertini::endgame::CauchyConfig & S, T num)
 														   {
 															   S.cycle_cutoff_time = num;
 														   }, _val, _1 )]
-								   ^ ratio_cutoff_[phx::bind( [this](bertini::endgame::CauchyConfig & S, T num)
+								   ^ ratio_cutoff_[phx::bind( [](bertini::endgame::CauchyConfig & S, T num)
 															 {
 																 S.ratio_cutoff_time = num;
 															 }, _val, _1 )])
@@ -355,14 +355,14 @@ namespace bertini {
 					
 					cycle_cutoff_.name("cycle_cutoff_");
 					cycle_cutoff_ = *(char_ - all_names_) >> (no_case[cyclecutoff_name] >> ':')
-					>> mpfr_rules.number_string_[phx::bind( [this](T & num, std::string str)
+					>> mpfr_rules.number_string_[phx::bind( [](T & num, std::string str)
 														   {
 															   num = bertini::NumTraits<T>::FromString(str);
 														   }, _val, _1 )] >> ';';
 					
 					ratio_cutoff_.name("ratio_cutoff_");
 					ratio_cutoff_ = *(char_ - all_names_) >> (no_case[ratiocutoff_name] >> ':')
-					>> mpfr_rules.number_string_[phx::bind( [this](T & num, std::string str)
+					>> mpfr_rules.number_string_[phx::bind( [](T & num, std::string str)
 														   {
 															   num = bertini::NumTraits<T>::FromString(str);
 														   }, _val, _1 )] >> ';';

--- a/core/include/bertini2/io/parsing/settings_parsers/random.hpp
+++ b/core/include/bertini2/io/parsing/settings_parsers/random.hpp
@@ -49,7 +49,7 @@ namespace bertini {
 
 					root_rule_.name("config::Random");
 					root_rule_ = (random_seed_[phx::bind(
-									[this](algorithm::RandomConfig& S, unsigned long v) {
+									[](algorithm::RandomConfig& S, unsigned long v) {
 										S.random_seed = v;
 									}, _val, _1)]
 								  >> -no_setting_)

--- a/core/include/bertini2/io/parsing/settings_parsers/tracking.hpp
+++ b/core/include/bertini2/io/parsing/settings_parsers/tracking.hpp
@@ -264,23 +264,23 @@ namespace bertini {
 					
 					root_rule_.name("SteppingConfig");
 					
-					root_rule_ = ((max_step_size_[phx::bind( [this](SteppingConfig & S, T num)
+					root_rule_ = ((max_step_size_[phx::bind( [](SteppingConfig & S, T num)
 															{
 																S.max_step_size = num;
 															}, _val, _1 )]
-								   ^ stepsize_success_[phx::bind( [this](SteppingConfig & S, R num)
+								   ^ stepsize_success_[phx::bind( [](SteppingConfig & S, R num)
 																 {
 																	 S.step_size_success_factor = num;
 																 }, _val, _1 )]
-								   ^ stepsize_fail_[phx::bind( [this](SteppingConfig & S, R num)
+								   ^ stepsize_fail_[phx::bind( [](SteppingConfig & S, R num)
 															  {
 																  S.step_size_fail_factor = num;
 															  }, _val, _1 )]
-								   ^ steps_increase_[phx::bind( [this](SteppingConfig & S, unsigned num)
+								   ^ steps_increase_[phx::bind( [](SteppingConfig & S, unsigned num)
 																	 {
 																		 S.consecutive_successful_steps_before_stepsize_increase = num;
 																	 }, _val, _1 )]
-								   ^ max_num_steps_[phx::bind( [this](SteppingConfig & S, unsigned num)
+								   ^ max_num_steps_[phx::bind( [](SteppingConfig & S, unsigned num)
 																	{
 																		S.max_num_steps = num;
 																	}, _val, _1 )])
@@ -385,7 +385,7 @@ namespace bertini {
 					
 					root_rule_.name("NewtonConfig");
 					
-					root_rule_ = (max_its_[phx::bind( [this](NewtonConfig & S, unsigned num)
+					root_rule_ = (max_its_[phx::bind( [](NewtonConfig & S, unsigned num)
 													 {
 														 S.max_num_newton_iterations = num;
 													 }, _val, _1 )]

--- a/core/include/bertini2/io/parsing/settings_parsers/tracking.hpp
+++ b/core/include/bertini2/io/parsing/settings_parsers/tracking.hpp
@@ -514,39 +514,39 @@ namespace bertini {
 
 					root_rule_.name("config::AMP");
 					
-					root_rule_ = ((coefficient_bound_[phx::bind( [this](AdaptiveMultiplePrecisionConfig & S, T num)
+					root_rule_ = ((coefficient_bound_[phx::bind( [](AdaptiveMultiplePrecisionConfig & S, T num)
 														   {
 															   S.coefficient_bound = num;
 														   }, _val, _1 )]
-								   ^ degree_bound_[phx::bind( [this](AdaptiveMultiplePrecisionConfig & S, T num)
+								   ^ degree_bound_[phx::bind( [](AdaptiveMultiplePrecisionConfig & S, T num)
 															 {
 																 S.degree_bound = num;
 															 }, _val, _1 )]
-								   ^ lin_solve_error_bnd_[phx::bind( [this](AdaptiveMultiplePrecisionConfig & S, T num)
+								   ^ lin_solve_error_bnd_[phx::bind( [](AdaptiveMultiplePrecisionConfig & S, T num)
 															 {
 																 S.epsilon = num;
 															 }, _val, _1 )]
-								   ^ jac_eval_err_bnd_[phx::bind( [this](AdaptiveMultiplePrecisionConfig & S, T num)
+								   ^ jac_eval_err_bnd_[phx::bind( [](AdaptiveMultiplePrecisionConfig & S, T num)
 															 {
 																 S.Phi = num;
 															 }, _val, _1 )]
-								   ^ func_eval_err_bnd_[phx::bind( [this](AdaptiveMultiplePrecisionConfig & S, T num)
+								   ^ func_eval_err_bnd_[phx::bind( [](AdaptiveMultiplePrecisionConfig & S, T num)
 															 {
 																 S.Psi = num;
 															 }, _val, _1 )]
-								   ^ safety_one_[phx::bind( [this](AdaptiveMultiplePrecisionConfig & S, int num)
+								   ^ safety_one_[phx::bind( [](AdaptiveMultiplePrecisionConfig & S, int num)
 															 {
 																 S.safety_digits_1 = num;
 															 }, _val, _1 )]
-								   ^ safety_two_[phx::bind( [this](AdaptiveMultiplePrecisionConfig & S, int num)
+								   ^ safety_two_[phx::bind( [](AdaptiveMultiplePrecisionConfig & S, int num)
 															 {
 																 S.safety_digits_2 = num;
 															 }, _val, _1 )]
-								   ^ max_prec_[phx::bind( [this](AdaptiveMultiplePrecisionConfig & S, unsigned num)
+								   ^ max_prec_[phx::bind( [](AdaptiveMultiplePrecisionConfig & S, unsigned num)
 															 {
 																 S.maximum_precision = num;
 															 }, _val, _1 )]
-								   ^ max_num_prec_decs_[phx::bind( [this](AdaptiveMultiplePrecisionConfig & S, unsigned num)
+								   ^ max_num_prec_decs_[phx::bind( [](AdaptiveMultiplePrecisionConfig & S, unsigned num)
 															 {
 																 S.max_num_precision_decreases = num;
 															 }, _val, _1 )]
@@ -565,7 +565,7 @@ namespace bertini {
 								 ;
 					
 
-					auto str_to_T = [this](T & num, std::string const& str)
+					auto str_to_T = [](T & num, std::string const& str)
 									   {
 									   	// std::cout << str << std::endl;
 										   num = bertini::NumTraits<T>::FromString(str);

--- a/core/include/bertini2/io/splash.hpp
+++ b/core/include/bertini2/io/splash.hpp
@@ -176,7 +176,7 @@ std::string MPIVersion()
     char buf[MPI_MAX_LIBRARY_VERSION_STRING];
     int len = 0;
     MPI_Get_library_version(buf, &len);
-    return std::string(buf, len);
+    return std::string(buf, static_cast<size_t>(len));
 #else
     return "not available (serial build)";
 #endif

--- a/core/include/bertini2/nag_algorithms/trace.hpp
+++ b/core/include/bertini2/nag_algorithms/trace.hpp
@@ -42,7 +42,7 @@ namespace bertini {
 
 
 		template <typename ComplexT>
-		ComplexT Trace(nag_datatype::WitnessSet<ComplexT> const& w)
+		ComplexT Trace(nag_datatype::WitnessSet<ComplexT> const& /*w*/)
 		{
 			return ComplexT(0);
 		}

--- a/core/include/bertini2/nag_algorithms/zero_dim_solve.hpp
+++ b/core/include/bertini2/nag_algorithms/zero_dim_solve.hpp
@@ -227,6 +227,7 @@ struct EGBoundaryMetaData
 
 	EGBoundaryMetaData() = default;
 	EGBoundaryMetaData(EGBoundaryMetaData const&) = default;
+	EGBoundaryMetaData& operator=(EGBoundaryMetaData const&) = default;
 	EGBoundaryMetaData(Vec<ComplexT> const& pt, SuccessCode const& code, RealT const& ss, unsigned prec) :
 		path_point(pt), success_code(code), last_used_stepsize(ss), precision(prec)
 	{}

--- a/core/include/bertini2/nag_datatypes/numerical_irreducible_decomposition.hpp
+++ b/core/include/bertini2/nag_datatypes/numerical_irreducible_decomposition.hpp
@@ -63,7 +63,7 @@ namespace bertini {
 				std::vector<int> codims;
 				for (const auto& w : finished_witness_sets_)
 					if (std::find(codims.begin(), codims.end(), w.Dimension()) == codims.end())
-						codims.push_back(w.Dimension());
+						codims.push_back(static_cast<int>(w.Dimension()));
 
 				return codims;
 			}

--- a/core/include/bertini2/parallel/thread_pool.hpp
+++ b/core/include/bertini2/parallel/thread_pool.hpp
@@ -138,7 +138,7 @@ public:
 	WorkerThreadPool(int n_threads, StateFactory state_factory, TrackFn track_fn)
 		: n_threads_(n_threads)
 	{
-		threads_.reserve(n_threads);
+		threads_.reserve(static_cast<size_t>(n_threads));
 		for (int i = 0; i < n_threads; ++i)
 		{
 			threads_.emplace_back([this, state_factory, track_fn]() mutable

--- a/core/include/bertini2/system/start/utility.hpp
+++ b/core/include/bertini2/system/start/utility.hpp
@@ -71,9 +71,9 @@ namespace bertini{
 
 		for (int ii = static_cast<int>(dimensions.size())-1; ii >= 0; --ii)
 		{
-		  T I = index%k[ii];
-		  T J = (index - I) / k[ii];
-		  subscripts[ii] = J;
+		  T I = index%k[static_cast<size_t>(ii)];
+		  T J = (index - I) / k[static_cast<size_t>(ii)];
+		  subscripts[static_cast<size_t>(ii)] = J;
 		  index = I;
 		}
 

--- a/core/include/bertini2/system/straight_line_program.hpp
+++ b/core/include/bertini2/system/straight_line_program.hpp
@@ -558,7 +558,7 @@ namespace bertini {
 
 			// copy content
 			for (size_t ii = 0; ii < program_->number_of_.Functions; ++ii) {
-				result(ii) = memory[ii + program_->output_locations_.Functions];
+				result(static_cast<Eigen::Index>(ii)) = memory[ii + program_->output_locations_.Functions];
 			}
 		}
 
@@ -583,7 +583,7 @@ namespace bertini {
 			// copy content
 			for (size_t jj =0; jj < program_->number_of_.Variables; ++jj) {
 				for (size_t ii = 0; ii < program_->number_of_.Functions; ++ii) {
-					result(ii, jj) = memory[ii+jj*program_->number_of_.Functions + program_->output_locations_.Jacobian];
+					result(static_cast<Eigen::Index>(ii), static_cast<Eigen::Index>(jj)) = memory[ii+jj*program_->number_of_.Functions + program_->output_locations_.Jacobian];
 				}
 			}
 		}
@@ -608,7 +608,7 @@ namespace bertini {
 			// 1. make container, size correctly.
 			// 2. copy content
 			for (size_t ii = 0; ii < program_->number_of_.Functions; ++ii) {
-				result(ii) = memory[ii + program_->output_locations_.TimeDeriv];
+				result(static_cast<Eigen::Index>(ii)) = memory[ii + program_->output_locations_.TimeDeriv];
 			}
 		}
 
@@ -726,7 +726,7 @@ namespace bertini {
 
 			for (size_t ii = 0; ii < program_->number_of_.Variables; ++ii) {
 				//assign  to memory
-				memory[ii + program_->input_locations_.Variables] = variable_values(ii);
+				memory[ii + program_->input_locations_.Variables] = variable_values(static_cast<Eigen::Index>(ii));
 			}
 			memory_.is_evaluated_ = false;
 		}

--- a/core/include/bertini2/system/system.hpp
+++ b/core/include/bertini2/system/system.hpp
@@ -621,7 +621,7 @@ namespace bertini {
 			// the patch doesn't move with time.  derivatives 0.
 			if (IsPatched())
 				for (size_t ii = 0; ii < NumTotalVariableGroups(); ++ii)
-					ds_dt(ii + NumNaturalFunctions()) = T(0);
+					ds_dt(static_cast<Eigen::Index>(ii + NumNaturalFunctions())) = T(0);
 			CoerceBlockOutputPrecision(ds_dt);
 		}
 
@@ -801,7 +801,9 @@ namespace bertini {
 		void SetVariables(const Vec<T> & new_values) const
 		{
 			if (new_values.size()!= static_cast<Eigen::Index>(NumVariables()))
+			{
 				throw std::runtime_error("variable vector of different length from system-owned variables in SetVariables");
+			}
 
 			#ifndef BERTINI_DISABLE_PRECISION_CHECKS
 				// A system with no variables (a constant) has an empty point: there is no
@@ -1570,7 +1572,6 @@ namespace bertini {
 
 			unsigned affine_group_counter = 0;
 			unsigned hom_group_counter = 0;
-			unsigned ungrouped_variable_counter = 0;
 
 			unsigned hom_index = 0; // index into x, the point we are dehomogenizing
 			unsigned dehom_index = 0; // index into x_dehomogenized, the point we are computing
@@ -1604,7 +1605,6 @@ namespace bertini {
 					case VariableGroupType::Ungrouped:
 					{
 						x_dehomogenized(dehom_index++) = x(hom_index++);
-						ungrouped_variable_counter++;
 						break;
 					}
 					default:

--- a/core/include/bertini2/trackers/amp_tracker.hpp
+++ b/core/include/bertini2/trackers/amp_tracker.hpp
@@ -1684,10 +1684,10 @@ namespace bertini{
 				const auto num_vars = GetSystem().NumVariables();
 
 				//  the current_space value is adjusted in the appropriate ChangePrecision function
-				std::get<Vec<mpfr_complex> >(tentative_space_).resize(num_vars);
+				std::get<Vec<mpfr_complex> >(tentative_space_).resize(static_cast<Eigen::Index>(num_vars));
 				Precision(std::get<Vec<mpfr_complex> >(tentative_space_), new_precision);
 
-				std::get<Vec<mpfr_complex> >(temporary_space_).resize(num_vars);
+				std::get<Vec<mpfr_complex> >(temporary_space_).resize(static_cast<Eigen::Index>(num_vars));
 				Precision(std::get<Vec<mpfr_complex> >(temporary_space_), new_precision);
 			}
 

--- a/core/include/bertini2/trackers/explicit_predictors.hpp
+++ b/core/include/bertini2/trackers/explicit_predictors.hpp
@@ -255,8 +255,8 @@ namespace bertini{
 						{
 							s_ = 2;
 							
-							FillButcherTable<double>(s_, aHeunEuler_, bHeunEuler_, b_minus_bstarHeunEuler_, cHeunEuler_);
-							FillButcherTable<mpfr_float>(s_, aHeunEuler_, bHeunEuler_, b_minus_bstarHeunEuler_, cHeunEuler_);
+							FillButcherTable<double>(static_cast<int>(s_),aHeunEuler_, bHeunEuler_, b_minus_bstarHeunEuler_, cHeunEuler_);
+							FillButcherTable<mpfr_float>(static_cast<int>(s_),aHeunEuler_, bHeunEuler_, b_minus_bstarHeunEuler_, cHeunEuler_);
 							
 							break;
 						}
@@ -264,8 +264,8 @@ namespace bertini{
 						{
 							s_ = 4;
 							
-							FillButcherTable<double>(s_, aRK4_, bRK4_, cRK4_);
-							FillButcherTable<mpfr_float>(s_, aRK4_, bRK4_, cRK4_);
+							FillButcherTable<double>(static_cast<int>(s_),aRK4_, bRK4_, cRK4_);
+							FillButcherTable<mpfr_float>(static_cast<int>(s_),aRK4_, bRK4_, cRK4_);
 							
 							break;
 						}
@@ -274,8 +274,8 @@ namespace bertini{
 						{
 							s_ = 6;
 							
-							FillButcherTable<double>(s_, aRKF45_, bRKF45_, b_minus_bstarRKF45_, cRKF45_);
-							FillButcherTable<mpfr_float>(s_, aRKF45_, bRKF45_, b_minus_bstarRKF45_, cRKF45_);
+							FillButcherTable<double>(static_cast<int>(s_),aRKF45_, bRKF45_, b_minus_bstarRKF45_, cRKF45_);
+							FillButcherTable<mpfr_float>(static_cast<int>(s_),aRKF45_, bRKF45_, b_minus_bstarRKF45_, cRKF45_);
 							
 							break;
 						}
@@ -284,8 +284,8 @@ namespace bertini{
 						{
 							s_ = 6;
 							
-							FillButcherTable<double>(s_, aRKCK45_, bRKCK45_, b_minus_bstarRKCK45_, cRKCK45_);
-							FillButcherTable<mpfr_float>(s_, aRKCK45_, bRKCK45_, b_minus_bstarRKCK45_, cRKCK45_);
+							FillButcherTable<double>(static_cast<int>(s_),aRKCK45_, bRKCK45_, b_minus_bstarRKCK45_, cRKCK45_);
+							FillButcherTable<mpfr_float>(static_cast<int>(s_),aRKCK45_, bRKCK45_, b_minus_bstarRKCK45_, cRKCK45_);
 							
 							break;
 						}
@@ -294,8 +294,8 @@ namespace bertini{
 						{
 							s_ = 8;
 							
-							FillButcherTable<double>(s_, aRKDP56_, bRKDP56_, b_minus_bstarRKDP56_, cRKDP56_);
-							FillButcherTable<mpfr_float>(s_, aRKDP56_, bRKDP56_, b_minus_bstarRKDP56_, cRKDP56_);
+							FillButcherTable<double>(static_cast<int>(s_),aRKDP56_, bRKDP56_, b_minus_bstarRKDP56_, cRKDP56_);
+							FillButcherTable<mpfr_float>(static_cast<int>(s_),aRKDP56_, bRKDP56_, b_minus_bstarRKDP56_, cRKDP56_);
 							
 							break;
 						}
@@ -304,8 +304,8 @@ namespace bertini{
 						{
 							s_ = 10;
 							
-							FillButcherTable<double>(s_, aRKV67_, bRKV67_, b_minus_bstarRKV67_, cRKV67_);
-							FillButcherTable<mpfr_float>(s_, aRKV67_, bRKV67_, b_minus_bstarRKV67_, cRKV67_);
+							FillButcherTable<double>(static_cast<int>(s_),aRKV67_, bRKV67_, b_minus_bstarRKV67_, cRKV67_);
+							FillButcherTable<mpfr_float>(static_cast<int>(s_),aRKV67_, bRKV67_, b_minus_bstarRKV67_, cRKV67_);
 							
 							break;
 						}

--- a/core/include/bertini2/trackers/observers.hpp
+++ b/core/include/bertini2/trackers/observers.hpp
@@ -237,7 +237,7 @@ namespace bertini {
 
 				if (auto p = dynamic_cast<const Initializing<EmitterT,dbl>*>(&e))
 				{
-					BOOST_LOG_TRIVIAL(severity_level::debug) << std::setprecision(p->Get().GetSystem().precision())
+					BOOST_LOG_TRIVIAL(severity_level::debug) << std::setprecision(static_cast<int>(p->Get().GetSystem().precision()))
 						<< "initializing in double, tracking path\nfrom\tt = "
 						<< p->StartTime() << "\nto\tt = " << p->EndTime()
 						<< "\n from\tx = \n" << p->StartPoint()
@@ -245,7 +245,7 @@ namespace bertini {
 				}
 				else if (auto p = dynamic_cast<const Initializing<EmitterT,mpfr_complex>*>(&e))
 				{
-					BOOST_LOG_TRIVIAL(severity_level::debug) << std::setprecision(p->Get().GetSystem().precision())
+					BOOST_LOG_TRIVIAL(severity_level::debug) << std::setprecision(static_cast<int>(p->Get().GetSystem().precision()))
 						 << "initializing in multiprecision, tracking path\nfrom\tt = " << p->StartTime() << "\nto\tt = " << p->EndTime() << "\n from\tx = \n" << p->StartPoint()
 						<< "\n tracking system " << p->Get().GetSystem() << "\n\n";
 				}
@@ -259,7 +259,7 @@ namespace bertini {
 					BOOST_LOG_TRIVIAL(severity_level::trace) << "Tracker iteration " << t.NumTotalStepsTaken() << "\ncurrent precision: " << t.CurrentPrecision();
 
 
-					BOOST_LOG_TRIVIAL(severity_level::trace) << std::setprecision(t.CurrentPrecision())
+					BOOST_LOG_TRIVIAL(severity_level::trace) << std::setprecision(static_cast<int>(t.CurrentPrecision()))
 						<< "t = " << t.CurrentTime()
 						<< "\ncurrent stepsize: " << t.CurrentStepsize()
 						<< "\ndelta_t = " << t.DeltaT() 
@@ -294,20 +294,20 @@ namespace bertini {
 
 				else if (auto p = dynamic_cast<const SuccessfulPredict<EmitterT,mpfr_complex>*>(&e))
 				{
-					BOOST_LOG_TRIVIAL(severity_level::trace) << std::setprecision(Precision(p->ResultingPoint())) << "prediction successful (mpfr_complex), result:\n" << p->ResultingPoint();
+					BOOST_LOG_TRIVIAL(severity_level::trace) << std::setprecision(static_cast<int>(Precision(p->ResultingPoint()))) << "prediction successful (mpfr_complex), result:\n" << p->ResultingPoint();
 				}
 				else if (auto p = dynamic_cast<const SuccessfulPredict<EmitterT,dbl>*>(&e))
 				{
-					BOOST_LOG_TRIVIAL(severity_level::trace) << std::setprecision(Precision(p->ResultingPoint())) << "prediction successful (dbl), result:\n" << p->ResultingPoint();
+					BOOST_LOG_TRIVIAL(severity_level::trace) << std::setprecision(static_cast<int>(Precision(p->ResultingPoint()))) << "prediction successful (dbl), result:\n" << p->ResultingPoint();
 				}
 
 				else if (auto p = dynamic_cast<const SuccessfulCorrect<EmitterT,mpfr_complex>*>(&e))
 				{
-					BOOST_LOG_TRIVIAL(severity_level::trace) << std::setprecision(Precision(p->ResultingPoint())) << "correction successful (mpfr_complex), result:\n" << p->ResultingPoint();
+					BOOST_LOG_TRIVIAL(severity_level::trace) << std::setprecision(static_cast<int>(Precision(p->ResultingPoint()))) << "correction successful (mpfr_complex), result:\n" << p->ResultingPoint();
 				}
 				else if (auto p = dynamic_cast<const SuccessfulCorrect<EmitterT,dbl>*>(&e))
 				{
-					BOOST_LOG_TRIVIAL(severity_level::trace) << std::setprecision(Precision(p->ResultingPoint())) << "correction successful (dbl), result:\n" << p->ResultingPoint();
+					BOOST_LOG_TRIVIAL(severity_level::trace) << std::setprecision(static_cast<int>(Precision(p->ResultingPoint()))) << "correction successful (dbl), result:\n" << p->ResultingPoint();
 				}
 
 

--- a/core/include/bertini2/trackers/observers.hpp
+++ b/core/include/bertini2/trackers/observers.hpp
@@ -348,7 +348,7 @@ namespace bertini {
 
 			using EmitterT = typename TrackerTraits<TrackerT>::EventEmitterType;
 
-			ObserveResult OnEvent(FailedStep<EmitterT> const& e)
+			ObserveResult OnEvent(FailedStep<EmitterT> const& /*e*/)
 			{
 				std::cout << "observed step failure" << std::endl;
 				return ObserveResult::KeepObserving;

--- a/core/src/basics/random.cpp
+++ b/core/src/basics/random.cpp
@@ -136,37 +136,37 @@ unsigned long DerivedWorkerSeed(uint64_t worker_index)
 		
 		mpfr_float a;
 		if (num_digits<=50)
-			a = std::move(RandomMp<50>());
+			a = RandomMp<50>();
 		else if (num_digits<=100)
-			a = std::move(RandomMp<100>());
+			a = RandomMp<100>();
 		else if (num_digits<=200)
-			a = std::move(RandomMp<200>());
+			a = RandomMp<200>();
 		else if (num_digits<=400)
-			a = std::move(RandomMp<400>());
+			a = RandomMp<400>();
 		else if (num_digits<=800)
-			a = std::move(RandomMp<800>());
+			a = RandomMp<800>();
 		else if (num_digits<=1600)
-			a = std::move(RandomMp<1600>());
+			a = RandomMp<1600>();
 		else if (num_digits<=3200)
-			a = std::move(RandomMp<3200>());
+			a = RandomMp<3200>();
 		else if (num_digits<=6400)
-			a = std::move(RandomMp<6400>());
+			a = RandomMp<6400>();
 		else if (num_digits<=8000)
-			a = std::move(RandomMp<8000>());
+			a = RandomMp<8000>();
 		else if (num_digits<=10000)
-			a = std::move(RandomMp<10000>());
+			a = RandomMp<10000>();
 		else if (num_digits<=12000)
-			a = std::move(RandomMp<12000>());
+			a = RandomMp<12000>();
 		else if (num_digits<=14000)
-			a = std::move(RandomMp<14000>());
+			a = RandomMp<14000>();
 		else if (num_digits<=16000)
-			a = std::move(RandomMp<16000>());
+			a = RandomMp<16000>();
 		else if (num_digits<=18000)
-			a = std::move(RandomMp<18000>());
+			a = RandomMp<18000>();
 		else if (num_digits<=20000)
-			a = std::move(RandomMp<20000>());
+			a = RandomMp<20000>();
 		else if (num_digits<=40000)
-			a = std::move(RandomMp<40000>());
+			a = RandomMp<40000>();
 		else
 			throw std::out_of_range("requesting random long number of digits -- higher than 40000.  this throw can be remedied by adding more cases to the generating function RandomMp in random.cpp.  If you have a better solution to this problem, please write the authors of this software.");
 		a.precision(num_digits);
@@ -197,37 +197,37 @@ unsigned long DerivedWorkerSeed(uint64_t worker_index)
 		
 		mpfr_float result;
 		if (num_digits<=50)
-			result = std::move(RandomMp<50>(a,b));
+			result = RandomMp<50>(a,b);
 		else if (num_digits<=100)
-			result = std::move(RandomMp<100>(a,b));
+			result = RandomMp<100>(a,b);
 		else if (num_digits<=200)
-			result = std::move(RandomMp<200>(a,b));
+			result = RandomMp<200>(a,b);
 		else if (num_digits<=400)
-			result = std::move(RandomMp<400>(a,b));
+			result = RandomMp<400>(a,b);
 		else if (num_digits<=800)
-			result = std::move(RandomMp<800>(a,b));
+			result = RandomMp<800>(a,b);
 		else if (num_digits<=1600)
-			result = std::move(RandomMp<1600>(a,b));
+			result = RandomMp<1600>(a,b);
 		else if (num_digits<=3200)
-			result = std::move(RandomMp<3200>(a,b));
+			result = RandomMp<3200>(a,b);
 		else if (num_digits<=6400)
-			result = std::move(RandomMp<6400>(a,b));
+			result = RandomMp<6400>(a,b);
 		else if (num_digits<=8000)
-			result = std::move(RandomMp<8000>(a,b));
+			result = RandomMp<8000>(a,b);
 		else if (num_digits<=10000)
-			result = std::move(RandomMp<10000>(a,b));
+			result = RandomMp<10000>(a,b);
 		else if (num_digits<=12000)
-			result = std::move(RandomMp<12000>(a,b));
+			result = RandomMp<12000>(a,b);
 		else if (num_digits<=14000)
-			result = std::move(RandomMp<14000>(a,b));
+			result = RandomMp<14000>(a,b);
 		else if (num_digits<=16000)
-			result = std::move(RandomMp<16000>(a,b));
+			result = RandomMp<16000>(a,b);
 		else if (num_digits<=18000)
-			result = std::move(RandomMp<18000>(a,b));
+			result = RandomMp<18000>(a,b);
 		else if (num_digits<=20000)
-			result = std::move(RandomMp<20000>(a,b));
+			result = RandomMp<20000>(a,b);
 		else if (num_digits<=40000)
-			result = std::move(RandomMp<40000>(a,b));
+			result = RandomMp<40000>(a,b);
 		else
 			throw std::out_of_range("requesting random long number of digits -- higher than 40000.  this throw can be remedied by adding more cases to the generating function RandomMp in random.cpp.  If you have a better solution to this problem, please write the authors of this software.");
 		result.precision(num_digits);

--- a/core/src/system/start/mhom.cpp
+++ b/core/src/system/start/mhom.cpp
@@ -88,7 +88,7 @@ namespace bertini
 						const int d = degree_matrix_(ii, jj);
 						if (d == 0)
 							continue;
-						const Eigen::Index gsize = static_cast<Eigen::Index>(var_groups_[jj].size());
+						const Eigen::Index gsize = static_cast<Eigen::Index>(var_groups_[static_cast<size_t>(jj)].size());
 						const bool projective = (static_cast<size_t>(jj) < s.NumHomVariableGroups());
 						Mat<mpfr_complex> C(d, gsize + 1);
 						for (Eigen::Index f = 0; f < d; ++f)
@@ -131,7 +131,7 @@ namespace bertini
 				const VariableGroup& vars = this->Variables();
 				std::map<node::Node const*, Eigen::Index> col_of;
 				for (Eigen::Index c = 0; c < static_cast<Eigen::Index>(vars.size()); ++c)
-					col_of[vars[c].get()] = c;
+					col_of[vars[static_cast<size_t>(c)].get()] = c;
 				const Eigen::Index n = static_cast<Eigen::Index>(this->NumVariables());
 
 				std::vector<Mat<mpfr_complex>> per_function;
@@ -232,7 +232,7 @@ namespace bertini
 		*/
 		void MHomogeneous::CreateDegreeMatrix(System const& target_system)
 		{
-			degree_matrix_ = Mat<int>::Zero(target_system.NumNaturalFunctions(),target_system.NumTotalVariableGroups());
+			degree_matrix_ = Mat<int>::Zero(static_cast<Eigen::Index>(target_system.NumNaturalFunctions()),static_cast<Eigen::Index>(target_system.NumTotalVariableGroups()));
 
 			var_groups_ = target_system.HomVariableGroups();
 			num_hom_groups_ = var_groups_.size();   // the leading var_groups_ entries are projective
@@ -241,13 +241,11 @@ namespace bertini
 			var_groups_.insert(var_groups_.end(), affine_var_groups.begin(), affine_var_groups.end());
 
 			int col_count = 0;
-			int outer_loop = 0;
 			size_t var_count = 0;
 			std::vector<int> zero_column_vector(target_system.Degrees(*(var_groups_.begin())).size(), 0);
 
 			for(std::vector<VariableGroup>::iterator it = var_groups_.begin(); it != var_groups_.end(); ++it)
 			{
-				outer_loop++;
   				std::vector<int> degs = target_system.Degrees(*it);
 				
 				std::vector<size_t> temp_v;
@@ -266,7 +264,7 @@ namespace bertini
 
   				for(size_t ii = 0; ii < degs.size(); ++ii)
   				{
-  					degree_matrix_(ii,col_count) = degs[ii];
+  					degree_matrix_(static_cast<Eigen::Index>(ii),col_count) = degs[ii];
   				}
   				col_count++;
 			}
@@ -307,8 +305,8 @@ namespace bertini
 		{
 			int row = 0;
 			int bad_choice = 0;
-			Vec<int> current_partition = -1*Vec<int>::Ones(target_system.NumNaturalFunctions());
-			Vec<int> variable_group_counter = Vec<int>::Zero(target_system.NumTotalVariableGroups());
+			Vec<int> current_partition = -1*Vec<int>::Ones(static_cast<Eigen::Index>(target_system.NumNaturalFunctions()));
+			Vec<int> variable_group_counter = Vec<int>::Zero(static_cast<Eigen::Index>(target_system.NumTotalVariableGroups()));
 
 			// Capacity per group = the number of functions that group may be assigned, which
 			// is the group's declared dimension.  Use var_groups_ (the groups as concatenated
@@ -323,7 +321,7 @@ namespace bertini
 				// k-1 functions; an affine group of size m takes m.  The leading num_hom_groups_
 				// entries of var_groups_ are the projective ones.
 				const int dim = static_cast<int>(var_groups_[ii].size()) - (ii < num_hom_groups_ ? 1 : 0);
-				variable_group_counter[ii] = dim;
+				variable_group_counter[static_cast<Eigen::Index>(ii)] = dim;
 			}
 			// std::cout << "variable_group_counter is " << std::endl;
 			// std::cout << variable_group_counter << std::endl;		
@@ -458,11 +456,11 @@ namespace bertini
 			
 			
 			// Using partition ii, create dimension vector.  Then find the subscript.
-			auto partition = valid_partitions_[partition_ii];
-			std::vector<size_t> dim_vector(partition.size());
+			auto partition = valid_partitions_[static_cast<size_t>(partition_ii)];
+			std::vector<size_t> dim_vector(static_cast<size_t>(partition.size()));
 			for (int ii = 0; ii < partition.size(); ++ii)
 			{
-				dim_vector[ii] = degree_matrix_(ii, partition(ii));
+				dim_vector[static_cast<size_t>(ii)] = static_cast<size_t>(degree_matrix_(ii, partition(ii)));
 			}
 			
 			std::vector<size_t> subscript = IndexToSubscript<size_t>(index, dim_vector);
@@ -497,9 +495,9 @@ namespace bertini
 			};
 			for(int ii = 0; ii < partition.size(); ++ii)
 			{
-				std::vector<size_t> cols = variable_cols_[partition[ii]];
+				std::vector<size_t> cols = variable_cols_[static_cast<size_t>(partition[ii])];
 				const Mat<mpfr_complex>& C = linear_coeffs_(ii, partition[ii]);
-				const Eigen::Index f = static_cast<Eigen::Index>(subscript[ii]);
+				const Eigen::Index f = static_cast<Eigen::Index>(subscript[static_cast<size_t>(ii)]);
 				for(size_t jj = 0; jj < cols.size(); ++jj)
 				{
 					A(ii, static_cast<Eigen::Index>(cols[jj])) = as_T(C(f, static_cast<Eigen::Index>(jj)));
@@ -565,7 +563,7 @@ namespace bertini
 			unsigned long long num_points = 1;
     			for(int ii = 0; ii < partition.size() ; ii++)
     			{
-    				num_points *= degree_matrix_(ii,partition[ii]); 
+    				num_points *= static_cast<unsigned long long>(degree_matrix_(ii,partition[ii]));
     			}
 
 			return num_points;

--- a/core/src/system/start/total_degree.cpp
+++ b/core/src/system/start/total_degree.cpp
@@ -86,7 +86,7 @@ namespace bertini {
 			auto two_i_pi = boost::math::constants::pi<double>() * dbl(0,2);
 
 			for (size_t ii = 0; ii< NumNaturalVariables(); ++ii)
-				start_point(ii+offset) = exp( two_i_pi * static_cast<double>(indices[ii]) / static_cast<double>(degrees_[ii])  ) * pow(random_values_[ii]->Value<dbl>(), 1.0 / static_cast<double>(degrees_[ii]));
+				start_point(static_cast<Eigen::Index>(ii+offset)) = exp( two_i_pi * static_cast<double>(indices[ii]) / static_cast<double>(degrees_[ii])  ) * pow(random_values_[ii]->Value<dbl>(), 1.0 / static_cast<double>(degrees_[ii]));
 
 			if (IsPatched())
 				RescalePointToFitPatchInPlace(start_point);
@@ -122,7 +122,7 @@ namespace bertini {
 				Precision(a,ThreadPrecision());
 				Precision(b,ThreadPrecision());
 
-				start_point(ii+offset) = a*b;
+				start_point(static_cast<Eigen::Index>(ii+offset)) = a*b;
 			}
 
 			if (IsPatched())
@@ -166,9 +166,9 @@ namespace bertini {
 
 		void TotalDegree::SeedRandomValues(int num_functions)
 		{
-			random_values_.resize(num_functions);
+			random_values_.resize(static_cast<size_t>(num_functions));
 			for (int ii = 0; ii < num_functions; ++ii)
-				random_values_[ii] = Rational::Make(node::Rational::Rand());
+				random_values_[static_cast<size_t>(ii)] = Rational::Make(node::Rational::Rand());
 		}
 
 		void TotalDegree::GenerateFunctions()
@@ -176,7 +176,7 @@ namespace bertini {
 			// by hypothesis, the system has a single variable group.
 			auto v = this->AffineVariableGroup(0);
 			for (auto iter = v.begin(); iter!=v.end(); iter++)
-				AddFunction(pow(*iter,(int) *(degrees_.begin() + (iter-v.begin()))) - random_values_[iter-v.begin()]);
+				AddFunction(pow(*iter,(int) *(degrees_.begin() + (iter-v.begin()))) - random_values_[static_cast<size_t>(iter-v.begin())]);
 		}
 	} // namespace start_system
 } //namespace bertini

--- a/core/src/system/straight_line_program.cpp
+++ b/core/src/system/straight_line_program.cpp
@@ -462,12 +462,12 @@ namespace bertini{
 		for (auto const& I : parsed)
 			if (I.frozen)
 			{
-				reordered.insert(reordered.end(), instructions_.begin() + I.off, instructions_.begin() + I.off + I.len);
+				reordered.insert(reordered.end(), instructions_.begin() + static_cast<std::ptrdiff_t>(I.off), instructions_.begin() + static_cast<std::ptrdiff_t>(I.off) + static_cast<std::ptrdiff_t>(I.len));
 				frozen_words += I.len;
 			}
 		for (auto const& I : parsed)
 			if (!I.frozen)
-				reordered.insert(reordered.end(), instructions_.begin() + I.off, instructions_.begin() + I.off + I.len);
+				reordered.insert(reordered.end(), instructions_.begin() + static_cast<std::ptrdiff_t>(I.off), instructions_.begin() + static_cast<std::ptrdiff_t>(I.off) + static_cast<std::ptrdiff_t>(I.len));
 
 		instructions_ = std::move(reordered);
 		first_live_instruction_ = frozen_words;

--- a/core/src/system/system.cpp
+++ b/core/src/system/system.cpp
@@ -322,7 +322,7 @@ namespace bertini
 			converter << "HOM_VAR_" << group_counter;
 
 			if (already_had_homvars){
-				Var hom_var = homogenizing_variables_[group_counter];
+				Var hom_var = homogenizing_variables_[static_cast<size_t>(group_counter)];
 				VariableGroup temp_group = *curr_var_gp;
 
 				PushFront(temp_group, hom_var);
@@ -335,7 +335,7 @@ namespace bertini
 			else
 			{
 				Var hom_var = Variable::Make(converter.str());
-				homogenizing_variables_[group_counter] = hom_var;
+				homogenizing_variables_[static_cast<size_t>(group_counter)] = hom_var;
 				for (auto& b : blocks_)
 					std::visit([&](auto& blk){ blk.Homogenize(*curr_var_gp, hom_var); }, b);
 			}
@@ -376,8 +376,8 @@ namespace bertini
 		auto group_counter = 0;
 		for (auto curr_var_gp = variable_groups_.begin(); curr_var_gp!=variable_groups_.end(); curr_var_gp++)
 		{
-			Var hom_var = provided_hom_vars[group_counter];
-			homogenizing_variables_[group_counter] = hom_var;
+			Var hom_var = provided_hom_vars[static_cast<size_t>(group_counter)];
+			homogenizing_variables_[static_cast<size_t>(group_counter)] = hom_var;
 			for (auto& b : blocks_)
 				std::visit([&](auto& blk){ blk.Homogenize(*curr_var_gp, hom_var); }, b);
 			group_counter++;
@@ -419,7 +419,7 @@ namespace bertini
 		{
 			auto tempvars = vars;
 			if (have_homvars)
-				PushFront(tempvars, homogenizing_variables_[counter]);
+				PushFront(tempvars, homogenizing_variables_[static_cast<size_t>(counter)]);
 			counter++;
 			if (!all_blocks_homogeneous(tempvars))
 				return false;
@@ -460,7 +460,7 @@ namespace bertini
 		{
 			auto tempvars = vars;
 			if (have_homvars)
-				PushFront(tempvars,homogenizing_variables_[counter]);
+				PushFront(tempvars,homogenizing_variables_[static_cast<size_t>(counter)]);
 			counter++;
 			if (!all_blocks_polynomial(tempvars))
 				return false;

--- a/core/test/classes/eigen_test.cpp
+++ b/core/test/classes/eigen_test.cpp
@@ -554,7 +554,7 @@ using bertini::KahanMatrix;
 
 		auto new_prec = 50-10;
 
-		bertini::DefaultPrecision(new_prec);
+		bertini::DefaultPrecision(static_cast<unsigned int>(new_prec));
 		Eigen::Matrix<data_type, Eigen::Dynamic, Eigen::Dynamic> B(2,2);
 		
 		B = A; // assignment preserves precision of source
@@ -577,7 +577,7 @@ using bertini::KahanMatrix;
 
 		auto new_prec = 50-10;
 
-		bertini::DefaultPrecision(new_prec);
+		bertini::DefaultPrecision(static_cast<unsigned int>(new_prec));
 		Eigen::Matrix<data_type, Eigen::Dynamic, 1> B(4);
 
 		B = A;

--- a/core/test/classes/function_tree_transform.cpp
+++ b/core/test/classes/function_tree_transform.cpp
@@ -289,7 +289,7 @@ BOOST_AUTO_TEST_CASE(complicated)
 	auto x = Variable::Make("x");
 	auto y = Variable::Make("y");
 
-	auto n = (((((2*x*1)*y)+(0*(pow(x,2))))/2)-(0*((pow(x,2))*y)/(pow(2,2))));
+	auto n = (((((2*x*1)*y)+(0*(pow(x,2))))/2)-(0*((pow(x,2))*y)/(static_cast<int>(pow(2,2)))));
 
 	auto ns = bertini::Simplify(n);
 

--- a/core/test/classes/fundamentals_test.cpp
+++ b/core/test/classes/fundamentals_test.cpp
@@ -320,14 +320,14 @@ BOOST_AUTO_TEST_CASE(RandomMP_honors_global_seed)
 	auto second = draw_five();
 
 	for (int ii = 0; ii < 5; ++ii)
-		BOOST_CHECK_EQUAL(first[ii], second[ii]);
+		BOOST_CHECK_EQUAL(first[static_cast<size_t>(ii)], second[static_cast<size_t>(ii)]);
 
 	SetGlobalSeed(5678u);
 	auto third = draw_five();
 
 	bool any_different = false;
 	for (int ii = 0; ii < 5; ++ii)
-		if (third[ii] != first[ii])
+		if (third[static_cast<size_t>(ii)] != first[static_cast<size_t>(ii)])
 			any_different = true;
 	BOOST_CHECK(any_different);
 }

--- a/core/test/classes/m_hom_start_system.cpp
+++ b/core/test/classes/m_hom_start_system.cpp
@@ -169,7 +169,7 @@ BOOST_AUTO_TEST_CASE(start_points_are_roots_of_the_start_system)
 
 	bertini::Vec<dbl> xq(H.NumVariables());
 	for (Eigen::Index k = 0; k < xq.size(); ++k)
-		xq(k) = dbl(0.37 * (k + 1) + 0.11, -0.19 * k + 0.07);
+		xq(k) = dbl(0.37 * static_cast<double>(k + 1) + 0.11, -0.19 * static_cast<double>(k) + 0.07);
 	const dbl tv(0.42, -0.13);
 	const dbl hstep(1e-6, 0);
 

--- a/core/test/classes/randomization_block_test.cpp
+++ b/core/test/classes/randomization_block_test.cpp
@@ -96,10 +96,10 @@ static void AgreesWithExpansion(System const& sys)
 	std::vector<Vec<dbl>> pts;
 	{
 		Vec<dbl> p(nv);
-		for (Eigen::Index k = 0; k < nv; ++k) p(k) = dbl(0.3 + 0.17 * k, 0.5 - 0.11 * k);
+		for (Eigen::Index k = 0; k < nv; ++k) p(k) = dbl(0.3 + 0.17 * static_cast<double>(k), 0.5 - 0.11 * static_cast<double>(k));
 		pts.push_back(p);
 		Vec<dbl> q(nv);
-		for (Eigen::Index k = 0; k < nv; ++k) q(k) = dbl(-0.7 + 0.05 * k, 0.9 + 0.03 * k);
+		for (Eigen::Index k = 0; k < nv; ++k) q(k) = dbl(-0.7 + 0.05 * static_cast<double>(k), 0.9 + 0.03 * static_cast<double>(k));
 		pts.push_back(q);
 	}
 
@@ -289,7 +289,7 @@ BOOST_AUTO_TEST_CASE(eval_and_jacobian_fully_define_rows_in_a_dirty_buffer)
 	const Eigen::Index nv = static_cast<Eigen::Index>(r.NumVariables());
 
 	Vec<dbl> p(nv);
-	for (Eigen::Index k = 0; k < nv; ++k) p(k) = dbl(0.4 + 0.1 * k, 0.2 - 0.05 * k);
+	for (Eigen::Index k = 0; k < nv; ++k) p(k) = dbl(0.4 + 0.1 * static_cast<double>(k), 0.2 - 0.05 * static_cast<double>(k));
 
 	// poison the output buffers with a huge value; the block must overwrite every owned entry.
 	Vec<dbl> seg(n);   seg.setConstant(dbl(1e300, 1e300));

--- a/core/test/classes/start_system_test.cpp
+++ b/core/test/classes/start_system_test.cpp
@@ -366,7 +366,7 @@ BOOST_AUTO_TEST_CASE(quadratic_cubic_quartic_start_points)
 
 		for (decltype(function_values.size()) jj = 0; jj < function_values.size(); ++jj)
 			BOOST_CHECK(abs(function_values(jj)) <
-				abs(vs[jj]->Value<dbl>())*relaxed_threshold_clearance_d);
+				abs(vs[static_cast<size_t>(jj)]->Value<dbl>())*relaxed_threshold_clearance_d);
 	}
 
 	for (decltype(TD.NumStartPoints()) ii = 0; ii < TD.NumStartPoints(); ++ii)
@@ -426,7 +426,7 @@ BOOST_AUTO_TEST_CASE(quadratic_cubic_quartic_start_points_homogenized_patched)
 			// a fixed absolute threshold is scale-naive and flakes when a random r happens
 			// to be large.  Rows with jj >= vs.size() are patch/homogenization equations of
 			// O(1) scale, so a unit scale (absolute floor) is correct for them.
-			double scale = (jj < vs.size()) ? abs(vs[jj]->Value<dbl>()) : 1.0;
+			double scale = (static_cast<size_t>(jj) < vs.size()) ? abs(vs[static_cast<size_t>(jj)]->Value<dbl>()) : 1.0;
 			if (scale < 1.0) scale = 1.0;
 			BOOST_CHECK(abs(function_values(jj)) < scale*1000*relaxed_threshold_clearance_d);
 		}
@@ -441,7 +441,7 @@ BOOST_AUTO_TEST_CASE(quadratic_cubic_quartic_start_points_homogenized_patched)
 		for (decltype(function_values.size()) jj = 0; jj < function_values.size(); ++jj)
 		{
 			// scale-relative, as in the double-precision loop above
-			mpfr_float scale = (jj < vs.size()) ? abs(vs[jj]->Value<mpfr>()) : mpfr_float(1);
+			mpfr_float scale = (static_cast<size_t>(jj) < vs.size()) ? abs(vs[static_cast<size_t>(jj)]->Value<mpfr>()) : mpfr_float(1);
 			if (scale < 1) scale = mpfr_float(1);
 			BOOST_CHECK(abs(function_values(jj)) < scale*threshold_clearance_mp);
 		}
@@ -455,7 +455,7 @@ BOOST_AUTO_TEST_CASE(total_degree_start_system_precision_16)
 {
 	int this_test_precision{16};
 
-	DefaultPrecision(this_test_precision);
+	DefaultPrecision(static_cast<unsigned int>(this_test_precision));
 
 	Var x = Variable::Make("x");
 	Var y = Variable::Make("y");
@@ -485,9 +485,9 @@ BOOST_AUTO_TEST_CASE(total_degree_start_system_precision_16)
 	// test whether all start points have correct precision
 	for (unsigned ii = 0; ii < TD.NumStartPoints(); ++ii)
 	{
-		DefaultPrecision(this_test_precision);
-		final_system.precision(this_test_precision);
-		TD.precision(this_test_precision);
+		DefaultPrecision(static_cast<unsigned int>(this_test_precision));
+		final_system.precision(static_cast<unsigned int>(this_test_precision));
+		TD.precision(static_cast<unsigned int>(this_test_precision));
 		auto start_point = TD.StartPoint<mpfr_complex>(ii);
 		BOOST_CHECK_EQUAL(bertini::Precision(start_point), this_test_precision);
 	}
@@ -500,7 +500,7 @@ BOOST_AUTO_TEST_CASE(total_degree_start_system_homogenized_patched_precision_16)
 {
 	int this_test_precision{16};
 
-	DefaultPrecision(this_test_precision);
+	DefaultPrecision(static_cast<unsigned int>(this_test_precision));
 
 	Var x = Variable::Make("x");
 	Var y = Variable::Make("y");
@@ -534,9 +534,9 @@ BOOST_AUTO_TEST_CASE(total_degree_start_system_homogenized_patched_precision_16)
 	// test whether all start points have correct precision
 	for (unsigned ii = 0; ii < TD.NumStartPoints(); ++ii)
 	{
-		DefaultPrecision(this_test_precision);
-		final_system.precision(this_test_precision);
-		TD.precision(this_test_precision);
+		DefaultPrecision(static_cast<unsigned int>(this_test_precision));
+		final_system.precision(static_cast<unsigned int>(this_test_precision));
+		TD.precision(static_cast<unsigned int>(this_test_precision));
 		auto start_point = TD.StartPoint<mpfr_complex>(ii);
 		BOOST_CHECK_EQUAL(bertini::Precision(start_point), this_test_precision);
 	}

--- a/core/test/endgames/generic_cauchy_test.hpp
+++ b/core/test/endgames/generic_cauchy_test.hpp
@@ -1797,9 +1797,6 @@ BOOST_AUTO_TEST_CASE(griewank_osborne)
 
 	unsigned num_paths_diverging = 0;
 	unsigned num_paths_converging = 0;
-	unsigned num_fails = 0;
-
-	unsigned num_infinite_solutions = 0;
 	unsigned num_converged_at_origin = 0;
 	for (auto& s : griewank_homogenized_solutions) //current_space_values)
 	{
@@ -1839,11 +1836,6 @@ BOOST_AUTO_TEST_CASE(griewank_osborne)
 		{
 			num_paths_diverging++;
 		}
-		else
-			++num_fails;
-
-		if (griewank_osborn_sys.DehomogenizePoint(my_endgame.FinalApproximation<BCT>()).template lpNorm<Eigen::Infinity>() > security_settings.max_norm)
-			++num_infinite_solutions;
 
 	}
 	BOOST_CHECK(num_paths_converging>=3);

--- a/core/test/endgames/generic_interpolation.hpp
+++ b/core/test/endgames/generic_interpolation.hpp
@@ -70,7 +70,7 @@ BOOST_AUTO_TEST_CASE( constant_four_variate )
 		derivatives.push_back(derivative);
 
 	BCT target_time = ComplexFromString("0.9471925368945182312341234123");
-	auto result = HermiteInterpolateAndSolve(target_time,num_samples,times,samples,derivatives);
+	auto result = HermiteInterpolateAndSolve(target_time,static_cast<unsigned int>(num_samples),times,samples,derivatives);
 	BOOST_CHECK( (result - sample).norm() < pow(RealFromString("10"),ambient_precision-2)); 
 }
 

--- a/core/test/nag_algorithms/zero_dim.cpp
+++ b/core/test/nag_algorithms/zero_dim.cpp
@@ -388,7 +388,7 @@ BOOST_AUTO_TEST_CASE(mhom_homotopy_block_matches_function_tree)
 	He.precision(80);
 	for (int trial = 0; trial < 5; ++trial)
 	{
-		Vec<mpfr_complex> p = RandomOfUnits<mpfr_complex>(n);
+		Vec<mpfr_complex> p = RandomOfUnits<mpfr_complex>(static_cast<unsigned int>(n));
 		mpfr_complex t = RandomOfUnits<mpfr_complex>(1)(0);
 		compare(H.Eval(p, t),     He.Eval(p, t),     1e-70);
 		compare(H.Jacobian(p, t), He.Jacobian(p, t), 1e-70);

--- a/core/test/tracking_basics/amp_criteria_test.cpp
+++ b/core/test/tracking_basics/amp_criteria_test.cpp
@@ -92,7 +92,7 @@ BOOST_AUTO_TEST_CASE(AMP_criteriaA_double)
 	Mat<dbl> dh_dx = sys.Jacobian(current_space, current_time); 
 	Eigen::PartialPivLU<Mat<dbl>> LU = dh_dx.lu();
 
-	Vec<dbl> randy = Vec<dbl>::Random(sys.NumVariables());
+	Vec<dbl> randy = Vec<dbl>::Random(static_cast<Eigen::Index>(sys.NumVariables()));
 	Vec<dbl> temp_soln = LU.solve(randy);
 					
 	auto norm_J = double(dh_dx.norm());
@@ -140,7 +140,7 @@ BOOST_AUTO_TEST_CASE(AMP_criteriaA_mp)
 	Mat<mpfr> dh_dx = sys.Jacobian(current_space, current_time); 
 	Eigen::PartialPivLU<Mat<mpfr>> LU = dh_dx.lu();
 
-	Vec<mpfr> randy = Vec<mpfr>::Random(sys.NumVariables());
+	Vec<mpfr> randy = Vec<mpfr>::Random(static_cast<Eigen::Index>(sys.NumVariables()));
 	Vec<mpfr> temp_soln = LU.solve(randy);
 					
 	auto norm_J = double(dh_dx.norm());
@@ -192,7 +192,7 @@ BOOST_AUTO_TEST_CASE(AMP_criteriaB_double)
 	Eigen::PartialPivLU<Mat<dbl>> LU = dh_dx.lu();
 	Vec<dbl> delta_z = LU.solve(-f);
 
-	Vec<dbl> randy = Vec<dbl>::Random(sys.NumVariables());
+	Vec<dbl> randy = Vec<dbl>::Random(static_cast<Eigen::Index>(sys.NumVariables()));
 	Vec<dbl> temp_soln = LU.solve(randy);
 					
 	auto norm_J = double(dh_dx.norm());
@@ -245,7 +245,7 @@ BOOST_AUTO_TEST_CASE(AMP_criteriaB_mp)
 	Eigen::PartialPivLU<Mat<mpfr>> LU = dh_dx.lu();
 	Vec<mpfr> delta_z = LU.solve(-f);
 
-	Vec<mpfr> randy = Vec<mpfr>::Random(sys.NumVariables());
+	Vec<mpfr> randy = Vec<mpfr>::Random(static_cast<Eigen::Index>(sys.NumVariables()));
 	Vec<mpfr> temp_soln = LU.solve(randy);
 					
 	auto norm_J = double(dh_dx.norm());
@@ -295,7 +295,7 @@ BOOST_AUTO_TEST_CASE(AMP_criteriaC_double)
 	Mat<dbl> dh_dx = sys.Jacobian(current_space, current_time); 
 	Eigen::PartialPivLU<Mat<dbl>> LU = dh_dx.lu();
 
-	Vec<dbl> randy = Vec<dbl>::Random(sys.NumVariables());
+	Vec<dbl> randy = Vec<dbl>::Random(static_cast<Eigen::Index>(sys.NumVariables()));
 	Vec<dbl> temp_soln = LU.solve(randy);
 	auto norm_J_inverse = double(temp_soln.norm());
 
@@ -342,7 +342,7 @@ BOOST_AUTO_TEST_CASE(AMP_criteriaC_mp)
 	Mat<mpfr> dh_dx = sys.Jacobian(current_space, current_time); 
 	Eigen::PartialPivLU<Mat<mpfr>> LU = dh_dx.lu();
 
-	Vec<mpfr> randy = Vec<mpfr>::Random(sys.NumVariables());
+	Vec<mpfr> randy = Vec<mpfr>::Random(static_cast<Eigen::Index>(sys.NumVariables()));
 	Vec<mpfr> temp_soln = LU.solve(randy);
 	auto norm_J_inverse = double(temp_soln.norm());
 

--- a/core/test/tracking_basics/amp_jacobian_estimate_test.cpp
+++ b/core/test/tracking_basics/amp_jacobian_estimate_test.cpp
@@ -104,7 +104,7 @@ BOOST_AUTO_TEST_CASE(estimate_reflects_genuine_near_singularity)
 
 	for (int k = 20; k <= 140; k += 40)
 	{
-		bertini::DefaultPrecision(k + 50); // enough digits to represent eps = 1e-k
+		bertini::DefaultPrecision(static_cast<unsigned int>(k + 50)); // enough digits to represent eps = 1e-k
 
 		mpfr_float eps = pow(mpfr_float(10), -k);
 		// J = [[1, 1], [1, 1+eps]] : det = eps, so ||J^{-1}||_2 ~ 2/eps ~ 1e+k (analytic).

--- a/core/test/tracking_basics/heun_test.cpp
+++ b/core/test/tracking_basics/heun_test.cpp
@@ -104,8 +104,7 @@ BOOST_AUTO_TEST_CASE(circle_line_heun_double)
 	double predicted_error = .197349645229023708608160063982175;
 	
 	Vec<dbl> heun_prediction_result;
-	dbl next_time;
-	
+
 	double tracking_tolerance(1e-5);
 	double condition_number_estimate;
 	unsigned num_steps_since_last_condition_number_computation = 1;

--- a/core/test/tracking_basics/higher_predictor_test.cpp
+++ b/core/test/tracking_basics/higher_predictor_test.cpp
@@ -121,8 +121,7 @@ BOOST_AUTO_TEST_CASE(circle_line_RK4_double)
 	dbl(0.524028449166667552309395092084449, 1.42874855320540049801773082714871);
 	
 	Vec<dbl> RK4_prediction_result;
-	dbl next_time;
-	
+
 	double tracking_tolerance(1e-5);
 	double condition_number_estimate;
 	unsigned num_steps_since_last_condition_number_computation = 1;
@@ -428,8 +427,7 @@ BOOST_AUTO_TEST_CASE(circle_line_RKF45_double)
 	double predicted_error = 0.0000106466724075688025735071053994891;
 	
 	Vec<dbl> RKF45_prediction_result;
-	dbl next_time;
-	
+
 	double tracking_tolerance(1e-5);
 	double condition_number_estimate;
 	unsigned num_steps_since_last_condition_number_computation = 1;
@@ -778,8 +776,7 @@ BOOST_AUTO_TEST_CASE(circle_line_RKCK45_double)
 	double predicted_error = 0.00000353010590253211978478006394088836;
 	
 	Vec<dbl> RKCK45_prediction_result;
-	dbl next_time;
-	
+
 	double tracking_tolerance(1e-5);
 	double condition_number_estimate;
 	unsigned num_steps_since_last_condition_number_computation = 1;
@@ -1260,8 +1257,7 @@ BOOST_AUTO_TEST_CASE(circle_line_RKDP56_double)
 	double predicted_error = 6.79397491522542193110307157970405e-7;
 	
 	Vec<dbl> RKDP56_prediction_result;
-	dbl next_time;
-	
+
 	double tracking_tolerance(1e-5);
 	double condition_number_estimate;
 	unsigned num_steps_since_last_condition_number_computation = 1;
@@ -1733,8 +1729,7 @@ BOOST_AUTO_TEST_CASE(circle_line_RKV67_double)
 	double predicted_error = 0.00000128891520195955347062706145253149;
 	
 	Vec<dbl> RKV67_prediction_result;
-	dbl next_time;
-	
+
 	double tracking_tolerance(1e-5);
 	double condition_number_estimate;
 	unsigned num_steps_since_last_condition_number_computation = 1;

--- a/python_bindings/CMakeLists.txt
+++ b/python_bindings/CMakeLists.txt
@@ -225,10 +225,15 @@ target_link_libraries(_pybertini PUBLIC ${MPFR_LIBRARIES})
 target_link_libraries(_pybertini PUBLIC ${MPC_LIBRARIES})
 
 
-# which directories contain headers we need
-target_include_directories(_pybertini PUBLIC SYSTEM ${Boost_INCLUDE_DIRS})
-target_include_directories(_pybertini PUBLIC SYSTEM ${PYTHON_INCLUDE_DIRS})
-target_include_directories(_pybertini PUBLIC SYSTEM ${Python3_NumPy_INCLUDE_DIRS})
+# which directories contain headers we need.
+# NOTE: the SYSTEM keyword must precede the scope keyword (SYSTEM PUBLIC, not
+# PUBLIC SYSTEM) -- otherwise CMake reads "SYSTEM" as a relative include path and
+# these external headers are NOT treated as system, leaking their warnings into
+# our build output. (Eigen comes via the imported Eigen3::Eigen target below,
+# which is already treated as SYSTEM.)
+target_include_directories(_pybertini SYSTEM PUBLIC ${Boost_INCLUDE_DIRS})
+target_include_directories(_pybertini SYSTEM PUBLIC ${PYTHON_INCLUDE_DIRS})
+target_include_directories(_pybertini SYSTEM PUBLIC ${Python3_NumPy_INCLUDE_DIRS})
 target_include_directories(_pybertini PUBLIC ${Bertini2_INCLUDES})
 
 if(WIN32)

--- a/python_bindings/CMakeLists.txt
+++ b/python_bindings/CMakeLists.txt
@@ -234,6 +234,12 @@ target_link_libraries(_pybertini PUBLIC ${MPC_LIBRARIES})
 target_include_directories(_pybertini SYSTEM PUBLIC ${Boost_INCLUDE_DIRS})
 target_include_directories(_pybertini SYSTEM PUBLIC ${PYTHON_INCLUDE_DIRS})
 target_include_directories(_pybertini SYSTEM PUBLIC ${Python3_NumPy_INCLUDE_DIRS})
+# eigenpy is linked as an imported target below, but its install prefix (e.g.
+# /usr/local/include) is not reliably treated as system, so its headers (e.g.
+# numpy-allocator.hpp) leak -Wshorten-64-to-32 etc. Mark its include dirs SYSTEM
+# explicitly so this third-party dependency's warnings stay out of our output.
+target_include_directories(_pybertini SYSTEM PUBLIC
+    $<TARGET_PROPERTY:eigenpy::eigenpy,INTERFACE_INCLUDE_DIRECTORIES>)
 target_include_directories(_pybertini PUBLIC ${Bertini2_INCLUDES})
 
 if(WIN32)
@@ -253,9 +259,16 @@ if(MPI_CXX_FOUND)
     target_compile_definitions(_pybertini PUBLIC BERTINI2_HAVE_MPI)
 endif()
 
-if(NOT WIN32)
-  target_compile_options(_pybertini PRIVATE "-Wno-conversion")
-endif()
+# eigenpy's own templates (e.g. numpy-allocator.hpp's npy_intp->int) emit
+# conversion/shorten warnings when instantiated from our binding code. Marking
+# eigenpy's include dir SYSTEM is not enough: clang still reports warnings raised
+# during template instantiation requested from non-system code. --system-header-
+# prefix=eigenpy/ tells clang to treat any eigenpy/ header as a system header,
+# suppressing exactly that third-party noise -- without a blanket -Wno-conversion
+# that would also hide genuine conversion bugs in OUR binding code. Clang-only
+# flag (GCC/MSVC don't accept it).
+target_compile_options(_pybertini PRIVATE
+    $<$<CXX_COMPILER_ID:AppleClang,Clang>:--system-header-prefix=eigenpy/>)
 
 # lld-link (Windows) won't pull data-only object files (e.g. explicit_predictors.obj)
 # from the static bertini2 archive unless every object is forced in. CMake 3.24+

--- a/python_bindings/include/configured_visitor.hpp
+++ b/python_bindings/include/configured_visitor.hpp
@@ -61,7 +61,7 @@ namespace bertini{
 			// Recursion over the config type-list: return a *copy* of the owner's
 			// configuration struct whose registered Python class is `cls`.
 			template<typename OwnerT>
-			boost::python::object GetConfigDispatch(OwnerT&, boost::python::object const& cls)
+			boost::python::object GetConfigDispatch(OwnerT&, boost::python::object const& /*cls*/)
 			{
 				PyErr_SetString(PyExc_KeyError,
 					"this object has no configuration of the requested type; see config_types()");

--- a/python_bindings/include/containers_export.hpp
+++ b/python_bindings/include/containers_export.hpp
@@ -51,7 +51,7 @@ template< typename T>
 inline std::ostream& operator<<(std::ostream & out, const std::vector<T> & t)
 {
 	out << "[";
-	for (int ii = 0; ii < t.size(); ++ii)
+	for (size_t ii = 0; ii < t.size(); ++ii)
 	{
 		out << t[ii];
 		if (ii!=t.size()-1)
@@ -69,7 +69,7 @@ template< typename T>
 inline std::ostream& operator<<(std::ostream & out, const std::deque<T> & t)
 {
 	out << "[";
-	for (int ii = 0; ii < t.size(); ++ii)
+	for (size_t ii = 0; ii < t.size(); ++ii)
 	{
 		out << t[ii];
 		if (ii!=t.size()-1)
@@ -104,7 +104,7 @@ private:
 		ContT self=extract<ContT>(obj)();
 		std::stringstream ss;
 		ss << "[";
-		for (int ii = 0; ii < self.size(); ++ii)
+		for (size_t ii = 0; ii < self.size(); ++ii)
 		{
 			ss << self[ii];
 			if (ii!=self.size()-1)

--- a/python_bindings/include/endgame_export.hpp
+++ b/python_bindings/include/endgame_export.hpp
@@ -137,7 +137,6 @@ namespace bertini{
 		{
 			using TrackerT = typename EndgameT::TrackerType;
 			using BCT = typename TrackerTraits<TrackerT>::BaseComplexT;
-			using BRT = typename TrackerTraits<TrackerT>::BaseRealT;
 
 			cl
 			.def("cycle_number", this->GetCycleNumberFn(),arg("self"),"Get the cycle number as currently computed")

--- a/python_bindings/include/endgame_observers.hpp
+++ b/python_bindings/include/endgame_observers.hpp
@@ -53,7 +53,7 @@ struct EndgameObserverVisitor: public def_visitor<EndgameObserverVisitor<ObsT> >
 public:
 
 	template<class PyClass>
-	void visit(PyClass& cl) const{
+	void visit(PyClass& /*cl*/) const{
 	}
 };
 

--- a/python_bindings/include/mpfr_export.hpp
+++ b/python_bindings/include/mpfr_export.hpp
@@ -237,6 +237,12 @@ namespace bertini{
 			void visit(PyClass& cl) const;
 
 		private:
+			// NOTE: for the PowVisitor<T,int> instantiation this emits a single
+			// -Wsign-conversion (int->unsigned) warning. It is left intentionally:
+			// the natural pow(a,b) is correct for every (T,S) instantiation here,
+			// including negative integer exponents (e.g. a**-2). Forcing the
+			// exponent to unsigned silences the warning but breaks negative
+			// exponents; promoting it to T fails to compile for the complex T.
 			static T __pow__(const T& a, const S& b){using std::pow; using boost::multiprecision::pow; return pow(a,b); };
 		};
 

--- a/python_bindings/include/tracker_observers.hpp
+++ b/python_bindings/include/tracker_observers.hpp
@@ -53,7 +53,7 @@ struct TrackingObserverVisitor: public def_visitor<TrackingObserverVisitor<ObsT>
 public:
 
 	template<class PyClass>
-	void visit(PyClass& cl) const{
+	void visit(PyClass& /*cl*/) const{
 	}
 };
 

--- a/python_bindings/src/mpfr_export.cpp
+++ b/python_bindings/src/mpfr_export.cpp
@@ -135,7 +135,7 @@ namespace bertini{
 
 		template<typename T>
 		template<typename PyClass>
-		void RealFreeVisitor<T>::visit(PyClass& cl) const
+		void RealFreeVisitor<T>::visit(PyClass& /*cl*/) const
 		{
 			def("abs", &RealFreeVisitor::__abs__, (arg("val")), "absolute value"); // free
 		}
@@ -215,7 +215,7 @@ namespace bertini{
 
 		template<typename T>
 		template<typename PyClass>
-		void TranscendentalVisitor<T>::visit(PyClass& cl) const
+		void TranscendentalVisitor<T>::visit(PyClass& /*cl*/) const
 		{
 			def("exp", &TranscendentalVisitor::__exp__, (arg("val")), "exponential, base e");
 			def("log", &TranscendentalVisitor::__log__, (arg("val")), "natural log");


### PR DESCRIPTION
# Clean up macOS (AppleClang) compiler warnings — core + bindings

Branch: `feature/macos_compiler_warnings` → `develop`

## Why

The library built and ran fine, but on macOS (Apple clang 21) the build emitted
an overwhelming flood of compiler warnings. The volume was the problem: it buried
real errors and made the compile output almost unusable. A previous pass cleaned
up the **Ubuntu/GCC** warnings (commit `e95c8d52`); AppleClang surfaces a
different set (`-Wshorten-64-to-32`, `-Wsign-conversion`, `-Wunused-lambda-capture`,
`-Wdeprecated-copy`, `-Wpessimizing-move`, …), so this is the macOS counterpart.

Goal: drastically cut warning noise from our **first-party** code so the build is
usable again — fixing at the root cause, not hiding behind pragmas or `-Wno`.

## Result

The whole tree (core library + all C++ tests + Python bindings) now builds with
**one** intentional, documented warning, down from hundreds.

## Approach

- **Root-cause fixes in our own code** — no `#pragma`, no new `-Wno-*`. Same
  philosophy as the prior Ubuntu pass.
- **Third-party headers marked `SYSTEM`** so their (and their template
  instantiations') warnings stay out of our output. GMP/MPFR/MPC were already
  `SYSTEM`; this adds **Boost**, **Eigen**, and **eigenpy**.
- Diffs kept to warning-bearing lines only — **no whitespace/indentation
  reformatting** (a separate indentation pass is planned, and this avoids
  tangling the two).

## Commits

1. **`fix(core): clear AppleClang warnings in core library`**
   - `-Wpessimizing-move`: drop redundant `std::move` on prvalue `RandomMp<N>()` returns
   - `-Wunused-lambda-capture`: drop unused `[this]` from Boost.Spirit parser action lambdas
   - `-Wsign-conversion`: explicit `static_cast` at signed/unsigned boundaries
     (`Eigen::Index` for Eigen indexing, `size_t` for std containers)
   - `-Wunused-parameter/variable/-but-set`, `-Wmisleading-indentation` (brace a
     brace-less `if`), `-Wdeprecated-copy` (`= default` copy-assign)

2. **`fix(core): clear remaining AppleClang warnings (tests + template-only) and mark Boost/Eigen SYSTEM`**
   - The template-only and test-file warnings that only appear in a **full** build
     (a library-only build undercounts them)
   - Mark Boost & Eigen include dirs `SYSTEM`; fix a `PUBLIC SYSTEM` → `SYSTEM PUBLIC`
     keyword-order bug in the bindings CMake that left Boost/Python/NumPy not
     actually treated as system

3. **`fix(bindings): remove -Wno-conversion, fix first-party warnings, mark eigenpy SYSTEM`**
   - Remove the blanket `-Wno-conversion` that was hiding genuine conversion bugs
     in our binding code, and fix the 14 first-party warnings it exposed
   - Add `--system-header-prefix=eigenpy/` (clang-only) so eigenpy's own template
     warnings (e.g. `numpy-allocator.hpp` `npy_intp`→`int`) are suppressed —
     marking the include dir `SYSTEM` is **not** enough, because clang still
     reports warnings raised during template instantiation requested from
     non-system code. This silences ~120 third-party eigenpy warnings without a
     blanket `-Wno` that would mask our own bugs.

## The one remaining warning (intentional)

`PowVisitor<T,int>::__pow__` keeps a single `-Wsign-conversion`. The natural
`pow(a,b)` is correct for every `(T,S)` instantiation including negative integer
exponents (`a**-2`). Forcing the exponent to `unsigned` silences the warning but
**breaks** negative exponents (caught by `mpfr_test::test_change_prec`), and
promoting it to `T` fails to compile for the complex `T`. Left as-is with a
comment.

## Verification

- **Full clean build:** 1 warning (the intentional `__pow__` one); 0 errors.
- **C++ tests:** `ctest --test-dir build/core` → **10/10 suites pass**.
- **Python tests:** `pytest python/test/` → **504 passed, 12 skipped, 1 failed**.
  - Running pytest caught a real regression I'd briefly introduced in `__pow__`
    (negative exponents) — reverted/fixed before commit.
  - The 1 remaining failure (`tracking/endgame_test.py::test_using_total_degree_ss`)
    is a **pre-existing environment issue**: a numpy 2.4 / Python 3.14 `SystemError`
    in `ufunc.reduce` over eigenpy's custom `Complex` dtype. It reproduces on a bare
    2-element `np.sum`, independent of this change.

## Scope notes

- **No functional/behavioral changes** intended — all edits are casts, type
  tweaks, dead-code removal, and build-flag/`SYSTEM` changes.
- **Not in scope:** a separate, large indentation-consistency reformat (deliberately
  kept out so the two efforts don't collide).
- Stats: 46 files changed.

## Reviewer note (CMake)

The third-party `SYSTEM` treatment is the load-bearing build change:
- `core/CMakeLists.txt`: Boost/Eigen added to the `SYSTEM PUBLIC` include block.
- `python_bindings/CMakeLists.txt`: `SYSTEM PUBLIC` keyword-order fix; eigenpy
  interface includes marked `SYSTEM`; `--system-header-prefix=eigenpy/` (clang
  frontend only — GCC/MSVC don't accept it).
