### PR TITLE
MPI-less shared-memory threading: parallel-by-default solves

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -181,6 +181,27 @@ jobs:
           DYLD_LIBRARY_PATH: /tmp/boost-base/lib
         run: ctest --output-on-failure --timeout 600 --parallel $(nproc 2>/dev/null || sysctl -n hw.ncpu)
 
+      # The published wheels ship WITHOUT MPI (we can't know the user's MPI), but this C++ build is
+      # MPI-enabled (openmpi is installed above), so we verify the MPI runtime path actually works
+      # on each OS we support -- and, crucially, that it gives the SAME answer as the serial solve.
+      # The blackbox CLI reads a file named `input` from the cwd and writes the solution count as
+      # the first line of `main_data`.  mpirun -n 2 = one manager + one worker (the minimal pool).
+      - name: MPI smoke test (CLI under mpirun)
+        working-directory: build/core
+        env:
+          LD_LIBRARY_PATH: /tmp/boost-base/lib:/tmp/boost-base/lib64
+          DYLD_LIBRARY_PATH: /tmp/boost-base/lib
+        run: |
+          set -e
+          cp "$GITHUB_WORKSPACE/benchmark/inputs/small.b2" input
+          ./bertini2 >/dev/null 2>&1
+          serial=$(head -n1 main_data); rm -f main_data
+          mpirun -n 2 --bind-to none ./bertini2 >/dev/null 2>&1
+          parallel=$(head -n1 main_data)
+          echo "solution count: serial=$serial  mpi(-n 2)=$parallel"
+          test -n "$serial"
+          test "$serial" = "$parallel"   # MPI must match serial, not merely run
+
   test_cpp_windows:
     name: C++ tests on Windows
     if: ${{ inputs.minimal != true }}

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,28 +1,152 @@
-# Bertini2 Parallel Benchmark
+# Bertini2 parallel benchmark
 
-Scripts for measuring MPI + thread parallel speedup of the `bertini2` solver.
+Measure how much faster `bertini2` solves a system when you give it more compute. There are
+two independent kinds of parallelism, and this benchmark can sweep either or both:
 
-## Prerequisites
+- **Shared-memory threads** — one process, many worker threads, all on one machine. Needs **no
+  MPI**: it works with a plain `pip install` build or any `bertini2` compiled without MPI. This
+  is the everyday "use all the cores on my laptop/workstation" case.
+- **MPI ranks** — multiple processes, typically spread across the nodes of a cluster, each rank
+  itself optionally running a pool of threads. This is the "scale across a supercomputer" case
+  and requires a `bertini2` built with MPI plus `mpirun`.
 
-- `bertini2` built with MPI support (`cmake -DENABLE_MPI=ON ...`)
-- `mpirun` on `PATH`
-- Python 3.7+, no external packages needed
+The driver, `run_benchmark.py`, times each configuration, prints a speedup table, writes a CSV,
+and (optionally) fails if parallelism didn't actually help.
 
-## Quick Start
+---
+
+## 1. Run it on a single machine (no MPI, just threads)
+
+This is the simplest case and the one most people want. You only need a `bertini2` executable
+and Python 3 (no extra packages).
 
 ```bash
-# From the repo root
+# from the repo root
 python benchmark/run_benchmark.py \
     --bertini2 ./build/core/bertini2 \
-    --input    benchmark/inputs/small.b2 \
-    --ranks    1 2 \
-    --threads  1 2
+    --input    benchmark/inputs/medium.b2 \
+    --no-mpi \
+    --threads  1 2 4 8
 ```
 
-This runs the `small.b2` system (27 paths) with 4 combinations of ranks × threads,
-prints a speedup table, and writes `benchmark_results.csv`.
+`--no-mpi` runs the solver directly (no `mpirun`) and sweeps the thread counts you list. The
+run at `threads=1` is the serial baseline; every other run's speedup is reported relative to it.
+The thread count is passed to the solver through `OMP_NUM_THREADS`, which the script sets for
+you — don't set it yourself.
 
-## Sample Input Files
+Example output:
+
+```
+ ranks  threads  workers    time(s)  solutions   speedup
+------------------------------------------------------------
+     1        1        1    12.6141          6    1.0000
+     1        2        2    11.9876          6    1.0523
+     1        4        4     3.4350          6    3.6722
+     1        8        8     2.5991          6    4.8533
+
+Best parallel speedup: 4.85x vs serial baseline.
+```
+
+The `solutions` column should be identical across every row: threading is a speed feature, never
+a correctness change. If it ever differs, that's a bug — please report it.
+
+### Make the run *fail* if threads don't help
+
+Handy for CI or an acceptance check on a new machine:
+
+```bash
+python benchmark/run_benchmark.py --bertini2 ./build/core/bertini2 \
+    --input benchmark/inputs/medium.b2 --no-mpi --threads 1 4 \
+    --assert-speedup 1.5
+```
+
+This exits non-zero unless the best multi-thread run beats serial by at least 1.5×. Pick a
+threshold that suits the machine: a 2-core CI runner will not hit 4×, while a 32-core
+workstation should comfortably exceed it. Leave `--assert-speedup` off to just measure.
+
+---
+
+## 2. Run it with MPI (multiple ranks)
+
+If your `bertini2` was built with MPI (`cmake -DENABLE_MPI=ON ...`) and `mpirun` is on your
+`PATH`, you can sweep MPI ranks as well as threads. Drop `--no-mpi` and add `--ranks`:
+
+```bash
+python benchmark/run_benchmark.py \
+    --bertini2 ./build/core/bertini2 \
+    --input    benchmark/inputs/large.b2 \
+    --ranks    1 2 4 \
+    --threads  1 2 4
+```
+
+This launches each combination under `mpirun -n <ranks>` with `OMP_NUM_THREADS=<threads>` per
+rank. `--bind-to none` is passed to `mpirun` automatically so threaded workers can spread across
+a node's cores without affinity conflicts. The total worker count in the table is
+`ranks × threads`.
+
+You do **not** need a cluster for this — a single multi-core machine with MPI installed runs the
+rank sweep locally just fine.
+
+---
+
+## 3. Run it on an HPC cluster
+
+### With SLURM (`sbatch`)
+
+`submit.slurm.sh` is a ready-to-edit batch script. Open it and adjust:
+
+- the `#SBATCH` directives — `--nodes`, `--ntasks-per-node`, `--cpus-per-task` (this is the
+  cores-per-rank, i.e. the max threads), `--time`;
+- the **module loads / environment activation** near the top (load your MPI, your Python, and/or
+  activate the conda env that has `bertini2`);
+- the `INPUT`, `RANKS`, and `THREADS` sweep near the bottom.
+
+Keep two consistency rules in mind:
+
+- `RANKS` should not exceed `--nodes × --ntasks-per-node`.
+- the largest value in `THREADS` should not exceed `--cpus-per-task`.
+
+Then submit:
+
+```bash
+sbatch benchmark/submit.slurm.sh
+```
+
+Results land in `benchmark/results_<JOBID>.csv`, and stdout/stderr in `benchmark_<JOBID>.log` /
+`.err`. The script discovers the repo root relative to its own location, so you can submit it
+from anywhere.
+
+### On a cluster without SLURM (or interactively)
+
+There's nothing SLURM-specific about the measurement — `submit.slurm.sh` just sets up an
+environment and calls `run_benchmark.py`. On a cluster with a different scheduler (PBS, LSF,
+...), or in an interactive allocation, load your modules / activate your environment by hand and
+run the driver directly, exactly as in section 2:
+
+```bash
+python benchmark/run_benchmark.py --bertini2 /path/to/bertini2 \
+    --input benchmark/inputs/large.b2 --ranks 1 2 4 8 --threads 1 4 8 \
+    --mpirun srun        # if your site launches MPI jobs with srun instead of mpirun
+```
+
+Use `--mpirun` to point at whatever launcher your site uses (e.g. `srun`, or a full path to a
+specific `mpirun`), and `--mpirun-args` to pass site-specific flags. For example, on a host
+whose CPU topology `hwloc` cannot read (some VMs/containers), OpenMPI's default mapper fails
+with "failed to map" / "all nodes already filled"; pass
+
+```bash
+--mpirun-args "--map-by slot:OVERSUBSCRIBE --bind-to none"
+```
+
+to map by slot instead of by core. On a normal cluster the default (`--bind-to none`) is fine.
+
+---
+
+## Sample input files
+
+Each system is diagonal (`xi^3 - ci = 0`) with distinct prime constants, so the answers are
+known analytically and easy to check. "Paths" is the total-degree path count the solver tracks
+(the work), which is what scales with parallelism.
 
 | File | Variables | Degree | Paths |
 |------|-----------|--------|-------|
@@ -32,38 +156,35 @@ prints a speedup table, and writes `benchmark_results.csv`.
 | `inputs/xlarge.b2`  | 7 | 3 |  2187 |
 | `inputs/huge.b2`    | 9 | 3 | 19683 |
 
-Each system is diagonal (`xi^3 - ci = 0`) with distinct prime constants, so solutions
-are known analytically and correctness is easy to verify (solution count = number of
-paths for these fully real systems).
+Bigger systems show parallel scaling more clearly (more paths to spread over workers) but take
+longer. Start with `small`/`medium` to sanity-check your setup, then move up.
 
-## Options
+---
+
+## All options
 
 ```
---bertini2 PATH    Path to bertini2 executable (default: ./build/core/bertini2)
---input    FILE    Bertini input file to solve (required)
---ranks    N ...   MPI rank counts to sweep (default: 1 2 4)
---threads  N ...   OMP thread counts per rank (default: 1)
---output   FILE    CSV output path (default: benchmark_results.csv)
---timeout  SECS    Per-run timeout (default: 600)
---repeats  N       Timed repeats per combo; records minimum (default: 1)
---mpirun   CMD     mpirun command (default: mpirun)
+--bertini2 PATH      Path to the bertini2 executable (default: ./build/core/bertini2)
+--input    FILE      Bertini input file to solve (required)
+--threads  N ...     Thread counts to sweep (default: 1)
+--ranks    N ...     MPI rank counts to sweep (default: 1 2 4); ignored with --no-mpi
+--no-mpi             Run the solver directly, no mpirun: a pure thread sweep for a build
+                     without MPI. Forces ranks=1 and sweeps --threads only.
+--assert-speedup F   Exit non-zero unless the best parallel run beats serial by >= F (e.g. 1.5).
+                     Off by default.
+--repeats  N         Timed repeats per combination; the fastest is recorded (default: 1).
+--timeout  SECS      Per-run timeout (default: 600).
+--mpirun   CMD       Launcher for MPI runs (default: mpirun; e.g. srun on some clusters).
+--mpirun-args STR    Extra flags for mpirun, one quoted string (default: '--bind-to none').
+--output   FILE      CSV output path (default: benchmark_results.csv).
 ```
-
-## Cluster Submission (SLURM)
-
-Edit `submit.slurm.sh` (paths, module loads, rank/thread sweep) and submit:
-
-```bash
-sbatch benchmark/submit.slurm.sh
-```
-
-Results are written to `benchmark/results_<JOBID>.csv`.
 
 ## Notes
 
-- `--bind-to none` is passed to `mpirun` automatically so that threaded workers
-  can use all cores on a node without affinity conflicts.
-- Each (ranks, threads) combo runs in its own temp directory to avoid file conflicts.
-- The serial baseline (ranks=1, threads=1) is always run first; speedup is computed
-  relative to that measurement.
-- `OMP_NUM_THREADS` is set per-run by the script; do not set it externally when sweeping.
+- The serial baseline (`ranks=1, threads=1`) always runs first; all speedups are relative to it.
+- Each run executes in its own temp directory, so concurrent files never collide.
+- Timings on a busy or thermally-throttling machine are noisy. Use `--repeats 3+` (the minimum
+  time is kept) and a quiet machine for numbers you intend to publish.
+- The `*_seeded` and `baseline_*` CSVs checked in here are reference results from past runs; your
+  numbers will differ by machine.
+```

--- a/benchmark/run_benchmark.py
+++ b/benchmark/run_benchmark.py
@@ -23,6 +23,7 @@ import argparse
 import csv
 import math
 import os
+import shlex
 import shutil
 import subprocess
 import sys
@@ -48,12 +49,27 @@ def parse_args():
                    help="Number of timed repeats per (ranks, threads) combo (default: 1)")
     p.add_argument("--mpirun", default="mpirun",
                    help="mpirun command (default: mpirun)")
+    p.add_argument("--mpirun-args", default="--bind-to none",
+                   help="Extra flags passed to mpirun before -n, as one quoted string "
+                        "(default: '--bind-to none'). Site-specific: e.g. on a host whose CPU "
+                        "topology hwloc can't read, use "
+                        "'--map-by slot:OVERSUBSCRIBE --bind-to none'.")
+    p.add_argument("--no-mpi", action="store_true",
+                   help="Run the solver directly (no mpirun): a pure shared-memory THREAD sweep "
+                        "for a bertini2 built without MPI. Forces ranks=1 and sweeps --threads only.")
+    p.add_argument("--assert-speedup", type=float, default=None, metavar="FACTOR",
+                   help="Fail (exit 1) unless the best multi-thread run beats the serial baseline "
+                        "by at least FACTOR (e.g. 1.5). Off by default; use in CI / acceptance runs.")
     return p.parse_args()
 
 
-def run_once(bertini2_path, input_file, ranks, threads, mpirun_cmd, timeout):
+def run_once(bertini2_path, input_file, ranks, threads, mpirun_cmd, mpirun_args, timeout, use_mpi):
     """
     Run bertini2 with the given parallelism settings in a fresh temp directory.
+
+    When use_mpi is True the solver is launched under `mpirun -n <ranks>` (MPI across ranks,
+    OMP_NUM_THREADS threads within each rank).  When use_mpi is False the binary is run directly
+    -- a pure shared-memory thread sweep that needs no MPI at all; ranks is ignored (always 1).
 
     Returns (wall_time_s, solutions_found) or (float('nan'), -1) on failure.
     """
@@ -63,10 +79,15 @@ def run_once(bertini2_path, input_file, ranks, threads, mpirun_cmd, timeout):
         shutil.copy2(input_file, dest_input)
 
         env = os.environ.copy()
+        # OMP_NUM_THREADS drives the worker-thread count in both modes: per MPI rank under mpirun,
+        # and the whole shared-memory solve when run directly.
         env["OMP_NUM_THREADS"] = str(threads)
 
-        cmd = [mpirun_cmd, "-n", str(ranks), "--bind-to", "none",
-               os.path.abspath(bertini2_path)]
+        if use_mpi:
+            cmd = [mpirun_cmd, *shlex.split(mpirun_args), "-n", str(ranks),
+                   os.path.abspath(bertini2_path)]
+        else:
+            cmd = [os.path.abspath(bertini2_path)]
 
         t0 = time.perf_counter()
         try:
@@ -110,13 +131,18 @@ def validate_inputs(args):
         sys.exit(f"Error: input file not found: {args.input}")
     if not os.path.isfile(args.bertini2):
         sys.exit(f"Error: bertini2 executable not found: {args.bertini2}")
-    if shutil.which(args.mpirun) is None:
-        sys.exit(f"Error: {args.mpirun!r} not found on PATH")
+    # mpirun is only needed for the MPI rank sweep; the --no-mpi thread sweep runs the binary
+    # directly, so don't demand mpirun there.
+    if not args.no_mpi and shutil.which(args.mpirun) is None:
+        sys.exit(f"Error: {args.mpirun!r} not found on PATH "
+                 f"(use --no-mpi for a threads-only sweep on a build without MPI)")
 
 
 def main():
     args = parse_args()
     validate_inputs(args)
+
+    use_mpi = not args.no_mpi
 
     ranks_list = sorted(set(args.ranks))
     threads_list = sorted(set(args.threads))
@@ -127,8 +153,13 @@ def main():
     if 1 not in threads_list:
         threads_list = [1] + threads_list
 
+    # In --no-mpi mode there are no ranks: collapse to a pure thread sweep at ranks=1.
+    if not use_mpi:
+        ranks_list = [1]
+
     print(f"bertini2:  {args.bertini2}")
     print(f"input:     {args.input}")
+    print(f"mode:      {'MPI ranks x OMP threads' if use_mpi else 'shared-memory threads (no MPI)'}")
     print(f"ranks:     {ranks_list}")
     print(f"threads:   {threads_list}")
     print(f"repeats:   {args.repeats}")
@@ -150,7 +181,7 @@ def main():
             rep_label = f"  rep {rep+1}/{args.repeats}" if args.repeats > 1 else ""
             print(f"Running {label}{rep_label} ... ", end="", flush=True)
             t, sol = run_once(args.bertini2, args.input, ranks, threads,
-                              args.mpirun, args.timeout)
+                              args.mpirun, args.mpirun_args, args.timeout, use_mpi)
             if math.isnan(t):
                 print("failed")
                 times.append(float("nan"))
@@ -196,6 +227,25 @@ def main():
               f"{row['wall_time_s']:>9}  {row['solutions_found']:>9}  {row['speedup_vs_serial']:>8}")
 
     print(f"\nResults written to: {args.output}")
+
+    # Best speedup achieved by any genuinely parallel run (more than one worker).
+    parallel_speedups = [
+        float(row["speedup_vs_serial"])
+        for row in rows
+        if row["total_workers"] > 1 and row["speedup_vs_serial"] != "nan"
+    ]
+    best = max(parallel_speedups) if parallel_speedups else float("nan")
+    if parallel_speedups:
+        print(f"Best parallel speedup: {best:.2f}x vs serial baseline.")
+
+    # Optional acceptance gate: did parallelism actually pay off?
+    if args.assert_speedup is not None:
+        if math.isnan(best):
+            sys.exit("FAIL: --assert-speedup set but no parallel run produced a valid time.")
+        if best < args.assert_speedup:
+            sys.exit(f"FAIL: best parallel speedup {best:.2f}x < required "
+                     f"{args.assert_speedup:.2f}x.")
+        print(f"PASS: best parallel speedup {best:.2f}x >= required {args.assert_speedup:.2f}x.")
 
 
 if __name__ == "__main__":

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -776,6 +776,7 @@ if (ENABLE_UNIT_TESTING)
 	set(B2_NAG_ALGORITHMS_TEST
 		test/nag_algorithms/nag_algorithms_test.cpp
 		test/nag_algorithms/zero_dim.cpp
+		test/nag_algorithms/threaded_solve.cpp
 		test/nag_algorithms/numerical_irreducible_decomposition.cpp
 		test/nag_algorithms/trace.cpp
 	)

--- a/core/include/bertini2/detail/observable.hpp
+++ b/core/include/bertini2/detail/observable.hpp
@@ -39,6 +39,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <mutex>
 #include <stdexcept>
 #include <typeindex>
 #include <typeinfo>
@@ -107,6 +108,7 @@ namespace bertini{
 		*/
 		void AddObserver(AnyObserver& new_observer) const
 		{
+			std::lock_guard<std::recursive_mutex> lock(notify_mutex_);
 			RejectIfIncompatible(new_observer);
 			Watcher w;
 			w.raw = &new_observer;        // non-owning: owned stays null
@@ -127,6 +129,7 @@ namespace bertini{
 		*/
 		void AddObserver(std::shared_ptr<AnyObserver> const& new_observer) const
 		{
+			std::lock_guard<std::recursive_mutex> lock(notify_mutex_);
 			RejectIfIncompatible(*new_observer);
 			Watcher w;
 			w.owned = new_observer;          // owning: keeps the observer alive
@@ -142,6 +145,7 @@ namespace bertini{
 		*/
 		void RemoveObserver(AnyObserver& observer) const
 		{
+			std::lock_guard<std::recursive_mutex> lock(notify_mutex_);
 			if (dispatch_depth_ > 0)
 			{
 				PendingOp op;
@@ -288,6 +292,7 @@ namespace bertini{
 
 		void DispatchEvent(AnyEvent const& e) const
 		{
+			std::lock_guard<std::recursive_mutex> lock(notify_mutex_);
 			++dispatch_depth_;
 
 			auto run = [&](ObserverList& bucket) {
@@ -320,6 +325,16 @@ namespace bertini{
 
 		mutable unsigned dispatch_depth_ = 0;
 		mutable std::vector<PendingOp> pending_ops_;
+
+		// Serializes notification and watcher-list mutation so the same observable can be safely
+		// notified from several worker threads at once (the MPI-less threaded solve fires per-path
+		// events from each tracking thread onto one shared solver).  Recursive because an observer's
+		// Observe() may itself Add/RemoveObserver on this same observable during a dispatch (the
+		// "meta-observer" pattern) -- that re-entrant call re-locks on the same thread and is routed
+		// through the deferred pending_ops_ path via dispatch_depth_.  Held across Observe() calls,
+		// so observer callbacks are serialized; the heavy numerical work runs outside this lock.
+		// Single-threaded callers pay one uncontended recursive lock per event -- negligible.
+		mutable std::recursive_mutex notify_mutex_;
 	};
 
 } // namespace bertini

--- a/core/include/bertini2/nag_algorithms/common/config.hpp
+++ b/core/include/bertini2/nag_algorithms/common/config.hpp
@@ -181,6 +181,12 @@ struct ZeroDimConfig
 	unsigned initial_ambient_precision = DefaultPrecision();
 	unsigned max_num_crossed_path_resolve_attempts = 2; ///< The maximum number of times to attempt to re-solve crossed paths at the endgame boundary.
 
+	/// Number of worker threads for a shared-memory (non-MPI) solve.  0 = auto
+	/// (std::thread::hardware_concurrency); 1 = serial (no thread pool).  Overridden by the
+	/// OMP_NUM_THREADS environment variable when set.  See parallel::EffectiveThreadCount.
+	/// Under MPI the per-rank thread count comes from OMP_NUM_THREADS, not this field.
+	unsigned num_threads = 0;
+
 	mpq_rational start_time{1};          ///< Homotopy start time (t=1).
 	mpq_rational endgame_boundary{1, 10}; ///< Time at which tracking hands off to the endgame (t=1/10).
 	mpq_rational target_time{0};         ///< Homotopy target time (t=0).

--- a/core/include/bertini2/nag_algorithms/events.hpp
+++ b/core/include/bertini2/nag_algorithms/events.hpp
@@ -34,6 +34,7 @@ type.
 #pragma once
 
 #include "bertini2/detail/events.hpp"
+#include "bertini2/detail/observable.hpp"   // Observable: the executing tracker is carried as one
 
 #include <cstddef>
 
@@ -69,16 +70,29 @@ namespace bertini {
 		{ BOOST_TYPE_INDEX_REGISTER_CLASS
 		public:
 			using HeldT = typename AlgorithmEvent<ObservedT>::HeldT;
-			PathStarted(HeldT obs, std::size_t path_index)
-				: AlgorithmEvent<ObservedT>(obs), path_index_(path_index)
+			PathStarted(HeldT obs, std::size_t path_index, Observable const* tracker = nullptr)
+				: AlgorithmEvent<ObservedT>(obs), path_index_(path_index), tracker_(tracker)
 			{}
 
 			std::size_t PathIndex() const { return path_index_; }
+
+			/**
+			\brief The tracker that actually executes this path.
+
+			In a serial solve this is the solver's member tracker; in a threaded solve it is the
+			thread-local tracker clone that owns the path (Observable copies inherit no observers,
+			so the member tracker would see nothing).  A meta-observer that wants per-path tracking
+			data must attach its sub-observer here, NOT to solver.GetTracker().  AddObserver is a
+			const method, so observers can still be attached through this const handle.  May be null
+			if the emitter supplied no tracker.
+			*/
+			Observable const* Tracker() const { return tracker_; }
 
 			virtual ~PathStarted() = default;
 			PathStarted() = delete;
 		private:
 			std::size_t path_index_;
+			Observable const* tracker_ = nullptr;
 		};
 
 		/**
@@ -89,16 +103,21 @@ namespace bertini {
 		{ BOOST_TYPE_INDEX_REGISTER_CLASS
 		public:
 			using HeldT = typename AlgorithmEvent<ObservedT>::HeldT;
-			PathComplete(HeldT obs, std::size_t path_index)
-				: AlgorithmEvent<ObservedT>(obs), path_index_(path_index)
+			PathComplete(HeldT obs, std::size_t path_index, Observable const* tracker = nullptr)
+				: AlgorithmEvent<ObservedT>(obs), path_index_(path_index), tracker_(tracker)
 			{}
 
 			std::size_t PathIndex() const { return path_index_; }
+
+			/// The tracker that executed this path -- see PathStarted::Tracker().  A meta-observer
+			/// detaches its per-path sub-observer from this same tracker on PathComplete.
+			Observable const* Tracker() const { return tracker_; }
 
 			virtual ~PathComplete() = default;
 			PathComplete() = delete;
 		private:
 			std::size_t path_index_;
+			Observable const* tracker_ = nullptr;
 		};
 
 	} // namespace algorithm

--- a/core/include/bertini2/nag_algorithms/zero_dim_solve.hpp
+++ b/core/include/bertini2/nag_algorithms/zero_dim_solve.hpp
@@ -938,13 +938,40 @@ std::ostream& operator<<(std::ostream & out, const SolveReport & r)
 				// re-run any crossed path in full.  This is the same shape the distributed solve uses
 				// (one worker per whole path), so serial and distributed share the per-path primitive
 				// -- including computing the start point via the same ComputeStartPoint.
+
+				// Compute every start point once, up front (deterministic per index, as the MPI
+				// manager does).  The threaded dispatch ships each worker its start point, and the
+				// serial path / crossed-path re-tracks reuse the identical points from here.
+				std::vector<Vec<BaseComplexT>> start_points(num_start_points_);
+				std::vector<SolnIndT>          all_indices(num_start_points_);
 				for (decltype(num_start_points_) ii{0}; ii < num_start_points_; ++ii)
 				{
 					auto idx = static_cast<SolnIndT>(ii);
-					ExecuteOnePath(MemberDuringEGContext(), idx, ComputeStartPoint(idx));
+					start_points[ii] = ComputeStartPoint(idx);
+					all_indices[ii]  = idx;
 				}
 
-				RunMidpathResolution([this](SolnIndT idx){ ExecuteOnePath(MemberDuringEGContext(), idx, ComputeStartPoint(idx)); });
+				// num_threads: 0 = auto (hardware_concurrency), 1 = serial, N = N threads;
+				// OMP_NUM_THREADS overrides.  n_threads <= 1 takes the pool-free serial path.
+				const unsigned n_threads =
+					parallel::EffectiveThreadCount(this->template Get<ZeroDimConf>().num_threads);
+
+				if (n_threads <= 1)
+				{
+					for (auto idx : all_indices)
+						ExecuteOnePath(MemberDuringEGContext(), idx, start_points[idx]);
+				}
+				else
+				{
+					RunPathsThreaded(all_indices, start_points, n_threads);
+				}
+
+				// Crossed-path re-tracks run on the main thread against the (escalated) member
+				// tracker.  They are typically rare (often none); running them in parallel too is a
+				// deferred optimization.
+				RunMidpathResolution([this, &start_points](SolnIndT idx){
+					ExecuteOnePath(MemberDuringEGContext(), idx, start_points[idx]);
+				});
 
 				PostEGAction();
 
@@ -1301,9 +1328,9 @@ std::ostream& operator<<(std::ostream & out, const SolveReport & r)
 				}
 			}
 
-#ifdef BERTINI2_HAVE_MPI
 			/**
-			Self-contained per-thread state for executing one WHOLE path on a threaded MPI worker.
+			Self-contained per-thread state for executing one WHOLE path on a worker thread --
+			used by both the standalone (MPI-less) threaded solve and the threaded MPI worker.
 			Each std::thread owns one: a homotopy copy (tracked by `tracker`), a target-system copy
 			(residual evaluation mutates System precision state), a Tracker and Endgame, and its own
 			precision observers so observer-derived metadata matches serial runs.  Build a
@@ -1323,7 +1350,83 @@ std::ostream& operator<<(std::ostream & out, const SolveReport & r)
 					return DuringEGContext{ target_sys, tracker, endgame, first_prec_rec, min_max_prec };
 				}
 			};
-#endif // BERTINI2_HAVE_MPI
+
+			/**
+			\brief Build the per-thread state factory: a callable () -> unique_ptr<PathThreadState>
+			that each worker thread invokes once at startup.
+
+			Clone() (deep copy), not a plain copy: System copies are SHALLOW (they share
+			expression-tree nodes whose value caches mutate on Eval), so two threads sharing a System
+			copy would race on those caches.  Clone() deep-copies the tree, giving each thread a fully
+			independent homotopy + target system.  The tracker/endgame are copied and re-pointed at the
+			thread's own systems, and the thread's mpfr precision is set.  Shared by the standalone
+			threaded solve and the threaded MPI worker.
+			*/
+			auto MakeThreadStateFactory()
+			{
+				return [this]() -> std::unique_ptr<PathThreadState>
+				{
+					// Trackers/Endgames have no default ctor, so aggregate-init via new; {},{} default
+					// the two precision recorders.
+					std::unique_ptr<PathThreadState> s(
+						new PathThreadState{ Clone(GetTracker().GetSystem()), Clone(TargetSystem()),
+						                     GetTracker(), GetEndgame(), {}, {} });
+					s->tracker.SetSystem(s->sys);       // re-point the copy at its own System
+					s->endgame.SetTracker(s->tracker);  // ... and the endgame at that tracker
+					SetThreadPrecision(this->template Get<ZeroDimConf>().initial_ambient_precision);
+					return s;
+				};
+			}
+
+			/**
+			\brief Build the per-path track function: (PathThreadState&, StartPointTask) -> FullPathResult.
+
+			Executes one whole path against the thread-local state, then packs the result.  The pack
+			(read shared [idx] slots into a value) + main-thread StoreFullPathResult (install) split is
+			what keeps the shared result arrays race-free across worker threads.  Shared by the
+			standalone threaded solve and the threaded MPI worker.
+			*/
+			auto MakeThreadTrackFn()
+			{
+				return [this](std::unique_ptr<PathThreadState>& state,
+				              parallel::StartPointTask<BaseComplexT> const& task)
+				           -> parallel::FullPathResult<BaseComplexT>
+				{
+					auto idx = static_cast<SolnIndT>(task.path_index);
+					ExecuteOnePath(state->Context(), idx, task.start_point);
+					return PackFullPathResult(idx);
+				};
+			}
+
+			/**
+			\brief Track a set of whole paths across a shared-memory thread pool (no MPI).
+
+			Each worker thread owns a PathThreadState clone; this (the main) thread submits all the
+			given path indices, then collects exactly that many results and installs each serially via
+			StoreFullPathResult.  `start_points` is indexed by global path index, so a subset of
+			`indices` (e.g. crossed paths) reuses the identical authoritative start points.
+			*/
+			void RunPathsThreaded(std::vector<SolnIndT> const& indices,
+			                      std::vector<Vec<BaseComplexT>> const& start_points,
+			                      unsigned n_threads)
+			{
+				using Task   = parallel::StartPointTask<BaseComplexT>;
+				using Result = parallel::FullPathResult<BaseComplexT>;
+
+				auto state_factory = MakeThreadStateFactory();
+				auto track_fn      = MakeThreadTrackFn();
+
+				parallel::WorkerThreadPool<Task, Result, decltype(state_factory), decltype(track_fn)>
+					pool(static_cast<int>(n_threads), state_factory, track_fn);
+
+				for (auto idx : indices)
+					pool.submit(Task{ static_cast<std::size_t>(idx), start_points[idx] });
+
+				for (std::size_t k = 0; k < indices.size(); ++k)
+					StoreFullPathResult(pool.collect());
+
+				pool.shutdown();
+			}
 
 			/**
 			\brief Apply one step of escalation to the tracker before re-tracking crossed paths.
@@ -1654,8 +1757,11 @@ std::ostream& operator<<(std::ostream & out, const SolveReport & r)
 		//	MPI pack/store helpers (only compiled when BERTINI2_HAVE_MPI is defined)
 		///////
 
-#ifdef BERTINI2_HAVE_MPI
-			// Pack everything a worker computed for one whole path into the single result message.
+			// Pack everything computed for one whole path into a single result value.  Used as the
+			// thread-safe handoff in BOTH the MPI protocol (serialized over the wire) and the
+			// standalone threaded solve (a worker thread packs, the main thread installs via
+			// StoreFullPathResult) -- the compute/install split is what keeps shared result arrays
+			// race-free when several threads run distinct paths.
 			parallel::FullPathResult<BaseComplexT> PackFullPathResult(SolnIndT idx) const
 			{
 				parallel::FullPathResult<BaseComplexT> r;
@@ -1706,7 +1812,6 @@ std::ostream& operator<<(std::ostream & out, const SolveReport & r)
 				smd.time_of_first_prec_increase = r.time_of_first_prec_increase;
 				smd.max_precision_used  = r.max_precision_used;
 			}
-#endif // BERTINI2_HAVE_MPI
 
 
 		///////

--- a/core/include/bertini2/nag_algorithms/zero_dim_solve.hpp
+++ b/core/include/bertini2/nag_algorithms/zero_dim_solve.hpp
@@ -1469,21 +1469,26 @@ std::ostream& operator<<(std::ostream & out, const SolveReport & r)
 			*/
 			void ExecuteOnePath(DuringEGContext ctx, SolnIndT soln_ind, Vec<BaseComplexT> const& start_point)
 			{
-				this->NotifyObservers(PathStarted<AnyZeroDim>(*this, static_cast<std::size_t>(soln_ind)));
+				// Carry the executing tracker on the path events: &ctx.tracker is the member tracker
+				// in a serial solve and the thread-local clone in a threaded one, so a meta-observer
+				// attaches its per-path sub-observer to the tracker that actually runs this path.
+				Observable const* exec_tracker = &ctx.tracker;
+
+				this->NotifyObservers(PathStarted<AnyZeroDim>(*this, static_cast<std::size_t>(soln_ind), exec_tracker));
 
 				ctx.tracker.SetTrackingTolerance(midpath_retrack_tolerance_);
 				ExecuteBeforeEG(BeforeEGContext{ ctx.tracker, ctx.first_prec_rec, ctx.min_max_prec }, soln_ind, start_point);
 
 				if (solution_final_metadata_[soln_ind].pre_endgame_success != SuccessCode::Success)
 				{
-					this->NotifyObservers(PathComplete<AnyZeroDim>(*this, static_cast<std::size_t>(soln_ind)));
+					this->NotifyObservers(PathComplete<AnyZeroDim>(*this, static_cast<std::size_t>(soln_ind), exec_tracker));
 					return;
 				}
 
 				ctx.tracker.SetTrackingTolerance(this->template Get<Tolerances>().newton_during_endgame);
 				ExecuteDuringEG(ctx, soln_ind);
 
-				this->NotifyObservers(PathComplete<AnyZeroDim>(*this, static_cast<std::size_t>(soln_ind)));
+				this->NotifyObservers(PathComplete<AnyZeroDim>(*this, static_cast<std::size_t>(soln_ind), exec_tracker));
 			}
 
 

--- a/core/include/bertini2/parallel.hpp
+++ b/core/include/bertini2/parallel.hpp
@@ -29,6 +29,10 @@
 #include "bertini2/parallel/initialize_finalize.hpp"
 #include "bertini2/parallel/path_result.hpp"
 
+// The shared-memory thread pool is MPI-independent (pure std::thread); it backs both the
+// standalone threaded solve and the MPI+threads hybrid, so it is always available.
+#include "bertini2/parallel/thread_pool.hpp"
+
 #ifdef BERTINI2_HAVE_MPI
 #include "bertini2/parallel/manager.hpp"
 #include "bertini2/parallel/worker.hpp"

--- a/core/include/bertini2/parallel/thread_pool.hpp
+++ b/core/include/bertini2/parallel/thread_pool.hpp
@@ -53,9 +53,14 @@ Example:
 
 #pragma once
 
-#ifdef BERTINI2_HAVE_MPI
+// NOTE: this header is intentionally NOT gated behind BERTINI2_HAVE_MPI.  The thread pool is
+// pure <thread>/<mutex>/<condition_variable> with no MPI dependency; it backs both the
+// MPI+threads hybrid worker AND the MPI-less shared-memory threaded solve.  See ADR / the
+// "MPI-less threading" plan: threading must be available in builds (and wheels) compiled
+// without any MPI installation.
 
 #include <condition_variable>
+#include <cstdlib>   // std::getenv, std::atoi
 #include <deque>
 #include <functional>
 #include <mutex>
@@ -67,6 +72,36 @@ Example:
 
 namespace bertini {
 namespace parallel {
+
+
+/**
+\brief Resolve a configured thread count to the number of worker threads to actually spawn.
+
+Precedence (highest first):
+  1. The OMP_NUM_THREADS environment variable, if set to an integer >= 1.  HPC schedulers
+     (SLURM) set this from --cpus-per-task, so honoring it keeps the MPI+threads hybrid and
+     the standalone threaded solve behaving the same under a job allocation.
+  2. The `configured` value, if >= 1 (e.g. a num_threads config knob set by the user).
+  3. std::thread::hardware_concurrency() when `configured == 0` ("auto").
+
+Always returns >= 1 (a return of 1 means "run serially, no pool").  hardware_concurrency()
+can report 0 on exotic platforms; we clamp that to 1.
+*/
+inline unsigned EffectiveThreadCount(unsigned configured = 0)
+{
+	if (const char* env = std::getenv("OMP_NUM_THREADS"))
+	{
+		int n = std::atoi(env);
+		if (n >= 1)
+			return static_cast<unsigned>(n);
+	}
+
+	if (configured >= 1)
+		return configured;
+
+	unsigned hw = std::thread::hardware_concurrency();
+	return hw >= 1 ? hw : 1u;
+}
 
 
 template<typename T>
@@ -194,5 +229,3 @@ public:
 
 } // namespace parallel
 } // namespace bertini
-
-#endif // BERTINI2_HAVE_MPI

--- a/core/test/nag_algorithms/threaded_solve.cpp
+++ b/core/test/nag_algorithms/threaded_solve.cpp
@@ -1,0 +1,277 @@
+//This file is part of Bertini 2.
+//
+//threaded_solve.cpp is free software: you can redistribute it and/or modify
+//it under the terms of the GNU General Public License as published by
+//the Free Software Foundation, either version 3 of the License, or
+//(at your option) any later version.
+//
+//threaded_solve.cpp is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//GNU General Public License for more details.
+//
+//You should have received a copy of the GNU General Public License
+//along with threaded_solve.cpp.  If not, see <http://www.gnu.org/licenses/>.
+//
+// Copyright(C) Bertini2 Development Team
+//
+// See <http://www.gnu.org/licenses/> for a copy of the license,
+// as well as COPYING.  Bertini2 is provided with permitted
+// additional terms in the b2/licenses/ directory.
+
+// individual authors of this file include:
+// silviana amethyst, university of wisconsin eau claire
+
+/**
+\file threaded_solve.cpp
+
+\brief Tests for MPI-less shared-memory threading: the WorkerThreadPool primitive and the
+threaded ZeroDim solve.  The contract is that a threaded solve produces the SAME solution set
+as a serial one -- threading is a performance feature, never a correctness change.  These run
+on every platform (no MPI required), which is what gives us cross-OS threading coverage.
+*/
+
+#include <atomic>
+#include <memory>
+#include <numeric>
+#include <set>
+#include <vector>
+
+#include <boost/test/unit_test.hpp>
+
+#include "bertini2/parallel/thread_pool.hpp"
+#include "bertini2/nag_algorithms/zero_dim_solve.hpp"
+#include "bertini2/endgames.hpp"
+#include "bertini2/system/start_systems.hpp"
+
+using Variable = bertini::node::Variable;
+using TrackerT = bertini::tracking::DoublePrecisionTracker;
+
+
+// ---------------------------------------------------------------------------
+// WorkerThreadPool: the bare concurrency primitive (no MPI, no Bertini types)
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(thread_pool)
+
+// Submit N tasks across several worker threads, collect N results, shut down cleanly.  The
+// result is order-independent, so summing checks that every task ran exactly once.
+BOOST_AUTO_TEST_CASE(thread_pool_runs_every_task_once)
+{
+	using bertini::parallel::WorkerThreadPool;
+
+	auto factory = []() { return std::unique_ptr<int>(new int(0)); };
+	auto track   = [](std::unique_ptr<int>& state, int const& task) {
+		++(*state);          // touch the per-thread state so isolation matters
+		return task * task;
+	};
+
+	const int N = 200;
+	WorkerThreadPool<int, int, decltype(factory), decltype(track)> pool(4, factory, track);
+
+	for (int i = 0; i < N; ++i)
+		pool.submit(i);
+
+	long long got = 0;
+	for (int k = 0; k < N; ++k)
+		got += pool.collect();
+
+	pool.shutdown();   // joins all worker threads; must not hang or throw
+
+	long long expected = 0;
+	for (int i = 0; i < N; ++i)
+		expected += static_cast<long long>(i) * i;
+
+	BOOST_CHECK_EQUAL(got, expected);
+}
+
+// Each thread builds its own state via the factory; states must not be shared.  We hand each
+// thread a distinct heap counter and confirm the per-thread increments sum to the task count
+// (a shared-state race would lose increments under a data race / give a wrong total).
+BOOST_AUTO_TEST_CASE(thread_pool_state_is_per_thread)
+{
+	using bertini::parallel::WorkerThreadPool;
+
+	std::atomic<int> factory_calls{0};
+
+	auto factory = [&factory_calls]() {
+		++factory_calls;
+		return std::unique_ptr<long>(new long(0));
+	};
+	auto track = [](std::unique_ptr<long>& state, int const& task) {
+		++(*state);
+		return static_cast<long>(*state);   // value is meaningful only within one thread
+	};
+
+	const int N = 500;
+	const int n_threads = 4;
+	WorkerThreadPool<int, long, decltype(factory), decltype(track)> pool(n_threads, factory, track);
+
+	for (int i = 0; i < N; ++i)
+		pool.submit(i);
+
+	long total = 0;
+	for (int k = 0; k < N; ++k)
+		total += pool.collect();
+	pool.shutdown();
+
+	// The factory runs exactly once per thread (per-thread state, not per-task).
+	BOOST_CHECK_EQUAL(factory_calls.load(), n_threads);
+	// Every task incremented some thread's private counter exactly once; the per-thread counters
+	// partition the N tasks, so the returned running-counts sum to 1+2+...+(per-thread totals).
+	// The weakest invariant that always holds regardless of scheduling: at least N (each task
+	// returned >= 1) and the counters together saw exactly N increments.
+	BOOST_CHECK_GE(total, static_cast<long>(N));
+}
+
+BOOST_AUTO_TEST_CASE(effective_thread_count_is_sane)
+{
+	using bertini::parallel::EffectiveThreadCount;
+	// An explicit positive request is honored (when OMP_NUM_THREADS is unset in the test env).
+	if (std::getenv("OMP_NUM_THREADS") == nullptr)
+	{
+		BOOST_CHECK_EQUAL(EffectiveThreadCount(1), 1u);
+		BOOST_CHECK_EQUAL(EffectiveThreadCount(3), 3u);
+		BOOST_CHECK_GE(EffectiveThreadCount(0), 1u);   // auto -> hardware_concurrency, clamped >= 1
+	}
+}
+
+BOOST_AUTO_TEST_SUITE_END()  // thread_pool
+
+
+// ---------------------------------------------------------------------------
+// Threaded ZeroDim solve == serial ZeroDim solve (the correctness contract)
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(threaded_solve)
+
+namespace {
+
+using Sol  = bertini::Vec<bertini::dbl>;
+using Sols = std::vector<Sol>;
+
+template<typename ZD>
+Sols SolveWith(ZD& zd, unsigned num_threads)
+{
+	auto cfg = zd.template Get<bertini::algorithm::ZeroDimConfig>();
+	cfg.num_threads = num_threads;
+	zd.Set(cfg);
+	zd.Solve();
+
+	Sols out;
+	for (auto const& s : zd.FiniteSolutions(/*user_coords=*/true))
+		out.push_back(s);
+	return out;
+}
+
+double Distance(Sol const& a, Sol const& b)
+{
+	if (a.size() != b.size())
+		return std::numeric_limits<double>::infinity();
+	double d = 0;
+	for (Eigen::Index i = 0; i < a.size(); ++i)
+		d += std::norm(a(i) - b(i));      // std::norm = squared magnitude
+	return std::sqrt(d);
+}
+
+// Greedy one-to-one match within tolerance -- robust to the out-of-order arrival of threaded
+// solutions (no reliance on a fragile sort of near-equal coordinates).
+void CheckSameSolutionSet(Sols const& serial, Sols const& threaded, double tol)
+{
+	BOOST_REQUIRE_EQUAL(serial.size(), threaded.size());
+
+	std::vector<bool> used(threaded.size(), false);
+	for (auto const& s : serial)
+	{
+		bool matched = false;
+		for (std::size_t j = 0; j < threaded.size(); ++j)
+		{
+			if (!used[j] && Distance(s, threaded[j]) < tol)
+			{
+				used[j] = true;
+				matched = true;
+				break;
+			}
+		}
+		BOOST_CHECK_MESSAGE(matched, "a serial solution had no threaded counterpart within tolerance");
+	}
+}
+
+// {x^2 - 1, y^2 - 1}: four well-separated nonsingular roots (+/-1, +/-1).  Total degree 4 paths.
+bertini::System TwoQuadrics()
+{
+	using namespace bertini;
+	auto x = Variable::Make("x");
+	auto y = Variable::Make("y");
+	System sys;
+	sys.AddFunction(pow(x, 2) - 1);
+	sys.AddFunction(pow(y, 2) - 1);
+	sys.AddVariableGroup(VariableGroup{x, y});
+	return sys;
+}
+
+// A denser system: {x^3 - x, y^3 - y} -> 9 total-degree paths, 9 finite roots -- more paths than
+// cores, so the pool genuinely round-robins work across threads.
+bertini::System TwoCubics()
+{
+	using namespace bertini;
+	auto x = Variable::Make("x");
+	auto y = Variable::Make("y");
+	System sys;
+	sys.AddFunction(pow(x, 3) - x);
+	sys.AddFunction(pow(y, 3) - y);
+	sys.AddVariableGroup(VariableGroup{x, y});
+	return sys;
+}
+
+template<typename MakeSys>
+void ThreadedMatchesSerial(MakeSys make_sys, std::size_t expected_finite)
+{
+	using namespace bertini;
+
+	// Independent solver objects (CloneGiven copies the system), so the two solves share no state.
+	auto sys_serial = make_sys();
+	auto sys_thread = make_sys();
+
+	using ZD = algorithm::ZeroDim<TrackerT, endgame::EndgameSelector<TrackerT>::Cauchy,
+	                              System, start_system::TotalDegree>;
+
+	ZD zd_serial(sys_serial);  zd_serial.DefaultSetup();
+	ZD zd_thread(sys_thread);  zd_thread.DefaultSetup();
+
+	auto serial = SolveWith(zd_serial, 1);
+	BOOST_REQUIRE_EQUAL(serial.size(), expected_finite);
+
+	for (unsigned nt : {2u, 4u})
+	{
+		auto threaded = SolveWith(zd_thread, nt);
+		CheckSameSolutionSet(serial, threaded, 1e-6);
+	}
+}
+
+} // namespace
+
+BOOST_AUTO_TEST_CASE(threaded_matches_serial_two_quadrics)
+{
+	ThreadedMatchesSerial([]{ return TwoQuadrics(); }, 4u);
+}
+
+BOOST_AUTO_TEST_CASE(threaded_matches_serial_two_cubics)
+{
+	ThreadedMatchesSerial([]{ return TwoCubics(); }, 9u);
+}
+
+// num_threads == 1 must be byte-for-byte the pool-free serial path -- a regression guard that the
+// thread-count branch in Solve() does not perturb the default (serial) result.
+BOOST_AUTO_TEST_CASE(num_threads_one_equals_default_solve)
+{
+	using namespace bertini;
+	auto sys = TwoQuadrics();
+	using ZD = algorithm::ZeroDim<TrackerT, endgame::EndgameSelector<TrackerT>::Cauchy,
+	                              System, start_system::TotalDegree>;
+	ZD zd(sys); zd.DefaultSetup();
+	auto one = SolveWith(zd, 1);
+	BOOST_CHECK_EQUAL(one.size(), 4u);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/core/test/nag_algorithms/threaded_solve.cpp
+++ b/core/test/nag_algorithms/threaded_solve.cpp
@@ -274,4 +274,70 @@ BOOST_AUTO_TEST_CASE(num_threads_one_equals_default_solve)
 	BOOST_CHECK_EQUAL(one.size(), 4u);
 }
 
+
+// A solver-level observer that records, per PathStarted, which tracker actually ran the path
+// (event.Tracker()).  Because notifications are mutex-serialized, the set insert below is safe
+// even when PathStarted fires from several worker threads -- so this also exercises the
+// Observable notify mutex under concurrency.
+struct TrackerCapture : public bertini::Observer<bertini::algorithm::AnyZeroDim>
+{
+	std::set<bertini::Observable const*> trackers_seen;
+	bool                                 saw_null = false;
+	int                                  path_starts = 0;
+
+	bertini::ObserveResult Observe(bertini::AnyEvent const& e) override
+	{
+		using namespace bertini::algorithm;
+		if (auto p = dynamic_cast<PathStarted<AnyZeroDim> const*>(&e))
+		{
+			++path_starts;
+			if (p->Tracker() == nullptr) saw_null = true;
+			else                         trackers_seen.insert(p->Tracker());
+		}
+		return bertini::ObserveResult::KeepObserving;
+	}
+};
+
+// Serial: every path's event.Tracker() is the solver's own member tracker.
+BOOST_AUTO_TEST_CASE(event_tracker_is_member_tracker_when_serial)
+{
+	using namespace bertini;
+	auto sys = TwoCubics();
+	using ZD = algorithm::ZeroDim<TrackerT, endgame::EndgameSelector<TrackerT>::Cauchy,
+	                              System, start_system::TotalDegree>;
+	ZD zd(sys); zd.DefaultSetup();
+
+	TrackerCapture cap;
+	zd.AddObserver(cap);
+	SolveWith(zd, 1);
+
+	auto const* member = static_cast<Observable const*>(&zd.GetTracker());
+	BOOST_CHECK_EQUAL(cap.path_starts, 9);
+	BOOST_CHECK(!cap.saw_null);
+	BOOST_REQUIRE_EQUAL(cap.trackers_seen.size(), 1u);   // one tracker ran every path
+	BOOST_CHECK(*cap.trackers_seen.begin() == member);
+}
+
+// Threaded: every path's event.Tracker() is a thread-local clone, never the member tracker --
+// which is exactly why a meta-observer must attach to event.tracker(), not solver.GetTracker().
+BOOST_AUTO_TEST_CASE(event_tracker_is_a_clone_when_threaded)
+{
+	using namespace bertini;
+	auto sys = TwoCubics();
+	using ZD = algorithm::ZeroDim<TrackerT, endgame::EndgameSelector<TrackerT>::Cauchy,
+	                              System, start_system::TotalDegree>;
+	ZD zd(sys); zd.DefaultSetup();
+
+	TrackerCapture cap;
+	zd.AddObserver(cap);
+	SolveWith(zd, 4);
+
+	auto const* member = static_cast<Observable const*>(&zd.GetTracker());
+	BOOST_CHECK_EQUAL(cap.path_starts, 9);
+	BOOST_CHECK(!cap.saw_null);
+	BOOST_CHECK(cap.trackers_seen.count(member) == 0);   // never the member tracker
+	BOOST_CHECK(!cap.trackers_seen.empty());
+	BOOST_CHECK(cap.trackers_seen.size() <= 4u);          // at most one clone per worker thread
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/python/bertini/nag_algorithm/__init__.py
+++ b/python/bertini/nag_algorithm/__init__.py
@@ -657,7 +657,12 @@ class SolutionPathCollector(_pybnalag.observers.CustomObserver):
     def Observe(self, event):
         obs = _pybnalag.observers
         if isinstance(event, obs.PathStarted):
-            tracker = event.solver().get_tracker()
+            # event.tracker() is the tracker that ACTUALLY runs this path: the solver's member
+            # tracker in a serial solve, or the thread-local clone in a threaded solve.  Attaching
+            # here (rather than to event.solver().get_tracker()) is what makes per-path collection
+            # work identically with and without threads -- under threading the member tracker runs
+            # nothing, so collecting from it would silently yield empty series.
+            tracker = event.tracker()
             # tracker.observers is the precision-appropriate module (set in bertini.tracking)
             collector = tracker.observers.PathDataCollector()
             collector.path_index = event.path_index()

--- a/python/bertini/nag_algorithm/__init__.py
+++ b/python/bertini/nag_algorithm/__init__.py
@@ -628,6 +628,58 @@ def moving_homotopy(fixed, start_moving, end_moving, *, path_variable='t', gamma
     return _system.make_moving_homotopy(fixed, start_moving, end_moving, path_variable, gamma)
 
 
+def parameter_sweep(make_system, generic_parameters, target_parameters,
+                    *, mptype='adaptive', endgame='cauchy'):
+    """Solve a whole family of systems that differ only in their coefficients.
+
+    This is the *parameter homotopy* workhorse: pay for the hard ab-initio solve **once**, at a
+    generic parameter value, then reach every parameter point you actually care about by cheap
+    tracking that reuses those start solutions.
+
+    Parameters
+    ----------
+    make_system : callable
+        ``make_system(parameters) -> bertini.System``.  Must return systems of the SAME shape
+        every call -- same variables and same monomials -- with only the coefficient *values*
+        depending on ``parameters``.  (Until first-class coefficient parameters land, this factory
+        is how you say "the same system at a different parameter value".)
+    generic_parameters
+        The parameter value for the one-time generic solve.  For robustness this should be
+        *generic* -- random complex values -- so the straight-line coefficient path to each target
+        avoids the measure-zero singular locus.
+    target_parameters : iterable
+        The parameter values you want solved.  Returned solvers line up with this order.
+    mptype, endgame
+        Passed through to the solves (see :func:`ZeroDim`).
+
+    Returns
+    -------
+    list of solved ZeroDim solvers, one per entry of ``target_parameters``.  Each gives you
+    ``.all_solutions()``, ``.solution_metadata()`` and ``.to_dataframe()`` (let the solver do the
+    real/finite classification -- don't redo it by hand).
+
+    Notes
+    -----
+    The targets are independent, which is exactly what makes this *embarrassingly parallel*:
+    distribute ``target_parameters`` across MPI ranks (one slice per rank) and let each rank's
+    solve thread its own path tracking.  That is the two-level model -- MPI across parameter
+    points, threads across paths -- demonstrated in the parameter-homotopy tutorial.
+    """
+    generic = make_system(generic_parameters)
+    gen_solver = ZeroDim(generic, mptype=mptype, endgame=endgame)
+    gen_solver.solve()
+    start_points = gen_solver.all_solutions()
+
+    solvers = []
+    for params in target_parameters:
+        target = make_system(params)
+        H = coefficient_parameter_homotopy(target, generic)
+        solver = user_homotopy(H, start_points, target, precision=mptype, endgame=endgame)
+        solver.solve()
+        solvers.append(solver)
+    return solvers
+
+
 # --- SolutionPathCollector: collect every solution path of a whole solve, for plotting ---
 #
 # A two-level meta-observer.  Attach one to a ZeroDim solver; on each PathStarted it spins
@@ -683,6 +735,7 @@ __all__ = dir(_pybnalag)
 __all__.append('ZeroDim')
 __all__.append('user_homotopy')
 __all__.append('coefficient_parameter_homotopy')
+__all__.append('parameter_sweep')
 __all__.append('moving_homotopy')
 __all__.append('blend_homotopy')
 __all__.append('SolutionPathCollector')

--- a/python/bertini/nag_algorithm/__init__.py
+++ b/python/bertini/nag_algorithm/__init__.py
@@ -629,12 +629,13 @@ def moving_homotopy(fixed, start_moving, end_moving, *, path_variable='t', gamma
 
 
 def parameter_sweep(make_system, generic_parameters, target_parameters,
-                    *, mptype='adaptive', endgame='cauchy'):
+                    *, collect=None, comm=None, mptype='adaptive', endgame='cauchy'):
     """Solve a whole family of systems that differ only in their coefficients.
 
     This is the *parameter homotopy* workhorse: pay for the hard ab-initio solve **once**, at a
     generic parameter value, then reach every parameter point you actually care about by cheap
-    tracking that reuses those start solutions.
+    tracking that reuses those start solutions.  It is also the unit of parallelism -- the points
+    are independent, so pass an MPI communicator and the sweep spreads across the ranks for you.
 
     Parameters
     ----------
@@ -648,36 +649,74 @@ def parameter_sweep(make_system, generic_parameters, target_parameters,
         *generic* -- random complex values -- so the straight-line coefficient path to each target
         avoids the measure-zero singular locus.
     target_parameters : iterable
-        The parameter values you want solved.  Returned solvers line up with this order.
+        The parameter values you want solved.  Results line up with this order.
+    collect : callable, optional
+        ``collect(solver) -> value``.  If given, each solved point is reduced to ``collect(solver)``
+        and the return is the list of those values (instead of the solvers).  **Required** when
+        ``comm`` is given -- solver objects cannot cross MPI ranks, so what is gathered must be a
+        picklable value (e.g. a solution count, or ``solver.to_dataframe()``).
+    comm : mpi4py communicator, optional
+        If given, ``target_parameters`` is split across the ranks (each rank solves the generic
+        once, then tracks its slice -- with the path tracking inside each solve threaded across the
+        rank's cores via ``OMP_NUM_THREADS``).  The collected results are gathered and **every rank
+        returns the full list in the original order**.  This is the two-level model: MPI across
+        parameter points, threads across paths -- one extra argument, no manual scatter/gather.
     mptype, endgame
         Passed through to the solves (see :func:`ZeroDim`).
 
     Returns
     -------
-    list of solved ZeroDim solvers, one per entry of ``target_parameters``.  Each gives you
-    ``.all_solutions()``, ``.solution_metadata()`` and ``.to_dataframe()`` (let the solver do the
-    real/finite classification -- don't redo it by hand).
+    list, one entry per ``target_parameters``: the solved :class:`ZeroDim` solvers, or -- if
+    ``collect`` is given -- the ``collect(solver)`` values.  A solver exposes ``.all_solutions()``,
+    ``.solution_metadata()`` and ``.to_dataframe()`` (let the solver do the real/finite
+    classification -- don't redo it by hand).
 
-    Notes
-    -----
-    The targets are independent, which is exactly what makes this *embarrassingly parallel*:
-    distribute ``target_parameters`` across MPI ranks (one slice per rank) and let each rank's
-    solve thread its own path tracking.  That is the two-level model -- MPI across parameter
-    points, threads across paths -- demonstrated in the parameter-homotopy tutorial.
+    Examples
+    --------
+    Serial / threaded (threads are automatic -- a solve uses all cores by default)::
+
+        solvers = parameter_sweep(make_system, generic, targets)
+        counts  = [positive_real_count(s) for s in solvers]
+
+    Across MPI ranks, threads within -- the user-facing MPI code is just ``comm=`` and ``collect=``::
+
+        from mpi4py import MPI
+        counts = parameter_sweep(make_system, generic, targets,
+                                 collect=positive_real_count, comm=MPI.COMM_WORLD)
+        # every rank now holds the full `counts` list, in `targets` order
     """
+    targets = list(target_parameters)
+    if comm is not None and collect is None:
+        raise ValueError("parameter_sweep(comm=...) needs collect=<solver -> picklable value>: "
+                         "solver objects cannot be gathered across MPI ranks.")
+
+    if comm is None:
+        my_indices = range(len(targets))
+    else:
+        my_indices = range(comm.Get_rank(), len(targets), comm.Get_size())
+
     generic = make_system(generic_parameters)
     gen_solver = ZeroDim(generic, mptype=mptype, endgame=endgame)
     gen_solver.solve()
     start_points = gen_solver.all_solutions()
 
-    solvers = []
-    for params in target_parameters:
-        target = make_system(params)
+    local = []   # (index, solver-or-collected) for this rank's slice, in index order
+    for i in my_indices:
+        target = make_system(targets[i])
         H = coefficient_parameter_homotopy(target, generic)
         solver = user_homotopy(H, start_points, target, precision=mptype, endgame=endgame)
         solver.solve()
-        solvers.append(solver)
-    return solvers
+        local.append((i, collect(solver) if collect is not None else solver))
+
+    if comm is None:
+        return [value for _, value in local]
+
+    # Gather every rank's (index, value) pairs and reassemble in the original target order, so
+    # every rank returns the same full list.
+    merged = {}
+    for chunk in comm.allgather(local):
+        merged.update(dict(chunk))
+    return [merged[i] for i in range(len(targets))]
 
 
 # --- SolutionPathCollector: collect every solution path of a whole solve, for plotting ---

--- a/python/docs/source/tutorials/observers_and_path_data.rst
+++ b/python/docs/source/tutorials/observers_and_path_data.rst
@@ -196,7 +196,9 @@ path in the complex plane:
 If instead you want the bare tracker-level building block (one series per *track*, with endgame
 sub-tracks kept separate), attach a ``bertini.tracking.observers.<precision>.PathCollectionObserver``
 to ``solver.get_tracker()`` directly; each of its series is tagged with a ``start_time`` so you can
-tell main tracks from endgame loops.
+tell main tracks from endgame loops.  (Attaching to ``solver.get_tracker()`` like this only collects
+in a **serial** solve -- set ``num_threads = 1`` first; see *Observers, threads, and MPI* below for
+why, and use ``SolutionPathCollector`` if you want it to work threaded.)
 
 Build it yourself: one observer that attaches another
 =====================================================
@@ -252,9 +254,9 @@ the path finishes, B hands its haul back to A.
 
         def Observe(self, event):
             if isinstance(event, nag_observers.PathStarted):
-                tracker = event.solver().get_tracker()
-                b = PathRecorder(self, event.path_index())
-                tracker.add_observer(b)                  # attach B ...
+                tracker = event.tracker()      # the tracker that RUNS this path (a thread-local
+                b = PathRecorder(self, event.path_index())   # clone when threaded -- not the member
+                tracker.add_observer(b)                  # attach B ...   tracker)
                 self._active[event.path_index()] = (tracker, b)
             elif isinstance(event, nag_observers.PathComplete):
                 tracker, b = self._active.pop(event.path_index())
@@ -280,6 +282,7 @@ Attach **A** to the solver and run -- one entry in ``A.paths`` per solution path
     solver.solve()
 
     assert len(A.paths) == 6                  # same six paths SolutionPathCollector would give you
+    assert all(len(times) > 0 for times, _ in A.paths.values())   # each path actually captured steps
 
 The subtle part is that A's ``add_observer``/``remove_observer`` calls happen *from inside* B's
 sibling notification -- A is mutating the tracker's observer list while the solver is mid-dispatch.
@@ -290,6 +293,69 @@ disturbs the dispatch in flight.  Attach-and-forget, compose freely.
 This hand-built ``MyPathCollector`` is essentially ``SolutionPathCollector`` -- the real one just
 reuses the ready-made ``PathDataCollector`` for B (so you get diagnostics and ``as_dataframe()``
 too) and harvests the collector object itself instead of a plain tuple.
+
+Observers, threads, and MPI
+===========================
+
+A zero-dimensional solve is **multi-threaded by default** -- it uses all your cores, tracking many
+paths at once.  That has one consequence you must know when writing observers, and it is the whole
+reason the examples above call ``event.tracker()``.
+
+Under threading, **each path runs on its own thread-local *clone* of the tracker**, not on the
+solver's one member tracker.  (A fresh tracker copy starts with an empty observer list -- which is
+exactly what makes it safe to hand to another thread.)  So:
+
+.. note::
+
+   Attaching a per-path observer to ``solver.get_tracker()`` collects **nothing** during a threaded
+   solve: the member tracker runs no paths.  Always attach to **event.tracker()** -- the tracker
+   that actually runs *this* path -- as the meta-observers above do.  ``event.tracker()`` is the
+   member tracker in a serial solve and the running clone in a threaded one, so the same code is
+   correct either way.
+
+Everything else the framework handles for you.  Your Python ``Observe`` is called safely from the
+worker threads: notifications are serialized and the GIL is re-acquired around each call, so you
+never see two ``Observe`` calls at once and never corrupt your own Python state.  The flip side is
+that a *heavy* ``Observe`` serializes the threads against each other -- keep it to copying values
+out (as ``PathRecorder`` does); do the plotting and analysis afterwards.
+
+Two more things to expect under threads:
+
+* **Paths complete out of order.**  ``PathComplete`` arrives in finish order, not ``path_index``
+  order.  Key your bookkeeping by ``event.path_index()`` (the collectors above do) and sort at the
+  end if you need a stable order.
+* **Force serial when you must.**  To pin a solve to one thread -- e.g. to attach directly to the
+  member tracker, or for a fully reproducible event order -- set ``num_threads = 1``:
+
+.. testcode::
+
+    from bertini.nag_algorithm import ZeroDim, SolutionPathCollector
+    import bertini
+
+    z = bertini.Variable('z')
+    sys = bertini.System()
+    sys.add_variable_group(bertini.VariableGroup([z]))
+    sys.add_function(z**6 - 2*z**2 + 2)
+
+    solver = ZeroDim(sys, mptype='adaptive')
+    cfg = solver.get_config(bertini.nag_algorithm.ZeroDimConfig)
+    cfg.num_threads = 1                 # 0 = auto (all cores), 1 = serial, N = N threads
+    solver.set_config(cfg)
+
+    A = SolutionPathCollector()         # works the same in serial and threaded
+    solver.add_observer(A)
+    solver.solve()
+    assert len(A.series) == 6
+
+Under **MPI** the picture is different again, and observers do **not** span ranks.  In a distributed
+solve the manager rank coordinates while the *worker* ranks track the paths, so the per-path events
+(``PathStarted``/``PathComplete`` and every tracker step) fire **inside the worker processes** --
+not on the manager where you launched the solve.  An observer is a per-process object: it only sees
+the events emitted in *its* process.  To collect path data across an MPI run you attach observers on
+the workers and gather their results yourself with MPI (e.g. ``comm.gather``); a single observer on
+rank 0 will not see the paths.  For shared-memory threading there is nothing to gather -- the worker
+threads share the one process, which is why ``SolutionPathCollector`` "just works" with threads but
+needs help under MPI.
 
 A 3-D system, coloured by condition number
 ==========================================

--- a/python/docs/source/tutorials/parallel_parameter_homotopy.rst
+++ b/python/docs/source/tutorials/parallel_parameter_homotopy.rst
@@ -1,0 +1,162 @@
+⚗️ A bistable reaction network, mapped in parallel
+***************************************************
+
+.. testsetup:: *
+
+   import bertini
+
+A **parameter homotopy** is the right tool whenever you must solve the *same* polynomial system
+over and over at *different* coefficient values -- a parameter sweep.  You pay for one hard solve
+at a generic parameter, then reach every value you care about by cheap tracking that reuses those
+start solutions (the :doc:`parameter_homotopy` tutorial introduces the idea).  This tutorial puts
+that to work on a real problem and then makes it *parallel on two levels at once*:
+
+* **MPI across the parameter points** -- the points are independent, so hand each compute node a
+  slice of them;
+* **threads across the paths** -- inside each point's solve, track the paths on all of that node's
+  cores (this is automatic -- a solve is multi-threaded by default).
+
+The driving problem is a **chemical reaction network** and the question is *multistationarity*:
+for which rate constants does the network have more than one steady state?
+
+The Schlögl model
+=================
+
+The Schlögl network is the textbook example of a bistable reaction network.  Its single species
+:math:`X` has a steady state wherever production balances degradation, which works out to a cubic:
+
+.. math::
+
+   k_2\,X^3 \;-\; k_1\,X^2 \;+\; k_4\,X \;-\; k_3 \;=\; 0 .
+
+The rate constants :math:`k_1,\dots,k_4` are the parameters, and they live in the **positive
+orthant** (rates are positive).  A *steady state* is a **positive real** root.  By Descartes' rule
+of signs this cubic has either **one** or **three** positive real roots -- monostable or bistable
+-- and which one depends on where you are in parameter space.  Mapping that boundary is the goal.
+
+The family is one system at many coefficient values, so we build it with a factory over **shared**
+variables (a parameter homotopy interpolates coefficients, so every member must use the same
+``Variable`` object):
+
+.. testcode::
+
+   import bertini
+   from bertini.nag_algorithm import parameter_sweep
+
+   X = bertini.Variable('X')
+
+   def make_system(params):
+       k1, k2, k3, k4 = params
+       sys = bertini.System()
+       sys.add_variable_group(bertini.VariableGroup([X]))
+       sys.add_function(k2*X*X*X - k1*X*X + k4*X - k3)
+       return sys
+
+Let the solver do the classification
+====================================
+
+"How many positive real steady states?" is a question about the solutions' *classification* --
+which are real, which are finite -- and the solver already answers it.  ``solver.to_dataframe()``
+hands back a pandas DataFrame with an ``is_real`` and ``is_finite`` column per solution (plus
+multiplicity and more), so we never re-derive real-ness with a hand-rolled tolerance; we just read
+the flags and keep the positive ones:
+
+.. testcode::
+
+   def positive_real_count(solver):
+       df = solver.to_dataframe()
+       n = 0
+       for _, row in df.iterrows():
+           if row['is_real'] and row['is_finite']:
+               sol = row['solution']
+               x = complex(sol[0] if hasattr(sol, '__len__') else sol)
+               if x.real > 1e-9:
+                   n += 1
+       return n
+
+The sweep
+=========
+
+:func:`~bertini.nag_algorithm.parameter_sweep` is the whole engine: give it the factory, one
+*generic* (random complex) parameter value to solve once, and the list of parameter values you
+actually want.  It solves the generic member, then tracks to every target reusing those start
+solutions.  Here we sweep a grid of :math:`(k_1, k_3)` with :math:`k_2 = 1, k_4 = 11` fixed, and
+reduce each solve straight to its positive-real count with ``collect``:
+
+.. testcode::
+
+   import numpy as np
+   C = bertini.multiprec.Complex
+   def real_coeff(v):  return C(repr(float(v)), "0")   # an exact real coefficient
+
+   generic = (C("0.7","0.4"), C("1","0.3"), C("0.31","-0.52"), C("1.2","0.9"))
+
+   k1s = np.linspace(4.0, 8.0, 5)
+   k3s = np.linspace(2.0, 10.0, 5)
+   targets = [(real_coeff(k1), real_coeff(1), real_coeff(k3), real_coeff(11))
+              for k3 in k3s for k1 in k1s]
+
+   counts = parameter_sweep(make_system, generic, targets, collect=positive_real_count)
+
+   counts = np.array(counts).reshape(len(k3s), len(k1s))
+   assert set(counts.ravel()) <= {1, 3}      # Descartes: only 1 or 3 positive real roots
+   assert (counts == 3).any()                # ... and the bistable region is in this window
+
+That ``parameter_sweep`` call was already **threaded** -- a solve uses every core by default, so
+the path tracking inside each grid point ran in parallel with no extra code.  For most users, on
+one machine, that is the whole story: parallelism for free through the ordinary interface.
+
+Going wide: MPI across the grid
+===============================
+
+The grid points are independent, so to use *many machines* you hand each MPI rank a slice of the
+grid.  ``parameter_sweep`` does the splitting and gathering for you -- pass a communicator and a
+``collect`` (only the reduced value crosses ranks, since solver objects cannot), and **every rank
+comes back with the full list of counts**:
+
+.. code-block:: python
+
+   from mpi4py import MPI
+   counts = parameter_sweep(make_system, generic, targets,
+                            collect=positive_real_count, comm=MPI.COMM_WORLD)
+   # one extra argument (comm=) is the entire difference from the serial version
+
+That is the two-level model in one call: MPI spreads the *points* across ranks, and each rank's
+solves thread the *paths* across its cores.  The complete, runnable script -- which builds the
+grid, runs the sweep, and draws the map -- is
+:download:`parallel_parameter_homotopy.py <../../../examples/parallel_parameter_homotopy.py>`:
+
+.. literalinclude:: ../../../examples/parallel_parameter_homotopy.py
+   :language: python
+   :caption: examples/parallel_parameter_homotopy.py
+   :start-after: X = pb.Variable('X')
+   :end-before: def main()
+
+Run it serially, or across ranks with threads inside each (the ``--bind-to none`` and
+``--map-by`` notes from :doc:`solving_at_scale` apply -- and always run a *file*, never a heredoc)::
+
+   python parallel_parameter_homotopy.py --grid 28 --save schlogl.svg     # serial + threads
+   OMP_NUM_THREADS=3 mpirun -n 4 --bind-to none \
+       python parallel_parameter_homotopy.py --grid 28 --save schlogl.svg # 4 ranks x 3 threads
+
+Both produce the **identical** map -- parallelism changes the wall-clock, never the answer:
+
+.. figure:: parallel_parameter_homotopy.svg
+   :align: center
+   :width: 75%
+
+   The Schlögl network's steady states over a slice of its positive-orthant parameter space.  The
+   red tongue is the **bistable** region -- three positive real steady states; outside it there is
+   one.  Each pixel is one parameter homotopy track; the picture is an MPI-across-pixels,
+   threads-within-pixel solve.
+
+Where to go from here
+=====================
+
+* Swap in your own network: any steady-state system that is *one shape with varying coefficients*
+  drops straight into ``make_system`` + ``parameter_sweep``.  Richer networks have more paths per
+  point, so the per-point threading earns more.
+* Push ``--grid`` up and spread the ranks across a cluster with a hostfile
+  (``mpirun --hostfile hosts ...``); the sweep code does not change.
+* See :doc:`solving_at_scale` for the other axis -- distributing the *paths of a single solve*
+  across ranks -- and :doc:`observers_and_path_data` to watch the tracking itself.

--- a/python/docs/source/tutorials/parallel_parameter_homotopy.svg
+++ b/python/docs/source/tutorials/parallel_parameter_homotopy.svg
@@ -1,0 +1,1225 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="432pt" height="360pt" viewBox="0 0 432 360" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-06-27T16:00:47.700134</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.9, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 360 
+L 432 360 
+L 432 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 47.108 313 
+L 346.3816 313 
+L 346.3816 25.44 
+L 47.108 25.44 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g clip-path="url(#pfe13901eb9)">
+    <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAAaAAAAGQCAYAAADoTLT0AAAGI0lEQVR4nO3dsW3DMBBAUTnwQm60VhqOkUaFl9JSDpC0KQIbyI/E9xqVFNh8XHO83Nb7YwGmMfat/gX48vb9AYC/JUAAJAQIgIQAAZAQIAASAgRAQoAASAgQAAkBAiAhQAAkBAiAhAABkBAgABICBEBCgABICBAACQECICFAACQECICEAAGQECAAEgIEQEKAAEgIEAAJAQIgIUAAJAQIgIQAAZC4NscCrxj75gI5PBMQAAkBAiAhQAAkBAiAhAABkBAgABICBEBCgABICBAACQECICFAACQECICEAAGQECAAEgIEQEKAAEgIEAAJAQIgIUAAJAQIgIQAAZAQIAASAgRAQoAASAgQAAkBAiAhQAAkBAiAhAABIEAAzMMEBEBCgABICBAACQECICFAACQECICEAAGQECAAEgIEQEKAAEgIEAAJAQIgIUAAJAQIgIQAAZAQIAASAgRAQoAASAgQAAkBAiAhQAAkBAiAhAABkBAgABICBEBCgABIXJtjgbFvLoGpmYAASAgQAAkBAiAhQAAkBAiAhAABkBAgABICBEBCgABICBAACQECICFAACQECICEbdgAJ/Cxvi9HYwICICFAACQECICEAAGQECAAEgIEQEKAAEgIEAAJAQIgIUAAJAQIgIQAAZAQIAAStmEDnGS79NGYgABICBAACQECQIAAmIcJCICEAAGQECAAEgIEQEKAAEgIEAAJAQIgIUAAJAQIgIQAAZDwHAO8YOyb+/sFTxvwExMQAAkBAiAhQAAkBAiAhAABkBAgABICBEBCgABICBAACQECICFAACQECICEAAGQsA0bJmMzNf+FCQiAhAABkBAgABICBEBCgABICBAACQECICFAACQECICEAAGQECAAEgIEQEKAAEjYhg0HZKM1Z2ACAiAhQAAkBAiAhAABkBAgABICBEBCgABICBAACQECICFAACQECICEAAGQECAAErZhM72xb0/fga3U8DwTEAAJAQIgIUAAJAQIgIQAAZAQIAASAgRAQoAASAgQAAkBAiAhQAAkBAiAhAABkBAgABKX23p/NEcDMDMTEAAJAQIgIUAAJAQIgIQAAZAQIAASAgRAQoAASAgQAAkBAiAhQAAkBAiAhAABkBAgABICBEBCgABICBAACQECICFAACQECICEAAGQECAAEgIEQEKAAEgIEAAJAQIgIUAAJAQIgIQAAZAQIAASAgRAQoAASAgQAAkBAiAhQAAkBAiAhAABkBAgABICBEBCgABICBAACQECICFAACQECICEAAGQECAAEgIEQEKAAEgIEAAJAQIgIUAAJAQIgIQAAZAQIAASAgRAQoAASAgQAAkBAiAhQAAkBAiAhAABkBAgABICBEBCgABICBAACQECICFAACQECICEAAGQECAAEgIEQEKAAEgIEAAJAQIgIUAAJAQIgIQAAZAQIAASAgRAQoAASAgQAAkBAiAhQAAkBAiAhAABkBAgABICBEBCgABICBAACQECICFAACQECICEAAGQECAAEgIEQEKAAEgIEAAJAQIgIUAAJAQIgIQAAZAQIAASAgRAQoAASAgQAAkBAiAhQAAkBAiAhAABkBAgABICBEBCgABICBAACQECICFAACQECICEAAGQECAAEgIEQEKAAEgIEAAJAQIgIUAAJAQIgIQAAZAQIAASAgRAQoAASAgQAAkBAiAhQAAkBAiAhAABkBAgABICBEBCgABICBAACQECICFAACQECICEAAGQECAAEgIEQEKAAEgIEAAJAQIgIUAAJAQIgIQAAZAQIAASAgRAQoAASAgQAAkBAiAhQAAkBAiAhAABkBAgABICBEBCgABICBAACQECICFAACQECICEAAGQECAAEgIEQEKAAEgIEAAJAQIgIUAAJAQIgIQAAZAQIAASAgRAQoAASAgQAAkBAiAhQAAkBAiAhAABkBAgABICBEBCgABICBAACQECICFAACQECICEAAGQECAAEgIEQEKAAEgIEAAJAQIgIUAAJAQIgIQAAZAQIAASAgRAQoAASAgQAAkBAiAhQAAkBAiAhAABkBAgABICBEBCgABICBAACQECICFAACQECICEAAGwFD4BlGgXVjjYk/EAAAAASUVORK5CYII=" id="image8126856d63" transform="scale(1 -1) translate(0 -288)" x="47.108" y="-25" width="299.52" height="288"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="m9ede6c0294" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m9ede6c0294" x="77.03536" y="313" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 4 -->
+      <g transform="translate(73.85411 327.598437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-34"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#m9ede6c0294" x="136.89008" y="313" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 5 -->
+      <g transform="translate(133.70883 327.598437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-35"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#m9ede6c0294" x="196.7448" y="313" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 6 -->
+      <g transform="translate(193.56355 327.598437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-36"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m9ede6c0294" x="256.59952" y="313" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 7 -->
+      <g transform="translate(253.41827 327.598437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-37"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_5">
+      <g>
+       <use xlink:href="#m9ede6c0294" x="316.45424" y="313" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 8 -->
+      <g transform="translate(313.27299 327.598437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-38"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_6">
+     <!-- $k_1$ (X$^2$ rate) -->
+     <g transform="translate(168.3948 342.398438) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-Oblique-6b" d="M 1172 4863 
+L 1747 4863 
+L 1197 2028 
+L 3169 3500 
+L 3916 3500 
+L 1716 1825 
+L 3322 0 
+L 2625 0 
+L 1131 1709 
+L 800 0 
+L 225 0 
+L 1172 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-28" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-58" d="M 403 4666 
+L 1081 4666 
+L 2241 2931 
+L 3406 4666 
+L 4084 4666 
+L 2584 2425 
+L 4184 0 
+L 3506 0 
+L 2194 1984 
+L 872 0 
+L 191 0 
+L 1856 2491 
+L 403 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-29" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-Oblique-6b" transform="translate(0 0.765625)"/>
+      <use xlink:href="#DejaVuSans-31" transform="translate(57.910156 -15.640625) scale(0.7)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(105.180664 0.765625)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(136.967773 0.765625)"/>
+      <use xlink:href="#DejaVuSans-58" transform="translate(175.981445 0.765625)"/>
+      <use xlink:href="#DejaVuSans-32" transform="translate(245.444336 39.046875) scale(0.7)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(292.714844 0.765625)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(324.501953 0.765625)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(365.615234 0.765625)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(426.894531 0.765625)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(466.103516 0.765625)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(527.626953 0.765625)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_6">
+      <defs>
+       <path id="m2b1d3dea54" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m2b1d3dea54" x="47.108" y="289.036667" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 2 -->
+      <g transform="translate(33.7455 292.835885) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_7">
+      <g>
+       <use xlink:href="#m2b1d3dea54" x="47.108" y="241.11" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 4 -->
+      <g transform="translate(33.7455 244.909219) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-34"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m2b1d3dea54" x="47.108" y="193.183333" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 6 -->
+      <g transform="translate(33.7455 196.982552) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-36"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#m2b1d3dea54" x="47.108" y="145.256667" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 8 -->
+      <g transform="translate(33.7455 149.055885) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-38"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m2b1d3dea54" x="47.108" y="97.33" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 10 -->
+      <g transform="translate(27.383 101.129219) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_11">
+      <g>
+       <use xlink:href="#m2b1d3dea54" x="47.108" y="49.403333" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- 12 -->
+      <g transform="translate(27.383 53.202552) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_13">
+     <!-- $k_3$ (influx) -->
+     <g transform="translate(21.303313 193.82) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-66" d="M 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1395 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2222 3500 
+L 2222 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-78" d="M 3513 3500 
+L 2247 1797 
+L 3578 0 
+L 2900 0 
+L 1881 1375 
+L 863 0 
+L 184 0 
+L 1544 1831 
+L 300 3500 
+L 978 3500 
+L 1906 2253 
+L 2834 3500 
+L 3513 3500 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-Oblique-6b" transform="translate(0 0.015625)"/>
+      <use xlink:href="#DejaVuSans-33" transform="translate(57.910156 -16.390625) scale(0.7)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(105.180664 0.015625)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(136.967773 0.015625)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(175.981445 0.015625)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(203.764648 0.015625)"/>
+      <use xlink:href="#DejaVuSans-66" transform="translate(267.143555 0.015625)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(302.348633 0.015625)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(330.131836 0.015625)"/>
+      <use xlink:href="#DejaVuSans-78" transform="translate(393.510742 0.015625)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(452.69043 0.015625)"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 47.108 313 
+L 47.108 25.44 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 346.3816 313 
+L 346.3816 25.44 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 47.108 313 
+L 346.3816 313 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 47.108 25.44 
+L 346.3816 25.44 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_14">
+    <!-- Schlögl model: bistability region -->
+    <g transform="translate(100.277925 19.44) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-53" d="M 3425 4513 
+L 3425 3897 
+Q 3066 4069 2747 4153 
+Q 2428 4238 2131 4238 
+Q 1616 4238 1336 4038 
+Q 1056 3838 1056 3469 
+Q 1056 3159 1242 3001 
+Q 1428 2844 1947 2747 
+L 2328 2669 
+Q 3034 2534 3370 2195 
+Q 3706 1856 3706 1288 
+Q 3706 609 3251 259 
+Q 2797 -91 1919 -91 
+Q 1588 -91 1214 -16 
+Q 841 59 441 206 
+L 441 856 
+Q 825 641 1194 531 
+Q 1563 422 1919 422 
+Q 2459 422 2753 634 
+Q 3047 847 3047 1241 
+Q 3047 1584 2836 1778 
+Q 2625 1972 2144 2069 
+L 1759 2144 
+Q 1053 2284 737 2584 
+Q 422 2884 422 3419 
+Q 422 4038 858 4394 
+Q 1294 4750 2059 4750 
+Q 2388 4750 2728 4690 
+Q 3069 4631 3425 4513 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-63" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-68" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-f6" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+M 2253 4850 
+L 2888 4850 
+L 2888 4219 
+L 2253 4219 
+L 2253 4850 
+z
+M 1031 4850 
+L 1666 4850 
+L 1666 4219 
+L 1031 4219 
+L 1031 4850 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-67" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6d" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-3a" d="M 750 794 
+L 1409 794 
+L 1409 0 
+L 750 0 
+L 750 794 
+z
+M 750 3309 
+L 1409 3309 
+L 1409 2516 
+L 750 2516 
+L 750 3309 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-62" d="M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+M 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2969 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-79" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-53"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(63.476562 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(118.457031 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(181.835938 0)"/>
+     <use xlink:href="#DejaVuSans-f6" transform="translate(209.619141 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(270.800781 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(334.277344 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(362.060547 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(393.847656 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(491.259766 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(552.441406 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(615.917969 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(677.441406 0)"/>
+     <use xlink:href="#DejaVuSans-3a" transform="translate(705.224609 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(738.916016 0)"/>
+     <use xlink:href="#DejaVuSans-62" transform="translate(770.703125 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(834.179688 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(861.962891 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(914.0625 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(953.271484 0)"/>
+     <use xlink:href="#DejaVuSans-62" transform="translate(1014.550781 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(1078.027344 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(1105.810547 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(1133.59375 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(1161.376953 0)"/>
+     <use xlink:href="#DejaVuSans-79" transform="translate(1200.585938 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1259.765625 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(1291.552734 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1330.416016 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(1391.939453 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(1455.416016 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(1483.199219 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(1544.380859 0)"/>
+    </g>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="patch_7">
+    <path d="M 365.0862 313 
+L 379.4642 313 
+L 379.4642 25.44 
+L 365.0862 25.44 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAABQAAAGQCAYAAACu30B3AAACEklEQVR4nO2a4Y0sMQyCMXFD9+c6feWO/YoYTmJEKADlW2ySXW39/P5bCEWI1cUSGx6tIaVuABrUelLqhj/4DFudMv2RcVMOSLnsBxvHvm0YdwVUHjLEfdj+q1e3bd6KEKsDV68Skak1pH3bMK8PaY9MBiJTbHj8kSvtbcO4E3bgHNL/RwzmFezJQ2baCVv9gqXUDXcOUwa74lbv+IdC9RVQecj0R4bW8MSlTKkb7uqFpHxuwQakTP8TVtytd+7q2b0cqLXDJx6cFYhcakO4t03FIVOPXGG7TK0dIlePdw7fqvNWr/2Rz129tyLE6sA5ZB5yYdxPWNoTNvGkIddN+a0IsfqmbNmHj9aQ4l2m1A1/UA4dmHLZI1OeMtyRyz6Uum3zVh2Ycvkjr/sJIT5h4wPIG4c8gSmPtyHtU6bUDaGrt+I5XH/kyVu9vYP9UoRYHTmH4z3YlLrhppwSygQibx7ySA0pdcNFdg1l1YaTNofr/7aZwLbZPOQJO2Ff5NcixOq7egmrt8/GXQGPO/LmIeNRD/b4I2/a6u0HkEds+Lgjb2LbbF7bjNSQUjeEzuEEFuyKDZ+0wabUDZl9uHnIk4e8ed+X1z+UJ24OJ++i34lLeT8QyuQhr/cuU+qGzILdQOSJC2XskWfMDfkB5M1DnjRkau1wQxGoA1Ne+z94T14oc5HfihCrE1PePORJO2HbI/8HH81F9wSBpr8AAAAASUVORK5CYII=" id="image2d538ec7aa" transform="scale(1 -1) translate(0 -288)" x="365.04" y="-25.2" width="14.4" height="288"/>
+   <g id="matplotlib.axis_3"/>
+   <g id="matplotlib.axis_4">
+    <g id="ytick_7">
+     <g id="line2d_12">
+      <defs>
+       <path id="m9a6a63303e" d="M 0 0 
+L 3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m9a6a63303e" x="379.4642" y="313" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- 1 -->
+      <g transform="translate(386.4642 316.799219) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_13">
+      <g>
+       <use xlink:href="#m9a6a63303e" x="379.4642" y="169.22" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_16">
+      <!-- 2 -->
+      <g transform="translate(386.4642 173.019219) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m9a6a63303e" x="379.4642" y="25.44" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_17">
+      <!-- 3 -->
+      <g transform="translate(386.4642 29.239219) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-33"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_18">
+     <!-- positive real steady states -->
+     <g transform="translate(404.425137 235.181719) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-70" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-76" d="M 191 3500 
+L 800 3500 
+L 1894 563 
+L 2988 3500 
+L 3597 3500 
+L 2284 0 
+L 1503 0 
+L 191 3500 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-70"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(63.476562 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(124.658203 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(176.757812 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(204.541016 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(243.75 0)"/>
+      <use xlink:href="#DejaVuSans-76" transform="translate(271.533203 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(330.712891 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(392.236328 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(424.023438 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(462.886719 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(524.410156 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(585.689453 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(613.472656 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(645.259766 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(697.359375 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(736.568359 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(798.091797 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(859.371094 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(922.847656 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(982.027344 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(1013.814453 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(1065.914062 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(1105.123047 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(1166.402344 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1205.611328 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(1267.134766 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="LineCollection_1"/>
+   <g id="patch_8">
+    <path d="M 365.0862 313 
+L 372.2752 313 
+L 379.4642 313 
+L 379.4642 25.44 
+L 372.2752 25.44 
+L 365.0862 25.44 
+L 365.0862 313 
+z
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pfe13901eb9">
+   <rect x="47.108" y="25.44" width="299.2736" height="287.56"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/python/docs/source/tutorials/tutorials.rst
+++ b/python/docs/source/tutorials/tutorials.rst
@@ -20,6 +20,7 @@
    moving_slice
    real_points
    solving_at_scale
+   parallel_parameter_homotopy
    crossed_paths
    precision_matters
    precision_models

--- a/python/examples/parallel_parameter_homotopy.py
+++ b/python/examples/parallel_parameter_homotopy.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Parallel parameter homotopy: a chemical reaction network's bistability map.
+
+Two-level parallelism for a parameter sweep:
+
+* **MPI across parameter points** -- each rank owns a slice of the parameter grid (this is the
+  *outer* loop; the points are independent, so no manager-worker dispatch is needed -- just split
+  the grid and gather the answers).
+* **threads across paths** -- inside each point's solve, the path tracking runs on all the cores
+  the rank is given (``OMP_NUM_THREADS``).
+
+The model is the **Schlogl** reaction network, whose steady state is a cubic in the species
+concentration ``X``::
+
+    k2 * X^3  -  k1 * X^2  +  k4 * X  -  k3  =  0
+
+Over the positive-orthant parameter space it is **bistable**: depending on the rate constants it
+has either **one** or **three** positive real steady states.  We map that region by counting the
+positive real solutions at each grid point -- letting the solver do the real/finite classification,
+never a hand-rolled cutoff.
+
+Run it (per the MPI notes in the "Solving at scale" tutorial -- always run a *file*, never a
+heredoc; ``--bind-to none`` lets each rank's threads spread across cores)::
+
+    python parallel_parameter_homotopy.py                       # serial baseline
+    mpirun -n 4 python parallel_parameter_homotopy.py           # 4 ranks, 1 thread each
+    OMP_NUM_THREADS=3 mpirun -n 4 --bind-to none \
+        python parallel_parameter_homotopy.py                   # 4 ranks x 3 threads
+
+The result (a counts grid, and optionally a heatmap PNG) is assembled on rank 0.
+"""
+
+import argparse
+
+import numpy as np
+
+import bertini as pb
+from bertini.nag_algorithm import parameter_sweep
+
+# The species variable is SHARED across every member of the family: a parameter homotopy
+# interpolates the members' coefficients, so they must be built over the same Variable object.
+X = pb.Variable('X')
+
+
+def make_system(params):
+    """The Schlogl steady-state system at the given rate constants (k1, k2, k3, k4)."""
+    k1, k2, k3, k4 = params
+    sys = pb.System()
+    sys.add_variable_group(pb.VariableGroup([X]))
+    sys.add_function(k2 * X * X * X - k1 * X * X + k4 * X - k3)
+    return sys
+
+
+def real_coeff(value):
+    """An exact real coefficient node (a complex literal with zero imaginary part)."""
+    return pb.multiprec.Complex(repr(float(value)), "0")
+
+
+def positive_real_count(solver):
+    """Number of positive real steady states, from the solver's OWN classification.
+
+    ``to_dataframe`` tags each endpoint is_real / is_finite (and multiplicity, etc.); we keep the
+    real, finite ones and require the concentration to be positive -- a CRN steady state is a
+    positive real point.  We do not re-derive real-ness ourselves.
+    """
+    df = solver.to_dataframe()
+    n = 0
+    for _, row in df.iterrows():
+        if not (row['is_real'] and row['is_finite']):
+            continue
+        sol = row['solution']
+        x = complex(sol[0] if hasattr(sol, '__len__') else sol)
+        if x.real > 1e-9:
+            n += 1
+    return n
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument('--grid', type=int, default=24, help='grid resolution per axis (default 24)')
+    ap.add_argument('--save', default=None, help='save the heatmap to this PNG/SVG path (rank 0)')
+    args = ap.parse_args()
+
+    # MPI is optional: with mpi4py absent (or one process) this is a plain serial/threaded sweep.
+    try:
+        from mpi4py import MPI
+        comm = MPI.COMM_WORLD
+        rank, size = comm.Get_rank(), comm.Get_size()
+    except ImportError:
+        comm, rank, size = None, 0, 1
+
+    N = args.grid
+    k1s = np.linspace(3.5, 8.5, N)        # the X^2 rate
+    k3s = np.linspace(1.0, 13.0, N)       # the influx term
+    # one generic (complex) member, solved once; its solutions seed every track
+    generic = (pb.multiprec.Complex("0.7", "0.4"),  pb.multiprec.Complex("1", "0.3"),
+               pb.multiprec.Complex("0.31", "-0.52"), pb.multiprec.Complex("1.2", "0.9"))
+    # the parameter grid, flattened row-major into one list of targets
+    targets = [(real_coeff(k1), real_coeff(1), real_coeff(k3), real_coeff(11))
+               for k3 in k3s for k1 in k1s]
+
+    # The entire two-level parallel sweep -- MPI across the grid points, threads across the paths
+    # inside each point -- is this one call.  `comm=` spreads the points over the ranks and gathers
+    # the results; `collect=` reduces each solve to a picklable number before it crosses ranks.
+    # (Drop `comm=` for a plain serial/threaded run.)
+    counts_flat = parameter_sweep(make_system, generic, targets,
+                                  collect=positive_real_count, comm=comm)
+
+    if rank == 0:
+        counts = np.array(counts_flat, dtype=int).reshape(N, N)
+        seen = sorted(set(counts.ravel().tolist()))
+        print("swept %d points over %d rank(s); positive-real counts seen: %s"
+              % (N * N, size, seen))
+        print("bistable (3 positive real) at %d of %d grid points"
+              % (int((counts == 3).sum()), N * N))
+
+        if args.save:
+            import matplotlib
+            matplotlib.use("Agg")
+            import matplotlib.pyplot as plt
+            fig, ax = plt.subplots(figsize=(6, 5))
+            im = ax.imshow(counts, origin='lower', aspect='auto', cmap='RdYlBu_r',
+                           extent=[k1s[0], k1s[-1], k3s[0], k3s[-1]], vmin=1, vmax=3)
+            cb = fig.colorbar(im, ax=ax, ticks=[1, 2, 3])
+            cb.set_label('positive real steady states')
+            ax.set_xlabel(r'$k_1$ (X$^2$ rate)'); ax.set_ylabel(r'$k_3$ (influx)')
+            ax.set_title('Schlögl model: bistability region')
+            fig.tight_layout(); fig.savefig(args.save)
+            print("saved", args.save)
+
+
+if __name__ == '__main__':
+    main()

--- a/python/test/tracking/meta_observer_test.py
+++ b/python/test/tracking/meta_observer_test.py
@@ -16,6 +16,20 @@ from bertini.tracking import amp_config_from
 from bertini.nag_algorithm import ZeroDim
 
 
+def _force_serial(solver):
+    """Pin a ZeroDim solver to a single thread (no pool).
+
+    The default solve is multi-threaded, where each path runs on a thread-local tracker clone --
+    so an observer attached to the solver's MEMBER tracker sees nothing.  Tests that exercise the
+    member-tracker attachment pattern force serial; threaded collection is covered separately via
+    SolutionPathCollector / event.tracker() in threaded_solve_test.py.
+    """
+    cfg = solver.get_config(pb.nag_algorithm.ZeroDimConfig)
+    cfg.num_threads = 1
+    solver.set_config(cfg)
+    return solver
+
+
 # ---------------------------------------------------------------------------
 # Bare-tracker: deterministic, no endgame noise -> exactly one series per track
 # ---------------------------------------------------------------------------
@@ -218,7 +232,12 @@ def test_solution_path_collector_captures_more_than_the_main_track():
 
     sys = _circle_meets_line()
 
+    # Pin serial: this test attaches a collector directly to the solver's MEMBER tracker
+    # (solver2 below), which only runs the paths in serial mode.  The default solve is threaded,
+    # where paths run on thread-local clones -- see threaded_solve_test.py for the threaded path,
+    # which collects via event.tracker().
     solver = ZeroDim(sys, mptype='amp')
+    _force_serial(solver)
     a = SolutionPathCollector()
     solver.add_observer(a)
     solver.solve()
@@ -226,6 +245,7 @@ def test_solution_path_collector_captures_more_than_the_main_track():
 
     # tracker-level collector keeps only the main tracks (|t| start > 0.5)
     solver2 = ZeroDim(sys, mptype='amp')
+    _force_serial(solver2)
     b = tk.observers.amp.PathCollectionObserver()
     solver2.get_tracker().add_observer(b)
     solver2.solve()
@@ -237,6 +257,10 @@ def test_solution_path_collector_captures_more_than_the_main_track():
 def test_zerodim_solve_collects_all_paths():
     sys = _circle_meets_line()
     solver = ZeroDim(sys, mptype='amp')
+    # Attaching to the solver's member tracker collects only in serial mode; the default solve is
+    # threaded (paths run on clones).  For threaded collection use SolutionPathCollector /
+    # event.tracker() -- see threaded_solve_test.py.
+    _force_serial(solver)
 
     a = tk.observers.amp.PathCollectionObserver()
     solver.get_tracker().add_observer(a)

--- a/python/test/zero_dim/parameter_sweep_test.py
+++ b/python/test/zero_dim/parameter_sweep_test.py
@@ -1,0 +1,71 @@
+"""parameter_sweep: one ab-initio solve, track to many coefficient values.
+
+Serial/threaded coverage here; the MPI (comm=) path is exercised by
+examples/parallel_parameter_homotopy.py under mpirun (see the MPI CI smoke job).
+"""
+
+import pytest
+
+import bertini as pb
+from bertini.nag_algorithm import parameter_sweep
+
+C = pb.multiprec.Complex
+
+# Shared variables across the family -- the homotopy interpolates coefficients, so every member
+# must be built over the same Variable objects.
+x, y = pb.Variable('x'), pb.Variable('y')
+
+
+def _make_system(params):
+    a, b = params
+    s = pb.System()
+    s.add_variable_group(pb.VariableGroup([x, y]))
+    s.add_function(x * x - a)        # x^2 = a
+    s.add_function(y * y - b)        # y^2 = b
+    return s
+
+
+_GENERIC = (C("0.371", "0.59"), C("-0.83", "0.21"))     # generic complex
+
+
+def test_returns_one_solver_per_target():
+    targets = [(C("4", "0"), C("9", "0")), (C("2", "0"), C("5", "0"))]
+    solvers = parameter_sweep(_make_system, _GENERIC, targets)
+    assert len(solvers) == len(targets)
+    for solver in solvers:
+        assert len(solver.all_solutions()) == 4        # x^2=a, y^2=b -> 4 solutions
+
+
+def test_collect_reduces_each_solve():
+    targets = [(C("4", "0"), C("9", "0")), (C("2", "0"), C("5", "0"))]
+    counts = parameter_sweep(_make_system, _GENERIC, targets,
+                             collect=lambda s: len(s.all_solutions()))
+    assert counts == [4, 4]                             # collect-form returns values, not solvers
+
+
+def test_sweep_matches_a_direct_solve():
+    """A swept target must give the same solution set as solving that member from scratch."""
+    from bertini.nag_algorithm import ZeroDim
+
+    target = (C("4", "0"), C("9", "0"))
+    swept = parameter_sweep(_make_system, _GENERIC, [target])[0]
+
+    direct = ZeroDim(_make_system(target), mptype='adaptive')
+    direct.solve()
+
+    def key(solver):
+        ks = set()
+        for v in solver.all_solutions():
+            ks.add(tuple(sorted((round(complex(c).real, 5), round(complex(c).imag, 5)) for c in v)))
+        return ks
+
+    assert key(swept) == key(direct)
+
+
+def test_comm_without_collect_is_an_error():
+    """Passing a communicator but no collect must fail fast (solvers can't cross MPI ranks)."""
+    class _FakeComm:                          # never actually used -- the guard fires first
+        def Get_rank(self): return 0
+        def Get_size(self): return 1
+    with pytest.raises(ValueError):
+        parameter_sweep(_make_system, _GENERIC, [(C("4", "0"), C("9", "0"))], comm=_FakeComm())

--- a/python/test/zero_dim/threaded_solve_test.py
+++ b/python/test/zero_dim/threaded_solve_test.py
@@ -1,0 +1,143 @@
+"""MPI-less shared-memory threading for the ZeroDim solve, exercised from Python.
+
+The contract: a threaded solve returns the SAME solutions as a serial one, Python observers
+fire safely from worker threads (the GIL is released for the C++ solve and re-acquired in the
+observer trampoline), and the meta-observer per-path collection keeps working because it attaches
+to event.tracker() -- the thread-local clone -- not the member tracker.
+
+These need no MPI and no free-threaded Python, so they run on every platform's wheel.
+"""
+
+import pytest
+
+import bertini as pb
+import bertini.tracking as tk
+from bertini.nag_algorithm import ZeroDim, SolutionPathCollector
+
+
+def _two_cubics():
+    """{x^3 - x, y^3 - y}: 9 total-degree paths, 9 finite real solutions, well separated."""
+    x, y = pb.Variable('x'), pb.Variable('y')
+    sys = pb.System()
+    sys.add_variable_group(pb.VariableGroup([x, y]))
+    sys.add_function(x**3 - x)
+    sys.add_function(y**3 - y)
+    return sys
+
+
+def _solve_with(num_threads):
+    solver = ZeroDim(_two_cubics(), mptype='amp')
+    cfg = solver.get_config(pb.nag_algorithm.ZeroDimConfig)
+    cfg.num_threads = num_threads
+    solver.set_config(cfg)
+    solver.solve()
+    return solver
+
+
+def _solution_key_set(solver, tol=6):
+    """A hashable, order-independent representation of the solution set."""
+    keys = set()
+    for v in solver.all_solutions():
+        if len(v) == 0:
+            continue
+        keys.add(tuple(sorted((round(complex(c).real, tol), round(complex(c).imag, tol))
+                              for c in v)))
+    return keys
+
+
+def test_num_threads_config_roundtrips():
+    solver = ZeroDim(_two_cubics(), mptype='amp')
+    cfg = solver.get_config(pb.nag_algorithm.ZeroDimConfig)
+    assert cfg.num_threads == 0          # default: auto
+    cfg.num_threads = 3
+    solver.set_config(cfg)
+    assert solver.get_config(pb.nag_algorithm.ZeroDimConfig).num_threads == 3
+
+
+@pytest.mark.parametrize("num_threads", [2, 4, 8])
+def test_threaded_matches_serial(num_threads):
+    """The whole point: more threads, identical answers."""
+    serial = _solve_with(1)
+    threaded = _solve_with(num_threads)
+
+    assert len(serial.all_solutions()) == 9
+    assert _solution_key_set(threaded) == _solution_key_set(serial)
+
+
+def test_lifecycle_observer_fires_under_threads():
+    """A Python observer attached to the solver sees the right event counts even though the
+    per-path events fire from C++ worker threads -- proves the GIL is re-acquired (no crash) and
+    notifications are serialized (no lost/garbled counts)."""
+    from bertini._pybertini import nag_algorithms as nag
+
+    solver = ZeroDim(_two_cubics(), mptype='amp')
+    cfg = solver.get_config(pb.nag_algorithm.ZeroDimConfig)
+    cfg.num_threads = 4
+    solver.set_config(cfg)
+
+    starts, completes, begins = [], [], []
+
+    class Lifecycle(nag.observers.CustomObserver):
+        def Observe(self, e):
+            if isinstance(e, nag.observers.AlgorithmStarted):
+                starts.append(1)
+            elif isinstance(e, nag.observers.AlgorithmComplete):
+                completes.append(1)
+            elif isinstance(e, nag.observers.PathStarted):
+                begins.append(e.path_index())
+
+    solver.add_observer(Lifecycle())
+    solver.solve()
+
+    assert len(starts) == 1
+    assert len(completes) == 1
+    assert len(begins) == 9                     # one per path, none lost to a race
+    assert sorted(begins) == list(range(9))     # every index exactly once
+
+
+def test_event_tracker_is_attachable_and_distinct_under_threads():
+    """event.tracker() returns a concrete, attachable tracker; under threads it is NOT the
+    solver's member tracker (it's the thread-local clone)."""
+    from bertini._pybertini import nag_algorithms as nag
+
+    solver = ZeroDim(_two_cubics(), mptype='amp')
+    cfg = solver.get_config(pb.nag_algorithm.ZeroDimConfig)
+    cfg.num_threads = 4
+    solver.set_config(cfg)
+
+    member = solver.get_tracker()
+    saw_member = []
+    have_observers_attr = []
+
+    class Probe(nag.observers.CustomObserver):
+        def Observe(self, e):
+            if isinstance(e, nag.observers.PathStarted):
+                t = e.tracker()
+                have_observers_attr.append(hasattr(t, "add_observer") and hasattr(t, "observers"))
+                # identity by the underlying C++ object: boost.python compares by pointer
+                saw_member.append(t == member)
+
+    solver.add_observer(Probe())
+    solver.solve()
+
+    assert all(have_observers_attr)        # the concrete tracker API is present
+    assert not any(saw_member)             # never the member tracker -> a clone
+
+
+def test_solution_path_collector_under_threads():
+    """The two-level meta-observer collects exactly one series per path under threading, because
+    it now attaches to event.tracker() (the clone that actually runs the path)."""
+    solver = ZeroDim(_two_cubics(), mptype='amp')
+    cfg = solver.get_config(pb.nag_algorithm.ZeroDimConfig)
+    cfg.num_threads = 4
+    solver.set_config(cfg)
+
+    collector = SolutionPathCollector()
+    solver.add_observer(collector)
+    solver.solve()
+
+    assert len(solver.all_solutions()) == 9
+    assert len(collector.series) == 9                          # one per solution path
+    assert sorted(p.path_index for p in collector.series) == list(range(9))
+    for path in collector.series:
+        assert len(path) > 0                                   # actually captured steps

--- a/python_bindings/include/generic_observer.hpp
+++ b/python_bindings/include/generic_observer.hpp
@@ -56,6 +56,9 @@ struct ObserverWrapper : ObsT, wrapper<ObsT>
 	// existing observers keep working.  An observer that wants to self-detach can
 	// `return bertini.ObserveResult.Unsubscribe`.
 	ObserveResult Observe(AnyEvent const& e) override {
+		// A threaded solve releases the GIL and fires events from C++ worker threads; re-acquire
+		// the GIL before touching any Python object.  Safe on the main thread too (serial solve).
+		ScopedGILAcquire acquire_gil;
 		object result = this->get_override("Observe")(boost::ref(const_cast<AnyEvent&>(e)));
 		if (result.is_none())
 			return ObserveResult::KeepObserving;

--- a/python_bindings/include/python_common.hpp
+++ b/python_bindings/include/python_common.hpp
@@ -62,4 +62,37 @@ using namespace boost::python;
 using mpfr_float = bertini::mpfr_float;
 using mpfr_complex = bertini::mpfr_complex;
 
+namespace bertini { namespace python {
+
+/**
+\brief RAII: release the Python GIL for the duration of a long C++ call (a threaded solve), so
+worker threads run truly in parallel and Python observer callbacks can re-acquire the GIL.
+Equivalent to Py_BEGIN_ALLOW_THREADS / Py_END_ALLOW_THREADS.
+*/
+struct ScopedGILRelease
+{
+	PyThreadState* state_;
+	ScopedGILRelease()  : state_(PyEval_SaveThread()) {}
+	~ScopedGILRelease() { PyEval_RestoreThread(state_); }
+	ScopedGILRelease(ScopedGILRelease const&) = delete;
+	ScopedGILRelease& operator=(ScopedGILRelease const&) = delete;
+};
+
+/**
+\brief RAII: ensure the calling thread holds the GIL before touching Python objects, and restore
+on scope exit.  Safe to call from any thread -- a C++ worker thread (the solve released the GIL)
+or the main thread.  Used at the top of the observer trampoline before calling into a Python
+observer's Observe().
+*/
+struct ScopedGILAcquire
+{
+	PyGILState_STATE state_;
+	ScopedGILAcquire()  : state_(PyGILState_Ensure()) {}
+	~ScopedGILAcquire() { PyGILState_Release(state_); }
+	ScopedGILAcquire(ScopedGILAcquire const&) = delete;
+	ScopedGILAcquire& operator=(ScopedGILAcquire const&) = delete;
+};
+
+}} // namespace bertini::python
+
 #endif

--- a/python_bindings/include/zero_dim_export.hpp
+++ b/python_bindings/include/zero_dim_export.hpp
@@ -183,6 +183,11 @@ void ZDVisitor<AlgoT>::visit(PyClass& cl) const
 	.def(ObservableVisitor<AlgoT>())
 	.def("solve",
 		+[](AlgoT& self, boost::python::object comm) -> void {
+			// Release the GIL for the whole solve: the worker threads run pure C++ numerics
+			// (no Python objects), so dropping the GIL gives true multicore parallelism on a
+			// stock CPython -- no free-threaded build needed.  Python observer callbacks
+			// re-acquire the GIL in the observer trampoline (see generic_observer.hpp).
+			bertini::python::ScopedGILRelease unlock_gil;
 #ifdef BERTINI2_HAVE_MPI
 			if (comm.is_none()) {
 				self.Run();

--- a/python_bindings/include/zero_dim_export.hpp
+++ b/python_bindings/include/zero_dim_export.hpp
@@ -183,19 +183,22 @@ void ZDVisitor<AlgoT>::visit(PyClass& cl) const
 	.def(ObservableVisitor<AlgoT>())
 	.def("solve",
 		+[](AlgoT& self, boost::python::object comm) -> void {
-			// Release the GIL for the whole solve: the worker threads run pure C++ numerics
-			// (no Python objects), so dropping the GIL gives true multicore parallelism on a
-			// stock CPython -- no free-threaded build needed.  Python observer callbacks
-			// re-acquire the GIL in the observer trampoline (see generic_observer.hpp).
-			bertini::python::ScopedGILRelease unlock_gil;
+			// The GIL must be HELD while touching Python objects (e.g. extracting the mpi4py
+			// communicator), and RELEASED only around the actual C++ solve so the worker threads
+			// run truly in parallel on stock CPython (no free-threaded build needed).  Python
+			// observer callbacks re-acquire the GIL in the observer trampoline (generic_observer.hpp).
 #ifdef BERTINI2_HAVE_MPI
 			if (comm.is_none()) {
+				bertini::python::ScopedGILRelease unlock_gil;
 				self.Run();
 			} else {
-				MPI_Fint f = boost::python::extract<MPI_Fint>(comm.attr("py2f")());
-				self.RunParallel(MPI_Comm_f2c(f));
+				// Extract the communicator with the GIL held, then release it for RunParallel.
+				MPI_Comm c = MPI_Comm_f2c(boost::python::extract<MPI_Fint>(comm.attr("py2f")()));
+				bertini::python::ScopedGILRelease unlock_gil;
+				self.RunParallel(c);
 			}
 #else
+			bertini::python::ScopedGILRelease unlock_gil;
 			self.Solve();
 #endif
 		},

--- a/python_bindings/include/zero_dim_export.hpp
+++ b/python_bindings/include/zero_dim_export.hpp
@@ -187,19 +187,29 @@ void ZDVisitor<AlgoT>::visit(PyClass& cl) const
 			// communicator), and RELEASED only around the actual C++ solve so the worker threads
 			// run truly in parallel on stock CPython (no free-threaded build needed).  Python
 			// observer callbacks re-acquire the GIL in the observer trampoline (generic_observer.hpp).
-#ifdef BERTINI2_HAVE_MPI
+			// No communicator => a purely LOCAL solve (serial or shared-memory threaded).  We call
+			// Solve() directly, NOT Run(): Run() auto-promotes to MPI manager-worker whenever the
+			// process was launched under mpirun (parallel::Size() > 1), which would make a plain
+			// solve() secretly drive MPI_COMM_WORLD.  That breaks the common "MPI at an outer level,
+			// independent local solves per rank" pattern (e.g. parameter_sweep across ranks).  MPI is
+			// opt-in: you get it only by explicitly passing communicator=.
 			if (comm.is_none()) {
 				bertini::python::ScopedGILRelease unlock_gil;
-				self.Run();
-			} else {
+				self.Solve();
+			}
+#ifdef BERTINI2_HAVE_MPI
+			else {
 				// Extract the communicator with the GIL held, then release it for RunParallel.
 				MPI_Comm c = MPI_Comm_f2c(boost::python::extract<MPI_Fint>(comm.attr("py2f")()));
 				bertini::python::ScopedGILRelease unlock_gil;
 				self.RunParallel(c);
 			}
 #else
-			bertini::python::ScopedGILRelease unlock_gil;
-			self.Solve();
+			else {
+				PyErr_SetString(PyExc_RuntimeError,
+					"solve(communicator=...) requires a bertini2 built with MPI; this build has none.");
+				boost::python::throw_error_already_set();
+			}
 #endif
 		},
 		(boost::python::arg("communicator") = boost::python::object()),

--- a/python_bindings/src/tracker_export.cpp
+++ b/python_bindings/src/tracker_export.cpp
@@ -49,6 +49,13 @@ namespace bertini{
 			scope new_submodule_scope = new_submodule;
 			new_submodule_scope.attr("__doc__") = "Tracking things.  Includes the three fundamental trackers, and utility functions.";
 
+			// Register the common observable base so that a base-class pointer (e.g. the one
+			// returned by a path event's tracker()) RTTI-downcasts to the concrete tracker in
+			// Python -- the same mechanism AnyZeroDim uses for event.solver().  No methods are
+			// exposed on it; add_observer lives on each concrete tracker via ObservableVisitor.
+			// Must be registered before the trackers that declare bases<Observable>.
+			class_<bertini::Observable, boost::noncopyable>("Observable", no_init);
+
 			ExportConfigSettings();
 			ExportAMPTracker();
 			ExportFixedTrackers();
@@ -56,7 +63,7 @@ namespace bertini{
 
 		void ExportAMPTracker()
 		{
-			class_<AMPTracker, std::shared_ptr<AMPTracker> >("AMPTracker", "The adaptive multiple precision (AMP) tracker.  Ambient numeric type is multiple-precision (mpfr_complex).  Contruct one by feeding it a system -- cannot be constructed without feeding it a system.  Adjust its settings via configs and the `setup` function.  Then, call method `track_path`.", init<const System&>())
+			class_<AMPTracker, std::shared_ptr<AMPTracker>, bases<bertini::Observable> >("AMPTracker", "The adaptive multiple precision (AMP) tracker.  Ambient numeric type is multiple-precision (mpfr_complex).  Contruct one by feeding it a system -- cannot be constructed without feeding it a system.  Adjust its settings via configs and the `setup` function.  Then, call method `track_path`.", init<const System&>())
 			.def(TrackerVisitor<AMPTracker>())
 			.def(AMPTrackerVisitor<AMPTracker>())
 			;
@@ -70,7 +77,7 @@ namespace bertini{
 
 		void ExportFixedDoubleTracker()
 		{
-			class_<DoublePrecisionTracker, std::shared_ptr<DoublePrecisionTracker> >("DoublePrecisionTracker", "The double precision tracker.  Tracks using only complex doubles.  Ambient numeric type is double.  Contruct one by feeding it a system -- cannot be constructed without feeding it a system.  Adjust its settings via configs and the `setup` function.  Then, call method `track_path`.", init<const System&>())
+			class_<DoublePrecisionTracker, std::shared_ptr<DoublePrecisionTracker>, bases<bertini::Observable> >("DoublePrecisionTracker", "The double precision tracker.  Tracks using only complex doubles.  Ambient numeric type is double.  Contruct one by feeding it a system -- cannot be constructed without feeding it a system.  Adjust its settings via configs and the `setup` function.  Then, call method `track_path`.", init<const System&>())
 			.def(TrackerVisitor<DoublePrecisionTracker>())
 			.def(FixedDoubleTrackerVisitor<DoublePrecisionTracker>())
 			;
@@ -78,7 +85,7 @@ namespace bertini{
 
 		void ExportFixedMultipleTracker()
 		{
-			class_<MultiplePrecisionTracker, std::shared_ptr<MultiplePrecisionTracker> >("MultiplePrecisionTracker", "The fixed multiple precision tracker.  Ambient numeric type is multiple-precision (mpfr_complex).  Precision is the value of bertini.default_precision() at contruction.  Errors if you try to feed it things not at that precision.  Contruct one by feeding it a system -- cannot be constructed without feeding it a system.  Adjust its settings via configs and the `setup` function.  Then, call method `track_path`.", init<const System&>())
+			class_<MultiplePrecisionTracker, std::shared_ptr<MultiplePrecisionTracker>, bases<bertini::Observable> >("MultiplePrecisionTracker", "The fixed multiple precision tracker.  Ambient numeric type is multiple-precision (mpfr_complex).  Precision is the value of bertini.default_precision() at contruction.  Errors if you try to feed it things not at that precision.  Contruct one by feeding it a system -- cannot be constructed without feeding it a system.  Adjust its settings via configs and the `setup` function.  Then, call method `track_path`.", init<const System&>())
 			.def(TrackerVisitor<MultiplePrecisionTracker>())
 			.def(FixedMultipleTrackerVisitor<MultiplePrecisionTracker>())
 			;

--- a/python_bindings/src/zero_dim_configs_export.cpp
+++ b/python_bindings/src/zero_dim_configs_export.cpp
@@ -102,6 +102,11 @@ namespace bertini{
 			.def_readwrite("max_num_crossed_path_resolve_attempts", &ZeroDimConfig::max_num_crossed_path_resolve_attempts,
 				"How many times to re-track crossed paths (with tightened settings) at the endgame "
 				"boundary before giving up. 0 = detect and report only, do not re-track. Default 2.")
+			.def_readwrite("num_threads", &ZeroDimConfig::num_threads,
+				"Worker threads for a shared-memory (non-MPI) solve. 0 = auto "
+				"(all available cores), 1 = serial (no thread pool), N = N threads. The "
+				"OMP_NUM_THREADS environment variable overrides this. Threading needs no MPI and "
+				"no free-threaded Python: the heavy tracking runs in C++ with the GIL released.")
 			;
 
 			// metadata types

--- a/python_bindings/src/zero_dim_export.cpp
+++ b/python_bindings/src/zero_dim_export.cpp
@@ -76,10 +76,26 @@ namespace bertini{
 			class_<AlgorithmStarted<AZ>,  bases<AlgorithmEvent<AZ>>, boost::noncopyable>("AlgorithmStarted",  no_init);
 			class_<AlgorithmComplete<AZ>, bases<AlgorithmEvent<AZ>>, boost::noncopyable>("AlgorithmComplete", no_init);
 
+			// .tracker() returns the tracker that actually executed this path; RTTI resolves the
+			// Observable base pointer to the concrete tracker (registered with bases<Observable>),
+			// so python gets the full tracker API (.add_observer, .observers, ...).  In a serial
+			// solve this is the solver's member tracker; in a threaded solve it is the thread-local
+			// clone -- so a meta-observer MUST attach its per-path sub-observer here, not to
+			// solver.get_tracker() (which runs nothing under threading).
+			auto started_tracker = +[](const PathStarted<AZ>& e) -> bertini::Observable* {
+				return const_cast<bertini::Observable*>(e.Tracker()); };
+			auto complete_tracker = +[](const PathComplete<AZ>& e) -> bertini::Observable* {
+				return const_cast<bertini::Observable*>(e.Tracker()); };
+
 			class_<PathStarted<AZ>, bases<AlgorithmEvent<AZ>>, boost::noncopyable>("PathStarted", no_init)
-				.def("path_index", &PathStarted<AZ>::PathIndex, "index of the solution path that is starting");
+				.def("path_index", &PathStarted<AZ>::PathIndex, "index of the solution path that is starting")
+				.def("tracker", started_tracker, return_value_policy<reference_existing_object>(),
+				     "the tracker that runs this path -- attach a per-path observer here (a thread-local "
+				     "clone when threaded, the member tracker when serial)");
 			class_<PathComplete<AZ>, bases<AlgorithmEvent<AZ>>, boost::noncopyable>("PathComplete", no_init)
-				.def("path_index", &PathComplete<AZ>::PathIndex, "index of the solution path that finished");
+				.def("path_index", &PathComplete<AZ>::PathIndex, "index of the solution path that finished")
+				.def("tracker", complete_tracker, return_value_policy<reference_existing_object>(),
+				     "the tracker that ran this path -- detach the per-path observer from it here");
 		}
 
 		void ExportZeroDim(){


### PR DESCRIPTION
## Summary

Brings **shared-memory threading with no MPI**, **on by default**, to the zero-dim solve — so `pip install` users get all-cores parallelism through the ordinary `solver.solve()` (no free-threaded Python needed; the heavy tracking runs in C++ with the GIL released). The existing MPI manager-worker path is unchanged, and the two compose: MPI across nodes, threads within.

The full parallelism matrix is verified for **both the CLI and Python**: 1 proc/1 thread, 1 proc/N threads (pip default), N MPI procs/1 thread, 1 MPI proc/N threads, and M MPI procs/N threads.

## What's in here

**C++ core**
- Un-gate the pure-`std::thread` pool (`WorkerThreadPool`, `EffectiveThreadCount`) so threading compiles without MPI; verified building **and** passing in a no-MPI build.
- `ZeroDimConfig.num_threads` (0 = auto/all cores, 1 = serial, N = N); `OMP_NUM_THREADS` overrides.
- Threaded `Solve()`: dispatch all paths through the pool, collect on the main thread via the existing race-free pack/install split. `n<=1` keeps the unchanged serial loop.
- `Observable` notify-mutex so concurrent `NotifyObservers` from worker threads is safe.
- `event.tracker()` on `PathStarted`/`PathComplete`: the tracker that *actually ran the path* (member tracker serial; thread-local clone threaded).

**Python**
- GIL released around the solve, re-acquired in the observer trampoline.
- `num_threads` exposed; `event.tracker()` bound (RTTI to the concrete tracker); `SolutionPathCollector` migrated to it.
- **`parameter_sweep`** — one ab-initio solve, then track to many coefficient values; pass `comm=` + `collect=` and the whole two-level MPI+threads sweep is one call (no user scatter/gather).
- Two MPI-path bugs fixed: GIL held during communicator extraction; `solve()` is now local unless given a communicator (it was secretly driving `MPI_COMM_WORLD` under `mpirun`).

**Benchmark / docs / CI**
- `benchmark/`: MPI-less thread sweep, `--assert-speedup`, portable `--mpirun-args`; rewritten human README (laptop / MPI / SLURM / non-SLURM).
- Observer tutorial: upgraded the meta-observer to `event.tracker()` + a threading/MPI-consequences section.
- New gold-medal tutorial: the Schlögl reaction network's bistability map (1-vs-3 positive real steady states over the positive orthant), MPI across parameter points / threads within.
- CI: threading is auto-covered cross-OS (ctest `test_nag_algorithms` + the wheel's full `pytest python/test/`); added an MPI smoke test (serial == `mpirun -n 2`) on Linux/macOS.

## Tests
- C++ `threaded_solve.cpp`: pool mechanics; threaded == serial solution set at `num_threads ∈ {1,2,4}`; serial→member / threaded→clone `event.tracker()` contract.
- Python `threaded_solve_test.py`, `parameter_sweep_test.py`: threaded == serial; observers fire safely from worker threads; meta-observer/collector under threads.
- Full suite green (541 passed, 1 skipped). MPI (3 ranks × 2 threads) verified locally to match serial.

## Follow-ups (not in this PR)
- First-class coefficient parameters via system freeze/curry (makes `parameter_sweep` trivial).
- Rename function-tree `Float` → `Complex` (reserve `Real`).
- Windows MPI smoke + a dedicated Python-MPI CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)