### PR TITLE
refactor!: rename function-tree node Float -> Complex

### DIFF
--- a/core/example/parameter_homotopy/include/my_system.hpp
+++ b/core/example/parameter_homotopy/include/my_system.hpp
@@ -17,10 +17,10 @@ namespace demo{
 		using bertini::Variable::Make;
 
 		// make symbolic objects for the parameters
-		auto param_A = MakeFloat(bertini::RandomComplex(30));
-		auto param_B = MakeFloat(bertini::RandomComplex(30));
-		auto param_C = MakeFloat(bertini::RandomComplex(30));
-		auto param_D = MakeFloat(bertini::RandomComplex(30));
+		auto param_A = MakeComplex(bertini::RandomComplex(30));
+		auto param_B = MakeComplex(bertini::RandomComplex(30));
+		auto param_C = MakeComplex(bertini::RandomComplex(30));
+		auto param_D = MakeComplex(bertini::RandomComplex(30));
 
 		return std::vector<Node>{param_A, param_B, param_C, param_D};
 	}

--- a/core/example/performance_numbers/include/construct_system.hpp
+++ b/core/example/performance_numbers/include/construct_system.hpp
@@ -21,17 +21,17 @@ namespace demo{
 	{
 		using bertini::Variable::Make;
         using bertini::Integer::Make;
-        using bertini::MakeFloat;
+        using bertini::MakeComplex;
 
 	    auto x1 = Variable::Make("x1");
 	    auto x2 = Variable::Make("x2");
 	    auto x3 = Variable::Make("x3");
 	    auto x4 = Variable::Make("x4");
         
-        auto p1 = MakeFloat("3.2");
-        auto p2 = MakeFloat("-2.8");
-        auto p3 = bertini::MakeFloat("3.5");
-        auto p4 = MakeFloat("-3.6");
+        auto p1 = MakeComplex("3.2");
+        auto p2 = MakeComplex("-2.8");
+        auto p3 = bertini::MakeComplex("3.5");
+        auto p4 = MakeComplex("-3.6");
         
         std::vector<Node> params{p1, p2, p3, p4};
 

--- a/core/include/bertini2/function_tree.hpp
+++ b/core/include/bertini2/function_tree.hpp
@@ -73,7 +73,7 @@ BOOST_SERIALIZATION_ASSUME_ABSTRACT(bertini::node::Number)
 BOOST_CLASS_EXPORT_KEY(bertini::node::Variable)
 BOOST_CLASS_EXPORT_KEY(bertini::node::Differential)
 
-BOOST_CLASS_EXPORT_KEY(bertini::node::Float)
+BOOST_CLASS_EXPORT_KEY(bertini::node::Complex)
 BOOST_CLASS_EXPORT_KEY(bertini::node::Integer)
 BOOST_CLASS_EXPORT_KEY(bertini::node::Rational)
 
@@ -113,7 +113,7 @@ BOOST_CLASS_TRACKING(bertini::node::Number, boost::serialization::track_always)
 BOOST_CLASS_TRACKING(bertini::node::Variable, boost::serialization::track_always)
 BOOST_CLASS_TRACKING(bertini::node::Differential, boost::serialization::track_always)
 
-BOOST_CLASS_TRACKING(bertini::node::Float, boost::serialization::track_always)
+BOOST_CLASS_TRACKING(bertini::node::Complex, boost::serialization::track_always)
 BOOST_CLASS_TRACKING(bertini::node::Integer, boost::serialization::track_always)
 BOOST_CLASS_TRACKING(bertini::node::Rational, boost::serialization::track_always)
 

--- a/core/include/bertini2/function_tree/forward_declares.hpp
+++ b/core/include/bertini2/function_tree/forward_declares.hpp
@@ -39,7 +39,7 @@ namespace bertini {
 	namespace node{ 
 		class Variable;
 		class Integer;
-		class Float;
+		class Complex;
 		class Rational;
 		class NamedExpression;
 		class Differential;
@@ -88,7 +88,7 @@ namespace bertini {
 		{
 			ar.template register_type<bertini::node::Variable>();
 			ar.template register_type<bertini::node::Integer>();
-			ar.template register_type<bertini::node::Float>();
+			ar.template register_type<bertini::node::Complex>();
 			ar.template register_type<bertini::node::Rational>();
 			ar.template register_type<bertini::node::NamedExpression>();
 			ar.template register_type<bertini::node::Differential>();

--- a/core/include/bertini2/function_tree/node.hpp
+++ b/core/include/bertini2/function_tree/node.hpp
@@ -159,7 +159,7 @@ public:
 	/**
 	\brief Is this node the literal constant 0?
 
-	Exact check on stored literal values (Integer/Float/Rational override);
+	Exact check on stored literal values (Integer/Complex/Rational override);
 	false for everything else, including non-literal expressions that happen
 	to evaluate to zero.  Used by differentiation to build already-simplified
 	trees without evaluating anything.
@@ -185,7 +185,7 @@ public:
 	Order-sensitive: equal structures hash equal, where children are folded in by their own
 	Hash() and operand order / signs / exponents participate.  The default (leaves and any
 	node not overriding HashImpl) is node identity (the object's address), so distinct objects
-	hash distinctly; value nodes (Integer/Rational/Float) and operators override to be
+	hash distinctly; value nodes (Integer/Rational/Complex) and operators override to be
 	structural.  Memoized -- valid because nodes are immutable post-construction -- and
 	deliberately independent of the mutable working precision (stable across precision()).
 

--- a/core/include/bertini2/function_tree/operators/arithmetic.hpp
+++ b/core/include/bertini2/function_tree/operators/arithmetic.hpp
@@ -1031,12 +1031,12 @@ namespace node{
 
 	inline std::shared_ptr<Node> pow(const std::shared_ptr<Node> & N, mpfr_float p)
 	{
-		return PowerOperator::Make(N,Float::Make(p));
+		return PowerOperator::Make(N,Complex::Make(p));
 	}
 
 	inline std::shared_ptr<Node> pow(const std::shared_ptr<Node> & N, mpfr_complex p)
 	{
-		return PowerOperator::Make(N,Float::Make(p));
+		return PowerOperator::Make(N,Complex::Make(p));
 	}
 
 	inline std::shared_ptr<Node> pow(const std::shared_ptr<Node> & N, mpq_rational const& p)
@@ -1077,7 +1077,7 @@ namespace node{
 
 	A multiplied literal zero collapses the whole product to 0; literal ones are
 	dropped; literal Integer/Rational constants (real-valued) are folded together
-	exactly (no Float folding -- precision semantics stay untouched).  A literal
+	exactly (no Complex folding -- precision semantics stay untouched).  A literal
 	zero DIVISOR is left in place, keeping the division by zero visible.  A single
 	surviving multiplied factor is returned unwrapped.  Builds fresh nodes; the
 	factor nodes are shared, never modified.
@@ -1119,22 +1119,22 @@ namespace node{
 	
 	inline std::shared_ptr<Node> operator+(std::shared_ptr<Node> lhs, mpfr_float const& rhs)
 	{
-		return SumOperator::Make(lhs,Float::Make(rhs));
+		return SumOperator::Make(lhs,Complex::Make(rhs));
 	}
 
 	inline std::shared_ptr<Node> operator+(std::shared_ptr<Node> lhs, mpfr_complex const& rhs)
 	{
-		return SumOperator::Make(lhs,Float::Make(rhs));
+		return SumOperator::Make(lhs,Complex::Make(rhs));
 	}
 	
 	inline std::shared_ptr<Node> operator+(mpfr_float const& lhs,  std::shared_ptr<Node> rhs)
 	{
-		return SumOperator::Make(Float::Make(lhs), rhs);
+		return SumOperator::Make(Complex::Make(lhs), rhs);
 	}
 
 	inline std::shared_ptr<Node> operator+(mpfr_complex const& lhs,  std::shared_ptr<Node> rhs)
 	{
-		return SumOperator::Make(Float::Make(lhs), rhs);
+		return SumOperator::Make(Complex::Make(lhs), rhs);
 	}
 
 	inline std::shared_ptr<Node> operator+(std::shared_ptr<Node> lhs, int rhs)
@@ -1191,22 +1191,22 @@ namespace node{
 	
 	inline std::shared_ptr<Node> operator-(std::shared_ptr<Node> lhs, mpfr_float const& rhs)
 	{
-		return SumOperator::Make(lhs, true, Float::Make(rhs), false);
+		return SumOperator::Make(lhs, true, Complex::Make(rhs), false);
 	}
 
 	inline std::shared_ptr<Node> operator-(mpfr_float const& lhs,  std::shared_ptr<Node> rhs)
 	{
-		return SumOperator::Make(Float::Make(lhs), true, rhs, false);
+		return SumOperator::Make(Complex::Make(lhs), true, rhs, false);
 	}
 
 	inline std::shared_ptr<Node> operator-(std::shared_ptr<Node> lhs, mpfr_complex const& rhs)
 	{
-		return SumOperator::Make(lhs, true, Float::Make(rhs), false);
+		return SumOperator::Make(lhs, true, Complex::Make(rhs), false);
 	}
 
 	inline std::shared_ptr<Node> operator-(mpfr_complex const& lhs,  std::shared_ptr<Node> rhs)
 	{
-		return SumOperator::Make(Float::Make(lhs), true, rhs, false);
+		return SumOperator::Make(Complex::Make(lhs), true, rhs, false);
 	}
 
 	inline std::shared_ptr<Node> operator-(std::shared_ptr<Node> lhs, int rhs)
@@ -1253,22 +1253,22 @@ namespace node{
 	
 	inline std::shared_ptr<Node> operator*(std::shared_ptr<Node> lhs, mpfr_float const& rhs)
 	{
-		return MultOperator::Make(lhs,Float::Make(rhs));
+		return MultOperator::Make(lhs,Complex::Make(rhs));
 	}
 
 	inline std::shared_ptr<Node> operator*(std::shared_ptr<Node> lhs, mpfr_complex const& rhs)
 	{
-		return MultOperator::Make(lhs,Float::Make(rhs));
+		return MultOperator::Make(lhs,Complex::Make(rhs));
 	}
 	
 	inline std::shared_ptr<Node> operator*(mpfr_float const& lhs,  std::shared_ptr<Node> rhs)
 	{
-		return MultOperator::Make(Float::Make(lhs), rhs);
+		return MultOperator::Make(Complex::Make(lhs), rhs);
 	}
 
 	inline std::shared_ptr<Node> operator*(mpfr_complex const& lhs,  std::shared_ptr<Node> rhs)
 	{
-		return MultOperator::Make(Float::Make(lhs), rhs);
+		return MultOperator::Make(Complex::Make(lhs), rhs);
 	}
 
 	inline std::shared_ptr<Node> operator*(std::shared_ptr<Node> lhs, int rhs)
@@ -1383,22 +1383,22 @@ namespace node{
 	
 	inline std::shared_ptr<Node> operator/(std::shared_ptr<Node> lhs, mpfr_float rhs)
 	{
-		return MultOperator::Make(lhs, true, Float::Make(rhs), false);
+		return MultOperator::Make(lhs, true, Complex::Make(rhs), false);
 	}
 
 	inline std::shared_ptr<Node> operator/(std::shared_ptr<Node> lhs, mpfr_complex rhs)
 	{
-		return MultOperator::Make(lhs, true, Float::Make(rhs), false);
+		return MultOperator::Make(lhs, true, Complex::Make(rhs), false);
 	}
 	
 	inline std::shared_ptr<Node> operator/(mpfr_float lhs,  std::shared_ptr<Node> rhs)
 	{
-		return MultOperator::Make(Float::Make(lhs), true, rhs, false);
+		return MultOperator::Make(Complex::Make(lhs), true, rhs, false);
 	}
 
 	inline std::shared_ptr<Node> operator/(mpfr_complex lhs,  std::shared_ptr<Node> rhs)
 	{
-		return MultOperator::Make(Float::Make(lhs), true, rhs, false);
+		return MultOperator::Make(Complex::Make(lhs), true, rhs, false);
 	}
 
 	inline std::shared_ptr<Node> operator/(std::shared_ptr<Node> lhs, int rhs)

--- a/core/include/bertini2/function_tree/symbols/number.hpp
+++ b/core/include/bertini2/function_tree/symbols/number.hpp
@@ -36,7 +36,7 @@
 /**
 \file number.hpp
 
-\brief Provides the Number Node types, including Rational, Float, and Integer
+\brief Provides the Number Node types, including Rational, Complex, and Integer
 
 */
 
@@ -251,18 +251,23 @@ namespace node{
 
 
 	/**
-	\brief Number type for storing floating point numbers within an expression tree.  
+	\brief A complex-number literal node in an expression tree.
 
-	 Number type for storing floating point numbers within an expression tree.  The number passed in at construct time is stored as the true value, and evaluation down or up samples from this 'true value'.  Consider using a Rational or Integer if possible.
+	Stores an arbitrary-precision **complex** value (mpfr_complex) -- a real-valued literal is just
+	the special case with zero imaginary part.  The value passed at construction time is held as the
+	'true value' at its authored precision, and evaluation down- or up-samples from it.  Despite the
+	historical "float" name this node carried, it is NOT real-only: it holds a full complex number.
+	Prefer a Rational or Integer when the coefficient is exact -- they evaluate faster and to
+	arbitrary precision without a stored sample.
 	*/
-	class Float : public Number
+	class Complex : public Number
 	{
 	public:
 		BERTINI_DEFAULT_VISITABLE()
 
 
 
-		~Float() = default;
+		~Complex() = default;
 		
 
 
@@ -299,14 +304,14 @@ namespace node{
 
 		std::size_t HashImpl() const override
 		{
-			std::size_t h = typeid(Float).hash_code();
+			std::size_t h = typeid(Complex).hash_code();
 			HashCombine(h, std::hash<std::string>{}(highest_precision_value_.real().str()));
 			HashCombine(h, std::hash<std::string>{}(highest_precision_value_.imag().str()));
 			return h;
 		}
 		bool IsSame(Node const& other) const override
 		{
-			auto o = dynamic_cast<Float const*>(&other);
+			auto o = dynamic_cast<Complex const*>(&other);
 			return o
 				&& highest_precision_value_.real() == o->highest_precision_value_.real()
 				&& highest_precision_value_.imag() == o->highest_precision_value_.imag();
@@ -314,26 +319,26 @@ namespace node{
 
 		template<typename... Ts>
 		static
-		std::shared_ptr<Float> Make(Ts&& ...ts){
-			return std::static_pointer_cast<Float>(Intern(std::shared_ptr<Node>( new Float(ts...) )));
+		std::shared_ptr<Complex> Make(Ts&& ...ts){
+			return std::static_pointer_cast<Complex>(Intern(std::shared_ptr<Node>( new Complex(ts...) )));
 		}
 
 	private:
 
 		explicit
-		Float(mpfr_complex const& val) : highest_precision_value_(val)
+		Complex(mpfr_complex const& val) : highest_precision_value_(val)
 		{}
 
 		explicit
-		Float(mpfr_float const& rval, mpfr_float const& ival = 0) : highest_precision_value_(rval,ival)
+		Complex(mpfr_float const& rval, mpfr_float const& ival = 0) : highest_precision_value_(rval,ival)
 		{}
 
 		explicit
-		Float(std::string const& val) : highest_precision_value_(val)
+		Complex(std::string const& val) : highest_precision_value_(val)
 		{}
 
 		explicit
-		Float(std::string const& rval, std::string const& ival) : highest_precision_value_(rval,ival)
+		Complex(std::string const& rval, std::string const& ival) : highest_precision_value_(rval,ival)
 		{}
 
 
@@ -341,7 +346,7 @@ namespace node{
 		mpfr_complex highest_precision_value_;
 
 		friend class boost::serialization::access;
-		Float() = default;
+		Complex() = default;
 		template <typename Archive>
 		void serialize(Archive& ar, const unsigned /*version*/) {
 			ar & boost::serialization::base_object<Number>(*this);

--- a/core/include/bertini2/io/parsing/function_rules.hpp
+++ b/core/include/bertini2/io/parsing/function_rules.hpp
@@ -142,7 +142,7 @@ namespace bertini {
 			struct FunctionParser : qi::grammar<Iterator, std::shared_ptr<node::Node>(), boost::spirit::ascii::space_type>
 			{
 				using Node = node::Node;
-				using Float = node::Float;
+				using Complex = node::Complex;
 				using Integer = node::Integer;
 				using Rational = node::Rational;
 				
@@ -238,7 +238,7 @@ namespace bertini {
 					
 					number_.name("number_");
 					number_ =
-					mpfr_rules_.long_number_string_ [ _val = make_shared_<Float>()(_1) ]
+					mpfr_rules_.long_number_string_ [ _val = make_shared_<Complex>()(_1) ]
 					|
 					mpfr_rules_.integer_string_ [ _val = make_shared_<Integer>()(_1) ];
 					

--- a/core/include/bertini2/system/straight_line_program.hpp
+++ b/core/include/bertini2/system/straight_line_program.hpp
@@ -261,16 +261,16 @@ namespace bertini {
 	 (re)produce the constant's value at any working precision, without evaluating a function-tree
 	 node (ADR-0027; node evaluation is being retired).  Integers and rationals are stored exactly
 	 (so they downsample to any precision without loss --- sidestepping any maximum-precision
-	 setting); Pi/E are recomputed at the working precision; a Float literal carries its
+	 setting); Pi/E are recomputed at the working precision; a Complex literal carries its
 	 authored-precision value (its inherent ceiling).
 	 */
 	struct ConstantRecipe{
-		enum class Kind : int { Integer, Rational, Float, Pi, E };
+		enum class Kind : int { Integer, Rational, Complex, Pi, E };
 
 		Kind kind = Kind::Integer;
 		mpz_int      int_value;             //< Kind::Integer  (exact)
 		mpq_rational rat_real, rat_imag;    //< Kind::Rational (exact)
-		mpfr_complex float_value;           //< Kind::Float (authored-precision literal; also a fixed variable's value)
+		mpfr_complex float_value;           //< Kind::Complex (authored-precision literal; also a fixed variable's value)
 		size_t slot = 0;                    //< where this constant lives in the register file
 
 		/// Produce the constant's value at the ambient working precision (ThreadPrecision), matching
@@ -816,7 +816,7 @@ namespace bertini {
 			// symbols and roots
 			public Visitor<node::Variable>,
 			public Visitor<node::Integer>,
-			public Visitor<node::Float>,
+			public Visitor<node::Complex>,
 			public Visitor<node::Rational>,
 			public Visitor<node::NamedExpression>,
 			public Visitor<node::Differential>,
@@ -870,7 +870,7 @@ namespace bertini {
 			// symbols and roots
 			virtual void Visit(node::Variable const& n);
 			virtual void Visit(node::Integer const& n);
-			virtual void Visit(node::Float const& n);
+			virtual void Visit(node::Complex const& n);
 			virtual void Visit(node::Rational const& n);
 			virtual void Visit(node::NamedExpression const& n);
 			virtual void Visit(node::Differential const& n);

--- a/core/src/function_tree/node.cpp
+++ b/core/src/function_tree/node.cpp
@@ -34,7 +34,7 @@
 BOOST_CLASS_EXPORT_IMPLEMENT(bertini::node::Variable)
 BOOST_CLASS_EXPORT_IMPLEMENT(bertini::node::Differential)
 
-BOOST_CLASS_EXPORT_IMPLEMENT(bertini::node::Float)
+BOOST_CLASS_EXPORT_IMPLEMENT(bertini::node::Complex)
 BOOST_CLASS_EXPORT_IMPLEMENT(bertini::node::Integer)
 BOOST_CLASS_EXPORT_IMPLEMENT(bertini::node::Rational)
 

--- a/core/src/function_tree/operators/arithmetic.cpp
+++ b/core/src/function_tree/operators/arithmetic.cpp
@@ -885,7 +885,7 @@ namespace {
 	dbl ConstantExponentValue(std::shared_ptr<Node> const& n)
 	{
 		if (auto i = std::dynamic_pointer_cast<Integer const>(n))  return dbl(double(i->GetValue()), 0);
-		if (auto f = std::dynamic_pointer_cast<Float const>(n))    return dbl(f->GetValue());
+		if (auto f = std::dynamic_pointer_cast<Complex const>(n))    return dbl(f->GetValue());
 		if (auto r = std::dynamic_pointer_cast<Rational const>(n)) return r->Value<dbl>();
 		return dbl(std::numeric_limits<double>::quiet_NaN(), 0);
 	}

--- a/core/src/function_tree/special_number.cpp
+++ b/core/src/function_tree/special_number.cpp
@@ -41,7 +41,7 @@ namespace node{
 
 	std::shared_ptr<Node> I()
 	{
-		return MakeFloat(0,1);
+		return MakeComplex(0,1);
 	}
 
 

--- a/core/src/function_tree/symbols/number.cpp
+++ b/core/src/function_tree/symbols/number.cpp
@@ -58,7 +58,7 @@ void Integer::print(std::ostream & target) const
 ////////////////
 
 
-void Float::print(std::ostream & target) const
+void Complex::print(std::ostream & target) const
 {
 	// real-valued floats print bare; the complex pair form is reserved for
 	// genuinely complex values

--- a/core/src/function_tree/symbols/special_number.cpp
+++ b/core/src/function_tree/symbols/special_number.cpp
@@ -71,7 +71,7 @@ std::shared_ptr<Node> E()
 
 std::shared_ptr<Node> I()
 {
-	return Float::Make(0,1);
+	return Complex::Make(0,1);
 }
 
 

--- a/core/src/system/straight_line_program.cpp
+++ b/core/src/system/straight_line_program.cpp
@@ -64,7 +64,7 @@ namespace bertini{
 
 	// Produce a constant's value directly from its exact recipe --- no function-tree node, no node
 	// evaluation (ADR-0027).  These mirror the number nodes' FreshEval_d / FreshEval_mp exactly
-	// (Integer/Float/Rational in number.cpp; Pi/E in special_number.cpp) so the compiled program
+	// (Integer/Complex/Rational in number.cpp; Pi/E in special_number.cpp) so the compiled program
 	// evaluates bit-for-bit identically to the old node-backed path, at the ambient working
 	// precision (ThreadPrecision).
 	template<>
@@ -72,7 +72,7 @@ namespace bertini{
 		switch (kind) {
 			case Kind::Integer:  return dbl_complex(double(int_value), 0);
 			case Kind::Rational: return dbl_complex(double(rat_real), double(rat_imag));
-			case Kind::Float:    return dbl_complex(float_value);
+			case Kind::Complex:    return dbl_complex(float_value);
 			case Kind::Pi:       return dbl_complex(boost::math::constants::pi<double>(), 0);
 			case Kind::E:        return dbl_complex(exp(1.0), 0.0);
 		}
@@ -85,7 +85,7 @@ namespace bertini{
 		switch (kind) {
 			case Kind::Integer:  return mpfr_complex(int_value, 0, ThreadPrecision());
 			case Kind::Rational: return mpfr_complex(mpfr_float(rat_real, ThreadPrecision()), mpfr_float(rat_imag, ThreadPrecision()));
-			case Kind::Float:    return mpfr_complex(float_value, ThreadPrecision());
+			case Kind::Complex:    return mpfr_complex(float_value, ThreadPrecision());
 			case Kind::Pi:       return mpfr_complex(boost::math::constants::pi<mpfr_float>());
 			case Kind::E:        return mpfr_complex(mpfr_float(exp(mpfr_float(1))));
 		}
@@ -412,7 +412,7 @@ namespace bertini{
 	void SLPProgram::PartitionInstructions()
 	{
 		// A memory slot is "frozen" if its value depends only on frozen inputs.  Seed: the literal
-		// numbers (Integer/Float/Rational and Pi/E, all in true_values_of_numbers_) are frozen; the
+		// numbers (Integer/Complex/Rational and Pi/E, all in true_values_of_numbers_) are frozen; the
 		// variable and time slots are live.  Then a single forward pass propagates frozenness: an
 		// instruction is frozen iff all its input slots are frozen, and it freezes its output slot.
 		const size_t num_slots = num_slots_;
@@ -496,8 +496,8 @@ namespace bertini{
 			ConstantRecipe r; r.kind = ConstantRecipe::Kind::Rational;
 			r.rat_real = n.GetValueReal(); r.rat_imag = n.GetValueImag(); return r;
 		}
-		ConstantRecipe RecipeFor(node::Float const& n){
-			ConstantRecipe r; r.kind = ConstantRecipe::Kind::Float; r.float_value = n.GetValue(); return r;
+		ConstantRecipe RecipeFor(node::Complex const& n){
+			ConstantRecipe r; r.kind = ConstantRecipe::Kind::Complex; r.float_value = n.GetValue(); return r;
 		}
 		ConstantRecipe RecipeFor(node::special_number::Pi const&){
 			ConstantRecipe r; r.kind = ConstantRecipe::Kind::Pi; return r;
@@ -519,7 +519,7 @@ namespace bertini{
 		// A system's variables are all pre-registered before its function trees are compiled, so
 		// reaching this Visit means a function references a variable that is not in the system's
 		// variable ordering.  That is unsupported: to bake a constant into a function, build it with
-		// a literal (Float / Integer / Rational), not a variable removed from the ordering.
+		// a literal (Complex / Integer / Rational), not a variable removed from the ordering.
 		throw std::runtime_error("SLP compile: a function references the variable '" + n.name() +
 			"', which is not in the system's variable ordering");
 	}
@@ -539,7 +539,7 @@ namespace bertini{
 		this->RegisterConstant(n.shared_from_this(), RecipeFor(n));
 	}
 
-	void SLPCompiler::Visit(node::Float const& n){
+	void SLPCompiler::Visit(node::Complex const& n){
 		this->RegisterConstant(n.shared_from_this(), RecipeFor(n));
 	}
 

--- a/core/src/system/system.cpp
+++ b/core/src/system/system.cpp
@@ -896,13 +896,13 @@ namespace bertini
 		Nd LinearFormNode(Mat<mpfr_complex> const& M, Eigen::Index r,
 		                  VariableGroup const& vars, size_t num_vars)
 		{
-			Nd form = node::Float::Make(M(r, static_cast<Eigen::Index>(num_vars))); // constant term
+			Nd form = node::Complex::Make(M(r, static_cast<Eigen::Index>(num_vars))); // constant term
 			for (size_t c = 0; c < num_vars; ++c)
 			{
 				mpfr_complex const& coeff = M(r, static_cast<Eigen::Index>(c));
 				if (coeff.real() == 0 && coeff.imag() == 0)
 					continue;
-				form = form + node::Float::Make(coeff) * vars[c];
+				form = form + node::Complex::Make(coeff) * vars[c];
 			}
 			return form;
 		}
@@ -988,7 +988,7 @@ namespace bertini
 							mpfr_complex const& c = R(static_cast<Eigen::Index>(i), static_cast<Eigen::Index>(j));
 							if (c.real() == 0 && c.imag() == 0)
 								continue;
-							Nd term = Float::Make(c) * fj[j];
+							Nd term = Complex::Make(c) * fj[j];
 							if (hom)
 								for (size_t g = 0; g < homvars.size(); ++g)
 								{
@@ -1020,7 +1020,7 @@ namespace bertini
 								mpfr_complex const& coeff = M(r, static_cast<Eigen::Index>(c));
 								if (coeff.real() == 0 && coeff.imag() == 0)
 									continue;
-								Nd term = node::Float::Make(coeff) * vars[c];
+								Nd term = node::Complex::Make(coeff) * vars[c];
 								form = form ? (form + term) : term;
 							}
 							out.push_back(form ? form : Nd(Integer::Make(0)));
@@ -1551,7 +1551,7 @@ namespace bertini
 	{
 		auto t = node::Variable::Make(path_variable_name);
 		auto g = gamma ? gamma
-		               : std::static_pointer_cast<node::Node>(node::Float::Make(bertini::multiprecision::RandomUnit(MaxPrecisionAllowed())));  // gamma trick: norm-1 complex at max precision (a Float node caps at its creation precision, so generate the constant at the AMP ceiling -- like patch coefficients -- rather than the current default)
+		               : std::static_pointer_cast<node::Node>(node::Complex::Make(bertini::multiprecision::RandomUnit(MaxPrecisionAllowed())));  // gamma trick: norm-1 complex at max precision (a Complex node caps at its creation precision, so generate the constant at the AMP ceiling -- like patch coefficients -- rather than the current default)
 
 		System homotopy;
 		if (start.HasStructuredBlocks() || target.HasStructuredBlocks())
@@ -1635,7 +1635,7 @@ namespace bertini
 
 		auto t = node::Variable::Make(path_variable_name);
 		auto g = gamma ? gamma
-		               : std::static_pointer_cast<node::Node>(node::Float::Make(bertini::multiprecision::RandomUnit(MaxPrecisionAllowed())));  // gamma trick: norm-1 complex at max precision (a Float node caps at its creation precision, so generate the constant at the AMP ceiling -- like patch coefficients -- rather than the current default)
+		               : std::static_pointer_cast<node::Node>(node::Complex::Make(bertini::multiprecision::RandomUnit(MaxPrecisionAllowed())));  // gamma trick: norm-1 complex at max precision (a Complex node caps at its creation precision, so generate the constant at the AMP ceiling -- like patch coefficients -- rather than the current default)
 
 		// Keep the fixed system's blocks as sibling blocks (do NOT clear them): they are autonomous,
 		// so they are evaluated once per point and contribute nothing to dH/dt as the moving rows

--- a/core/test/classes/homogenization_test.cpp
+++ b/core/test/classes/homogenization_test.cpp
@@ -38,11 +38,11 @@
 BOOST_AUTO_TEST_SUITE(homogenization)
 
 using Variable = bertini::node::Variable;
-using Float = bertini::node::Float;
+using Complex = bertini::node::Complex;
 using mpfr_float = bertini::mpfr_float;
 using Var = std::shared_ptr<bertini::node::Variable>;
 
-using Flt = std::shared_ptr<bertini::node::Float>;
+using Flt = std::shared_ptr<bertini::node::Complex>;
 using VariableGroup = bertini::VariableGroup;
 using dbl = bertini::dbl;
 using mpfr = bertini::mpfr_complex;
@@ -421,7 +421,7 @@ BOOST_AUTO_TEST_CASE(nothomogeneous_sqrt_x)
 
 BOOST_AUTO_TEST_CASE(is_homogeneous_sin_0)
 {
-	Flt n = Float::Make("1");
+	Flt n = Complex::Make("1");
 
 	auto f1 = sin(n);
 	
@@ -432,7 +432,7 @@ BOOST_AUTO_TEST_CASE(is_homogeneous_sin_0)
 
 BOOST_AUTO_TEST_CASE(is_homogeneous_cos_1)
 {
-	Flt n = Float::Make("1");
+	Flt n = Complex::Make("1");
 
 	auto f1 = cos(n);
 	
@@ -443,7 +443,7 @@ BOOST_AUTO_TEST_CASE(is_homogeneous_cos_1)
 
 BOOST_AUTO_TEST_CASE(is_homogeneous_sin_1_plus_1)
 {
-	Flt n = Float::Make("1");
+	Flt n = Complex::Make("1");
 
 	auto f1 = sin(n + n);
 	

--- a/core/test/classes/moving_homotopy_test.cpp
+++ b/core/test/classes/moving_homotopy_test.cpp
@@ -35,7 +35,7 @@ using bertini::node::Variable;
 // gamma fixed off the real axis for reproducibility.
 static std::shared_ptr<node::Node> Gamma()
 {
-	return node::Float::Make(mpfr_complex("0.6", "0.8"));
+	return node::Complex::Make(mpfr_complex("0.6", "0.8"));
 }
 
 // A LinearFormsBlock-backed single-form system  c.[x;1]  over variables {x,y}.

--- a/core/test/classes/node_serialization_test.cpp
+++ b/core/test/classes/node_serialization_test.cpp
@@ -60,7 +60,7 @@ template<typename NumT> using Vec = bertini::Vec<NumT>;
 template<typename NumT> using Mat = bertini::Mat<NumT>;
 using Variable = bertini::node::Variable;
 using Node = bertini::node::Node;
-using Float = bertini::node::Float;
+using Complex = bertini::node::Complex;
 
 
 using dbl = bertini::dbl;
@@ -98,7 +98,7 @@ BOOST_AUTO_TEST_CASE(serialize_variable)
 
 BOOST_AUTO_TEST_CASE(serialize_float)
 {
-	std::shared_ptr<Float> two_point_oh_four = Float::Make("2.04");
+	std::shared_ptr<Complex> two_point_oh_four = Complex::Make("2.04");
 
 	{
 		std::ofstream fout("serialization_test_node");
@@ -109,7 +109,7 @@ BOOST_AUTO_TEST_CASE(serialize_float)
 		oa << two_point_oh_four;
 	}
 	
-	std::shared_ptr<Float> two_point_oh_four2;
+	std::shared_ptr<Complex> two_point_oh_four2;
 	{
 		std::ifstream fin("serialization_test_node");
 		

--- a/core/test/classes/system_printing_test.cpp
+++ b/core/test/classes/system_printing_test.cpp
@@ -107,7 +107,7 @@ BOOST_AUTO_TEST_CASE(moving_homotopy_blend)
 	System fixed; fixed.AddVariableGroup(VariableGroup{x, y}); fixed.AddFunction(x*x + y*y - node::Integer::Make(1));
 	System sm; sm.AddVariableGroup(VariableGroup{x, y}); sm.AddFunction(y);
 	System em; em.AddVariableGroup(VariableGroup{x, y}); em.AddFunction(y - x);
-	System H = MakeMovingHomotopy(fixed, sm, em, "t", node::Float::Make(mpfr_complex("0.6", "0.8")));
+	System H = MakeMovingHomotopy(fixed, sm, em, "t", node::Complex::Make(mpfr_complex("0.6", "0.8")));
 
 	std::string t = Terse(H);
 	BOOST_CHECK(Has(t, "f_0 = "));               // the fixed polynomial row

--- a/core/test/classes/system_test.cpp
+++ b/core/test/classes/system_test.cpp
@@ -694,7 +694,7 @@ by a Node and must also invalidate is_differentiated_.
 */
 BOOST_AUTO_TEST_CASE(operator_mult_equals_invalidates_slp_cache)
 {
-	using bertini::node::Float;
+	using bertini::node::Complex;
 
 	bertini::System sys;
 	Var x = Variable::Make("x"), y = Variable::Make("y");
@@ -709,7 +709,7 @@ BOOST_AUTO_TEST_CASE(operator_mult_equals_invalidates_slp_cache)
 	values << dbl(1.0), dbl(2.0);
 	(void) sys.Eval(values);          // primes SLP for f = x+y
 
-	sys *= Float::Make("3.0");        // f should now be 3*(x+y)
+	sys *= Complex::Make("3.0");        // f should now be 3*(x+y)
 
 	auto after = sys.Eval(values);    // expected [9], currently [3]
 	BOOST_CHECK_EQUAL(after(0), dbl(9.0));

--- a/core/test/tracking_basics/euler_test.cpp
+++ b/core/test/tracking_basics/euler_test.cpp
@@ -47,7 +47,7 @@ BOOST_AUTO_TEST_SUITE(euler_predict_tracking_basics)
 
 using System = bertini::System;
 using Variable = bertini::node::Variable;
-using Float = bertini::node::Float;
+using Complex = bertini::node::Complex;
 using ExplicitRKPredictor = bertini::tracking::predict::ExplicitRKPredictor;
 
 using Var = std::shared_ptr<Variable>;

--- a/core/test/tracking_basics/heun_test.cpp
+++ b/core/test/tracking_basics/heun_test.cpp
@@ -45,7 +45,7 @@ BOOST_AUTO_TEST_SUITE(heun_predict_tracking_basics)
 
 using System = bertini::System;
 using Variable = bertini::node::Variable;
-using Float = bertini::node::Float;
+using Complex = bertini::node::Complex;
 using ExplicitRKPredictor = bertini::tracking::predict::ExplicitRKPredictor;
 
 
@@ -241,7 +241,7 @@ BOOST_AUTO_TEST_CASE(circle_line_heun_double)
 		
 		bertini::System sys;
 		Var x = Variable::Make("x"), y = Variable::Make("y"), t = Variable::Make("t");
-		std::shared_ptr<Float> half = Float::Make("0.5");
+		std::shared_ptr<Complex> half = Complex::Make("0.5");
 		
 		VariableGroup vars{x,y};
 		
@@ -321,7 +321,7 @@ BOOST_AUTO_TEST_CASE(circle_line_heun_double)
 		
 		bertini::System sys;
 		Var x = Variable::Make("x"), y = Variable::Make("y"), t = Variable::Make("t");
-		std::shared_ptr<Float> half = Float::Make("0.5");
+		std::shared_ptr<Complex> half = Complex::Make("0.5");
 		
 		VariableGroup vars{x,y};
 		

--- a/core/test/tracking_basics/higher_predictor_test.cpp
+++ b/core/test/tracking_basics/higher_predictor_test.cpp
@@ -46,7 +46,7 @@ BOOST_AUTO_TEST_SUITE(higher_predict_tracking_basics)
 
 using System = bertini::System;
 using Variable = bertini::node::Variable;
-using Float = bertini::node::Float;
+using Complex = bertini::node::Complex;
 using ExplicitRKPredictor = bertini::tracking::predict::ExplicitRKPredictor;
 
 using Var = std::shared_ptr<Variable>;
@@ -566,7 +566,7 @@ BOOST_AUTO_TEST_CASE(monodromy_RKF45_d)
 	
 	bertini::System sys;
 	Var x = Variable::Make("x"), y = Variable::Make("y"), t = Variable::Make("t");
-	std::shared_ptr<Float> half = Float::Make("0.5");
+	std::shared_ptr<Complex> half = Complex::Make("0.5");
 	
 	VariableGroup vars{x,y};
 	
@@ -645,7 +645,7 @@ BOOST_AUTO_TEST_CASE(monodromy_RKF45_mp)
 	
 	bertini::System sys;
 	Var x = Variable::Make("x"), y = Variable::Make("y"), t = Variable::Make("t");
-	std::shared_ptr<Float> half = Float::Make("0.5");
+	std::shared_ptr<Complex> half = Complex::Make("0.5");
 	
 	VariableGroup vars{x,y};
 	
@@ -915,7 +915,7 @@ BOOST_AUTO_TEST_CASE(monodromy_RKCK45_d)
 	
 	bertini::System sys;
 	Var x = Variable::Make("x"), y = Variable::Make("y"), t = Variable::Make("t");
-	std::shared_ptr<Float> half = Float::Make("0.5");
+	std::shared_ptr<Complex> half = Complex::Make("0.5");
 	
 	VariableGroup vars{x,y};
 	
@@ -994,7 +994,7 @@ BOOST_AUTO_TEST_CASE(monodromy_RKCK45_mp)
 	
 	bertini::System sys;
 	Var x = Variable::Make("x"), y = Variable::Make("y"), t = Variable::Make("t");
-	std::shared_ptr<Float> half = Float::Make("0.5");
+	std::shared_ptr<Complex> half = Complex::Make("0.5");
 	
 	VariableGroup vars{x,y};
 	
@@ -1077,7 +1077,7 @@ BOOST_AUTO_TEST_CASE(monodromy_RKCK45_mp_change_precision)
 	
 	bertini::System sys;
 	Var x = Variable::Make("x"), y = Variable::Make("y"), t = Variable::Make("t");
-	std::shared_ptr<Float> half = Float::Make("0.5");
+	std::shared_ptr<Complex> half = Complex::Make("0.5");
 	
 	VariableGroup vars{x,y};
 	
@@ -1532,7 +1532,7 @@ BOOST_AUTO_TEST_CASE(monodromy_RKDP56_d)
 	
 	bertini::System sys;
 	Var x = Variable::Make("x"), y = Variable::Make("y"), t = Variable::Make("t");
-	std::shared_ptr<Float> half = Float::Make("0.5");
+	std::shared_ptr<Complex> half = Complex::Make("0.5");
 	
 	VariableGroup vars{x,y};
 	
@@ -1611,7 +1611,7 @@ BOOST_AUTO_TEST_CASE(monodromy_RKDP56_mp)
 	
 	bertini::System sys;
 	Var x = Variable::Make("x"), y = Variable::Make("y"), t = Variable::Make("t");
-	std::shared_ptr<Float> half = Float::Make("0.5");
+	std::shared_ptr<Complex> half = Complex::Make("0.5");
 	
 	VariableGroup vars{x,y};
 	
@@ -1868,7 +1868,7 @@ BOOST_AUTO_TEST_CASE(monodromy_RKV67_d)
 	
 	bertini::System sys;
 	Var x = Variable::Make("x"), y = Variable::Make("y"), t = Variable::Make("t");
-	std::shared_ptr<Float> half = Float::Make("0.5");
+	std::shared_ptr<Complex> half = Complex::Make("0.5");
 	
 	VariableGroup vars{x,y};
 	
@@ -1947,7 +1947,7 @@ BOOST_AUTO_TEST_CASE(monodromy_RKV67_mp)
 	
 	bertini::System sys;
 	Var x = Variable::Make("x"), y = Variable::Make("y"), t = Variable::Make("t");
-	std::shared_ptr<Float> half = Float::Make("0.5");
+	std::shared_ptr<Complex> half = Complex::Make("0.5");
 	
 	VariableGroup vars{x,y};
 	

--- a/python/bertini/linalg.py
+++ b/python/bertini/linalg.py
@@ -52,7 +52,7 @@ downstream computation.  Pass the value exactly instead.
 import numpy as np
 from fractions import Fraction
 
-from bertini.function_tree.symbol import Variable, Integer, Rational, Float
+from bertini.function_tree.symbol import Variable, Integer, Rational, Complex
 from bertini import multiprec as _mp
 
 try:
@@ -61,9 +61,9 @@ except ImportError:  # pragma: no cover - fall back to the native module
     from bertini._pybertini.function_tree import AbstractNode as _AbstractNode
 
 # bertini multiprecision value types (not function-tree nodes) that we accept as exact
-# coefficients by wrapping them in a Float node.
+# coefficients by wrapping them in a Complex node.
 _MP_VALUE_TYPES = tuple(
-    t for t in (getattr(_mp, n, None) for n in ('Complex', 'Float', 'Int', 'Rational'))
+    t for t in (getattr(_mp, n, None) for n in ('Float', 'Complex', 'Int', 'Rational'))
     if isinstance(t, type)
 )
 
@@ -127,9 +127,9 @@ def coefficient(value):
     if isinstance(value, Fraction):
         return Rational(str(value))            # 'p/q', or 'p' when the denominator is 1
     if isinstance(value, str):
-        return Rational(value) if '/' in value else Float(value)
+        return Rational(value) if '/' in value else Complex(value)
     if _MP_VALUE_TYPES and isinstance(value, _MP_VALUE_TYPES):
-        return Float(value)
+        return Complex(value)
     if isinstance(value, (float, complex, np.floating, np.complexfloating)):
         raise TypeError(
             f"refusing to use the Python {type(value).__name__} {value!r} as a coefficient: "

--- a/python/bertini/sympy_bridge.py
+++ b/python/bertini/sympy_bridge.py
@@ -113,7 +113,7 @@ def from_sympy(expr, variables=None):
         if isinstance(e, _sp.Rational):  # after Integer: Integer is a Rational in sympy
             return _sym.Rational(f'{e.p}/{e.q}')
         if isinstance(e, _sp.Float):
-            return _sym.Float(str(e))
+            return _sym.Complex(str(e))
         if e is _sp.pi:
             return _sym.make_pi()
         if e is _sp.E:
@@ -245,7 +245,7 @@ def to_sympy(node):
         re = _exact_rational(n.value_real())
         im = _exact_rational(n.value_imag())
         return re if im == 0 else re + _sp.I * im
-    if isinstance(n, _sym.Float):
+    if isinstance(n, _sym.Complex):
         v = n.value()
         digits = v.real.precision
         # repr is full-precision (str truncates to ostream's default 6 digits)

--- a/python/test/classes/differentiation_test.py
+++ b/python/test/classes/differentiation_test.py
@@ -61,14 +61,14 @@ def tol_mp():
 
 @pytest.fixture
 def diffvars():
-    # variables, two Float constants, and the evaluation point (a superset map; eval_at takes only
+    # variables, two Complex constants, and the evaluation point (a superset map; eval_at takes only
     # the variables each partial derivative actually contains).
     x = Variable("x")
     y = Variable("y")
     z = Variable('z')
     p = Variable('p')
-    a = Float(mpfr_complex("3.12", ".612"))
-    b = Float(mpfr_complex("-.823", "2.62"))
+    a = Complex(mpfr_complex("3.12", ".612"))
+    b = Complex(mpfr_complex("-.823", "2.62"))
     pt = dict(x=mpfr_complex("-2.43", ".21"), y=mpfr_complex("4.84", "-1.94"),
               z=mpfr_complex("-6.48", "-.731"), p=mpfr_complex("-.321", "-.72"))
     return x, y, z, p, a, b, pt

--- a/python/test/classes/function_tree_test.py
+++ b/python/test/classes/function_tree_test.py
@@ -70,15 +70,15 @@ def sym():
 
 def test_Float_construct(sym):
     x_d, y_d, z_d, p_d, tol_d, x_mp, y_mp, z_mp, p_mp, tol_mp = sym
-    x = Float("4.3", "-9e-3")
-    x = Float(y_mp)
-    x = Float(mpfr_float("9.3"), mpfr_float("-3"))
-    x = Float("9.2", "-43.2e2")
+    x = Complex("4.3", "-9e-3")
+    x = Complex(y_mp)
+    x = Complex(mpfr_float("9.3"), mpfr_float("-3"))
+    x = Complex("9.2", "-43.2e2")
 
 
 def test_Float_funcs(sym):
     x_d, y_d, z_d, p_d, tol_d, x_mp, y_mp, z_mp, p_mp, tol_mp = sym
-    x = Float(x_mp); y = Float(y_mp); z = Float(z_mp)
+    x = Complex(x_mp); y = Complex(y_mp); z = Complex(z_mp)
     #
     assert x.degree() == 0
     y.differentiate()                 # a constant differentiates without error
@@ -134,15 +134,15 @@ def test_special_constants_construct():
 
 @pytest.fixture
 def op():
-    """Variables and Float constants for the structural operator tests (degree / homogeneity /
+    """Variables and Complex constants for the structural operator tests (degree / homogeneity /
     polynomiality / homogenization).  Operator value-correctness is verified through the SLP in
     eval_expression_test.py, not by evaluating nodes here."""
     x = Variable("x")
     y = Variable("y")
     z = Variable("z")
     p = Variable("p")
-    a = Float(mpfr_complex("3.12", ".612"))
-    b = Float(mpfr_complex("-.823", "2.62"))
+    a = Complex(mpfr_complex("3.12", ".612"))
+    b = Complex(mpfr_complex("-.823", "2.62"))
     tol_d = float(9e-14)
     tol_mp = mpfr_float("1e-27")
     return x, y, z, p, a, b, tol_d, tol_mp

--- a/python/test/classes/node_introspection_test.py
+++ b/python/test/classes/node_introspection_test.py
@@ -120,7 +120,7 @@ def test_rational_value_exact():
 
 
 def test_float_value():
-    n = sym.Float('2.5')  # exactly representable in binary
+    n = sym.Complex('2.5')  # exactly representable in binary
     v = n.value()
     assert v.real == mp.Float('2.5')
     assert v.imag == mp.Float(0)
@@ -188,8 +188,8 @@ def _rebuild(n):
         return sym.Integer(n.value())
     if isinstance(n, sym.Rational):
         return sym.Rational(n.value_real(), n.value_imag())
-    if isinstance(n, sym.Float):
-        return sym.Float(n.value())
+    if isinstance(n, sym.Complex):
+        return sym.Complex(n.value())
     raise NotImplementedError(type(n).__name__)
 
 

--- a/python/test/classes/sympy_bridge_test.py
+++ b/python/test/classes/sympy_bridge_test.py
@@ -139,9 +139,9 @@ def test_reverse_jacobian_form_raises():
 def test_reverse_float_precision_carry():
     mp.default_precision(50)
     fifty = '1.' + '3' * 49
-    from bertini.function_tree.symbol import Float
-    expr = to_sympy(Float(fifty))
-    # the mpfr precision rides into sympy's Float; allow the last digits to round
+    from bertini.function_tree.symbol import Complex
+    expr = to_sympy(Complex(fifty))
+    # the mpfr precision rides into sympy's Complex; allow the last digits to round
     assert str(expr)[:48] == fifty[:48]
 
 

--- a/python/test/classes/system_test.py
+++ b/python/test/classes/system_test.py
@@ -62,7 +62,7 @@ def variables():
 @pytest.fixture
 def fg(variables):
     x, y, z = variables
-    a = Float("4.897", "1.23")
+    a = Complex("4.897", "1.23")
     f = (x*y)
     g = (pow(x, 2)*y - a*z*x)
     return f, g

--- a/python_bindings/include/function_tree_export.hpp
+++ b/python_bindings/include/function_tree_export.hpp
@@ -55,7 +55,7 @@ namespace bertini{
 		void SetupFunctionTree()
 		{
 			// Tell Python that pointers to derived Nodes can be used as Node pointers when passed to methods
-			implicitly_convertible<std::shared_ptr<Float>, Nodeptr>();
+			implicitly_convertible<std::shared_ptr<Complex>, Nodeptr>();
 			implicitly_convertible<std::shared_ptr<special_number::Pi>, Nodeptr>();
 			implicitly_convertible<std::shared_ptr<special_number::E>, Nodeptr>();
 			implicitly_convertible<std::shared_ptr<Integer>, Nodeptr>();

--- a/python_bindings/src/function_tree.cpp
+++ b/python_bindings/src/function_tree.cpp
@@ -51,7 +51,7 @@ namespace bertini{
 		void SetupFunctionTree()
 		{
 			// Tell Python that pointers to derived Nodes can be used as Node pointers
-			implicitly_convertible<std::shared_ptr<node::Float>, Nodeptr>();
+			implicitly_convertible<std::shared_ptr<node::Complex>, Nodeptr>();
 			implicitly_convertible<std::shared_ptr<node::special_number::Pi>, Nodeptr>();
 			implicitly_convertible<std::shared_ptr<node::special_number::E>, Nodeptr>();
 			implicitly_convertible<std::shared_ptr<node::Variable>, Nodeptr>();

--- a/python_bindings/src/symbol_export.cpp
+++ b/python_bindings/src/symbol_export.cpp
@@ -115,13 +115,20 @@ namespace bertini{
 			class_<Number, boost::noncopyable, bases<Symbol>, std::shared_ptr<Number> >("AbstractNumber", no_init)
 			;
 			
-			// Float class
-			class_<Float, bases<Number>, std::shared_ptr<Float> >("Float", no_init)
-			.def("__init__", make_constructor(&Float::template Make<mpfr_float const&, mpfr_float const&>))
-			.def("__init__", make_constructor(&Float::template Make<std::string const&>))
-			.def("__init__", make_constructor(&Float::template Make<std::string const&, std::string const&>))
-			.def("__init__", make_constructor(&Float::template Make<mpfr_complex const&>))
-			.def("value", &Float::GetValue, return_value_policy<copy_const_reference>(), "the literal value this node represents, at its stored (highest) precision")
+			// Complex class -- a complex-number literal node (NOT a real "float"): it stores a full
+			// arbitrary-precision complex value; a real literal is the zero-imaginary special case.
+			// Construct from one argument (the real part, or a multiprec value) or two (real, imag).
+			// Prefer Integer/Rational for exact coefficients -- they are faster and need no stored sample.
+			class_<Complex, bases<Number>, std::shared_ptr<Complex> >("Complex",
+				"A complex-number literal node in an expression tree.  Holds a full arbitrary-precision "
+				"complex value (a real literal is just zero imaginary part).  Build it as Complex(real) "
+				"or Complex(real, imag) from exact strings/multiprec values; prefer Integer or Rational "
+				"for exact non-irrational coefficients.", no_init)
+			.def("__init__", make_constructor(&Complex::template Make<mpfr_float const&, mpfr_float const&>))
+			.def("__init__", make_constructor(&Complex::template Make<std::string const&>))
+			.def("__init__", make_constructor(&Complex::template Make<std::string const&, std::string const&>))
+			.def("__init__", make_constructor(&Complex::template Make<mpfr_complex const&>))
+			.def("value", &Complex::GetValue, return_value_policy<copy_const_reference>(), "the literal value this node represents, at its stored (highest) precision")
 			;
 			
 			


### PR DESCRIPTION
The function-tree literal node named `Float` actually stores an arbitrary-precision **complex** value (a real literal is just zero imaginary part), so the name was misleading. Hard rename to `Complex`, freeing `Real` for a future real-only literal node — and the foundation for the tiered-SLP-arithmetic sprint.

**Breaking (pre-release, no alias):** C++ `bertini::node::Complex` (was `Float`), free factory `MakeComplex` (was `MakeFloat`), SLP `Kind::Complex`, Python `function_tree.symbol.Complex` (was `Float`). Old serialized archives (keyed by type name) won't load.

**Not touched:** the multiprec **value** types `bertini.multiprec.Float` / `.Complex` (mpfr_float / mpfr_complex) keep their names — only the tree node moved.

## Tests
- All 10 C++ suites pass (incl. node serialization).
- Full pytest green (530 passed); the value/node disambiguation verified (the `multiprec.Float` binding and `linalg._MP_VALUE_TYPES` were carefully left intact after an over-match was caught and fixed).
- Docstrings clarified: the node holds a complex number, not a real "float".

🤖 Generated with [Claude Code](https://claude.com/claude-code)