### PR TITLE
refactor!: standardize scalar numeric type names (real/complex × dbl/mp)

### DIFF
--- a/core/example/parameter_homotopy/include/my_system.hpp
+++ b/core/example/parameter_homotopy/include/my_system.hpp
@@ -9,7 +9,7 @@ namespace demo{
 	using Node = std::shared_ptr<bertini::node::Node>;
 	using Variable = std::shared_ptr<bertini::node::Variable>;
 
-	using dbl = bertini::dbl;
+	using complex_dbl = bertini::complex_dbl;
 	using mpfr = bertini::mpfr;
 
 	auto MakeStep1Parameters()

--- a/core/example/parameter_homotopy/src/main.cpp
+++ b/core/example/parameter_homotopy/src/main.cpp
@@ -48,7 +48,7 @@ int main()
             bertini::mpfr v;
             bertini::RandomReal(v, 30);
             p->precision(30);
-            p->set_current_value(bertini::dbl(v));
+            p->set_current_value(bertini::complex_dbl(v));
             p->set_current_value(v);
         }
 
@@ -56,7 +56,7 @@ int main()
 
         // std::cout << "your target system for step2:\n" << target_sys_step2 << '\n';
         // for (auto& p : std::get<1>(step2_stuff))
-        //     std::cout << "solving for parameter values " << *p <<  " " << p->Eval<bertini::dbl>() << '\n';
+        //     std::cout << "solving for parameter values " << *p <<  " " << p->Eval<bertini::complex_dbl>() << '\n';
 
         auto steptwo_solutions = demo::StepTwo(target_sys_step2, target_sys_step1, homotopy_sys_step2, stepone_solutions);
         

--- a/core/example/performance_numbers/include/construct_system.hpp
+++ b/core/example/performance_numbers/include/construct_system.hpp
@@ -5,7 +5,7 @@
 
 template<typename NumType> using Vec = Eigen::Matrix<NumType, Eigen::Dynamic, 1>;
 template<typename NumType> using Mat = Eigen::Matrix<NumType, Eigen::Dynamic, Eigen::Dynamic>;
-using dbl = bertini::dbl;
+using complex_dbl = bertini::complex_dbl;
 using mpfr = bertini::mpfr;
 
 namespace demo{

--- a/core/example/performance_numbers/src/main.cpp
+++ b/core/example/performance_numbers/src/main.cpp
@@ -29,9 +29,9 @@ int main()
     
     
     
-    auto v_d = demo::GenerateSystemInput<dbl>(sys1);
-    auto b_d = demo::GenerateRHS<dbl>(sys1);
-    auto A_d = demo::GenerateMatrix<dbl>(matrix_N);
+    auto v_d = demo::GenerateSystemInput<complex_dbl>(sys1);
+    auto b_d = demo::GenerateRHS<complex_dbl>(sys1);
+    auto A_d = demo::GenerateMatrix<complex_dbl>(matrix_N);
     auto v_mp = demo::GenerateSystemInput<mpfr>(sys1);
     auto b_mp = demo::GenerateRHS<mpfr>(sys1);
     auto A_mp = demo::GenerateMatrix<mpfr>(matrix_N);

--- a/core/include/bertini2/blackbox/global_configs.hpp
+++ b/core/include/bertini2/blackbox/global_configs.hpp
@@ -66,7 +66,7 @@ struct Configs
 
 
 struct Defaults : 
-detail::Configured<Configs::All<bertini::dbl>, Configs::All<bertini::mpfr_complex>>
+detail::Configured<Configs::All<bertini::complex_dbl>, Configs::All<bertini::complex_mp>>
 {
 
 

--- a/core/include/bertini2/double_extensions.hpp
+++ b/core/include/bertini2/double_extensions.hpp
@@ -43,8 +43,10 @@ namespace bertini{
 // Avoids pulling mpfr_complex.hpp into the Boost.Multiprecision include chain.
 std::mt19937& ThreadEngine();
 
-	using dbl = std::complex<double>;
-	using dbl_complex = std::complex<double>;
+	// The two double-precision scalar types, named to parallel real_mp / complex_mp.
+	// real_dbl is an explicit alias for double so a future change lives in one place.
+	using real_dbl = double;
+	using complex_dbl = std::complex<double>;
 
 	/**
 	\brief Overload * for unsigned * complex<double>
@@ -78,7 +80,8 @@ std::mt19937& ThreadEngine();
 	}
 
 	namespace{
-		using dbl = std::complex<double>;
+		using real_dbl = double;
+		using complex_dbl = std::complex<double>;
 	}
 
 	/**
@@ -88,13 +91,13 @@ std::mt19937& ThreadEngine();
 
 	 \note This overload was removed from C++ in C++11, for some insane reason.  Here it is, back in black.
 	 */
-	inline dbl pow(const dbl & z, int power)
+	inline complex_dbl pow(const complex_dbl & z, int power)
 	{
 		if (power < 0) {
 			return pow(1./z, -power);
 		}
 		else if (power==0)
-			return dbl(1,0);
+			return complex_dbl(1,0);
 		else if(power==1)
 			return z;
 		else if(power==2)
@@ -104,7 +107,7 @@ std::mt19937& ThreadEngine();
 		else
 		{
 			unsigned int p(static_cast<unsigned int>(power));
-			dbl result(1,0), z_to_the_current_power_of_two = z;
+			complex_dbl result(1,0), z_to_the_current_power_of_two = z;
 			// have copy of p in memory, can freely modify it.
 			do {
 				if ( (p & 1) == 1 ) { // get the lowest bit of the number

--- a/core/include/bertini2/eigen_extensions.hpp
+++ b/core/include/bertini2/eigen_extensions.hpp
@@ -43,8 +43,8 @@
 #include <Eigen/Core>
 
 namespace {
-using mpfr_real = bertini::mpfr_float;
-using mpfr_complex = bertini::mpfr_complex;
+using mpfr_real = bertini::real_mp;
+using complex_mp = bertini::complex_mp;
 }
 
 namespace Eigen {
@@ -117,15 +117,15 @@ namespace Eigen {
 
 
 	/**
-	 \brief This templated struct permits us to use the mpfr_complex type in Eigen matrices.
+	 \brief This templated struct permits us to use the complex_mp type in Eigen matrices.
 
 	 Provides methods to get the epsilon, dummy_precision, lowest, highest functions, largely by inheritance from the NumTraits<mpfr_real> contained in mpfr_extensions.
 	 */
-	template<> struct NumTraits<mpfr_complex> : NumTraits<mpfr_real>
+	template<> struct NumTraits<complex_mp> : NumTraits<mpfr_real>
 	{
 		typedef mpfr_real Real;
 		typedef mpfr_real NonInteger;
-		typedef mpfr_complex Nested;// Nested;
+		typedef complex_mp Nested;// Nested;
 		enum {
 			IsComplex = 1,
 			IsInteger = 0,
@@ -140,29 +140,29 @@ namespace Eigen {
 
 	namespace internal {
 		template<>
-		struct abs2_impl<mpfr_complex>
+		struct abs2_impl<complex_mp>
 		{
-			static inline mpfr_real run(const mpfr_complex& x)
+			static inline mpfr_real run(const complex_mp& x)
 			{
 				return real(x)*real(x) + imag(x)*imag(x);
 			}
 		};
 
 
-		template<> inline mpfr_complex random<mpfr_complex>()
+		template<> inline complex_mp random<complex_mp>()
 		{
 			return bertini::multiprecision::rand();
 		}
 
-		template<> inline mpfr_complex random<mpfr_complex>(const mpfr_complex& a, const mpfr_complex& b)
+		template<> inline complex_mp random<complex_mp>(const complex_mp& a, const complex_mp& b)
 		{
-			return a + (b-a) * random<mpfr_complex>();
+			return a + (b-a) * random<complex_mp>();
 		}
 
 		template<>
-		struct conj_helper<mpfr_complex, mpfr_complex, false, true>
+		struct conj_helper<complex_mp, complex_mp, false, true>
 		{
-			typedef mpfr_complex Scalar;
+			typedef complex_mp Scalar;
 			EIGEN_STRONG_INLINE Scalar pmadd(const Scalar& x, const Scalar& y, const Scalar& c) const
 			{ return c + pmul(x,y); }
 
@@ -171,9 +171,9 @@ namespace Eigen {
 		};
 
 		template<>
-		struct conj_helper<mpfr_complex, mpfr_complex, true, false>
+		struct conj_helper<complex_mp, complex_mp, true, false>
 		{
-			typedef mpfr_complex Scalar;
+			typedef complex_mp Scalar;
 			EIGEN_STRONG_INLINE Scalar pmadd(const Scalar& x, const Scalar& y, const Scalar& c) const
 			{ return c + pmul(x,y); }
 
@@ -185,78 +185,78 @@ namespace Eigen {
 
 		//int
 		template<>
-		struct scalar_product_traits<int,mpfr_complex>
+		struct scalar_product_traits<int,complex_mp>
 		{
 	    	enum { Defined = 1 };
-	    	typedef mpfr_complex ReturnType;
+	    	typedef complex_mp ReturnType;
 		};
 
 		template<>
-		struct scalar_product_traits<mpfr_complex, int>
+		struct scalar_product_traits<complex_mp, int>
 		{
 	    	enum { Defined = 1 };
-	    	typedef mpfr_complex ReturnType;
+	    	typedef complex_mp ReturnType;
 		};
 
 		//long
 		template<>
-		struct scalar_product_traits<long,mpfr_complex>
+		struct scalar_product_traits<long,complex_mp>
 		{
 	    	enum { Defined = 1 };
-	    	typedef mpfr_complex ReturnType;
+	    	typedef complex_mp ReturnType;
 		};
 
 		template<>
-		struct scalar_product_traits<mpfr_complex, long>
+		struct scalar_product_traits<complex_mp, long>
 		{
 	    	enum { Defined = 1 };
-	    	typedef mpfr_complex ReturnType;
+	    	typedef complex_mp ReturnType;
 		};
 
 		//long long
 		template<>
-		struct scalar_product_traits<long long,mpfr_complex>
+		struct scalar_product_traits<long long,complex_mp>
 		{
 	    	enum { Defined = 1 };
-	    	typedef mpfr_complex ReturnType;
+	    	typedef complex_mp ReturnType;
 		};
 
 		template<>
-		struct scalar_product_traits<mpfr_complex, long long>
+		struct scalar_product_traits<complex_mp, long long>
 		{
 	    	enum { Defined = 1 };
-	    	typedef mpfr_complex ReturnType;
+	    	typedef complex_mp ReturnType;
 		};
 
 
 		//mpfr_real
 		template<>
-		struct scalar_product_traits<mpfr_real,mpfr_complex>
+		struct scalar_product_traits<mpfr_real,complex_mp>
 		{
 	    	enum { Defined = 1 };
-	    	typedef mpfr_complex ReturnType;
+	    	typedef complex_mp ReturnType;
 		};
 
 		template<>
-		struct scalar_product_traits<mpfr_complex, mpfr_real>
+		struct scalar_product_traits<complex_mp, mpfr_real>
 		{
 	    	enum { Defined = 1 };
-	    	typedef mpfr_complex ReturnType;
+	    	typedef complex_mp ReturnType;
 		};
 
 		//mpz_int
 		template<>
-		struct scalar_product_traits<bertini::mpz_int,mpfr_complex>
+		struct scalar_product_traits<bertini::mpz_int,complex_mp>
 		{
 	    	enum { Defined = 1 };
-	    	typedef mpfr_complex ReturnType;
+	    	typedef complex_mp ReturnType;
 		};
 
 		template<>
-		struct scalar_product_traits<mpfr_complex, bertini::mpz_int>
+		struct scalar_product_traits<complex_mp, bertini::mpz_int>
 		{
 	    	enum { Defined = 1 };
-	    	typedef mpfr_complex ReturnType;
+	    	typedef complex_mp ReturnType;
 		};
 
 	} // re: namespace internal

--- a/core/include/bertini2/endgames/amp_endgame.hpp
+++ b/core/include/bertini2/endgames/amp_endgame.hpp
@@ -76,14 +76,14 @@ public:
 	}
 
 	static
-	void EnsureAtPrecision(mpfr_float & obj, unsigned prec)
+	void EnsureAtPrecision(real_mp & obj, unsigned prec)
 	{
 		using bertini::Precision;
 		Precision(obj,prec);
 	}
 
 	static
-	void EnsureAtPrecision(mpfr_complex & obj, unsigned prec)
+	void EnsureAtPrecision(complex_mp & obj, unsigned prec)
 	{
 		using bertini::Precision;
 		Precision(obj,prec);
@@ -91,7 +91,7 @@ public:
 
 
 
-	SuccessCode RefineSampleImpl(Vec<mpfr_complex> & result, Vec<mpfr_complex> const& current_sample, mpfr_complex const& current_time, NumErrorT tol, unsigned max_iterations) const
+	SuccessCode RefineSampleImpl(Vec<complex_mp> & result, Vec<complex_mp> const& current_sample, complex_mp const& current_time, NumErrorT tol, unsigned max_iterations) const
 	{
 
 		using bertini::Precision;
@@ -124,7 +124,7 @@ public:
 			auto next_sample_higher_prec = current_sample;
 			Precision(next_sample_higher_prec, higher_precision);
 
-			auto result_higher_prec = Vec<mpfr_complex>(current_sample.size());
+			auto result_higher_prec = Vec<complex_mp>(current_sample.size());
 
 			auto time_higher_precision = current_time;
 			Precision(time_higher_precision,higher_precision);

--- a/core/include/bertini2/endgames/cauchy.hpp
+++ b/core/include/bertini2/endgames/cauchy.hpp
@@ -561,21 +561,21 @@ public:
 	/*
 	Input: A time value and the space value above that time.
 
-	Output: An mpfr_float representing a tolerance threshold for declaring a loop to be closed.
+	Output: An real_mp representing a tolerance threshold for declaring a loop to be closed.
 	Details: Used in Bertini 1 as a heuristic for computing separatedness of roots. Decided to not be used since assumptions for this tolerance are not usually met.
 	template<typename ComplexT>
-	mpfr_float FindToleranceForClosedLoop(ComplexT x_time, Vec<ComplexT> x_sample)
+	real_mp FindToleranceForClosedLoop(ComplexT x_time, Vec<ComplexT> x_sample)
 	{
-		auto degree_max = std::max(this->GetTracker().AMP_config_.degree_bound,mpfr_float("2.0"));
+		auto degree_max = std::max(this->GetTracker().AMP_config_.degree_bound,real_mp("2.0"));
 		auto K = this->GetTracker().AMP_config_.coefficient_bound;
-		mpfr_float N;
-		mpfr_float M;
-		mpfr_float L;
+		real_mp N;
+		real_mp M;
+		real_mp L;
 		if(max_closed_loop_tolerance_ < min_closed_loop_tolerance_)
 		{
 			max_closed_loop_tolerance_ = min_closed_loop_tolerance_;
 		}
-		auto error_tolerance = mpfr_float("1e-13");
+		auto error_tolerance = real_mp("1e-13");
 		if(x_sample.size() <= 1)
 		{
 			N = degree_max;
@@ -594,7 +594,7 @@ public:
 					tol = minimum_singular_value;
 			else
 			{
-			tol = mpfr_float("2.0") / tol;
+			tol = real_mp("2.0") / tol;
 		tol = tol * minimum_singular_value;
 			}
 			// make sure that tol is between min_tol & max_tol

--- a/core/include/bertini2/function_tree/operators/arithmetic.hpp
+++ b/core/include/bertini2/function_tree/operators/arithmetic.hpp
@@ -247,8 +247,8 @@ namespace node{
 			temp_mp_.precision(prec);
 		}
 
-		mutable mpfr_complex temp_mp_;
-		mutable dbl temp_d_;
+		mutable complex_mp temp_mp_;
+		mutable complex_dbl temp_d_;
 
 		friend MultOperator;
 	};
@@ -520,8 +520,8 @@ namespace node{
 			temp_mp_.precision(prec);
 		}
 
-		mutable mpfr_complex temp_mp_;
-		mutable dbl temp_d_;
+		mutable complex_mp temp_mp_;
+		mutable complex_dbl temp_d_;
 
 		friend SumOperator;
 	};
@@ -1027,14 +1027,14 @@ namespace node{
 
 	std::shared_ptr<Node> pow(const std::shared_ptr<Node> & N, double p) = delete;
 	
-	std::shared_ptr<Node> pow(const std::shared_ptr<Node> & N, dbl p) = delete;
+	std::shared_ptr<Node> pow(const std::shared_ptr<Node> & N, complex_dbl p) = delete;
 
-	inline std::shared_ptr<Node> pow(const std::shared_ptr<Node> & N, mpfr_float p)
+	inline std::shared_ptr<Node> pow(const std::shared_ptr<Node> & N, real_mp p)
 	{
 		return PowerOperator::Make(N,Complex::Make(p));
 	}
 
-	inline std::shared_ptr<Node> pow(const std::shared_ptr<Node> & N, mpfr_complex p)
+	inline std::shared_ptr<Node> pow(const std::shared_ptr<Node> & N, complex_mp p)
 	{
 		return PowerOperator::Make(N,Complex::Make(p));
 	}
@@ -1117,22 +1117,22 @@ namespace node{
 		return SumOperator::Make(lhs,rhs);
 	}
 	
-	inline std::shared_ptr<Node> operator+(std::shared_ptr<Node> lhs, mpfr_float const& rhs)
+	inline std::shared_ptr<Node> operator+(std::shared_ptr<Node> lhs, real_mp const& rhs)
 	{
 		return SumOperator::Make(lhs,Complex::Make(rhs));
 	}
 
-	inline std::shared_ptr<Node> operator+(std::shared_ptr<Node> lhs, mpfr_complex const& rhs)
+	inline std::shared_ptr<Node> operator+(std::shared_ptr<Node> lhs, complex_mp const& rhs)
 	{
 		return SumOperator::Make(lhs,Complex::Make(rhs));
 	}
 	
-	inline std::shared_ptr<Node> operator+(mpfr_float const& lhs,  std::shared_ptr<Node> rhs)
+	inline std::shared_ptr<Node> operator+(real_mp const& lhs,  std::shared_ptr<Node> rhs)
 	{
 		return SumOperator::Make(Complex::Make(lhs), rhs);
 	}
 
-	inline std::shared_ptr<Node> operator+(mpfr_complex const& lhs,  std::shared_ptr<Node> rhs)
+	inline std::shared_ptr<Node> operator+(complex_mp const& lhs,  std::shared_ptr<Node> rhs)
 	{
 		return SumOperator::Make(Complex::Make(lhs), rhs);
 	}
@@ -1189,22 +1189,22 @@ namespace node{
 		return SumOperator::Make(lhs,true,rhs,false);
 	}
 	
-	inline std::shared_ptr<Node> operator-(std::shared_ptr<Node> lhs, mpfr_float const& rhs)
+	inline std::shared_ptr<Node> operator-(std::shared_ptr<Node> lhs, real_mp const& rhs)
 	{
 		return SumOperator::Make(lhs, true, Complex::Make(rhs), false);
 	}
 
-	inline std::shared_ptr<Node> operator-(mpfr_float const& lhs,  std::shared_ptr<Node> rhs)
+	inline std::shared_ptr<Node> operator-(real_mp const& lhs,  std::shared_ptr<Node> rhs)
 	{
 		return SumOperator::Make(Complex::Make(lhs), true, rhs, false);
 	}
 
-	inline std::shared_ptr<Node> operator-(std::shared_ptr<Node> lhs, mpfr_complex const& rhs)
+	inline std::shared_ptr<Node> operator-(std::shared_ptr<Node> lhs, complex_mp const& rhs)
 	{
 		return SumOperator::Make(lhs, true, Complex::Make(rhs), false);
 	}
 
-	inline std::shared_ptr<Node> operator-(mpfr_complex const& lhs,  std::shared_ptr<Node> rhs)
+	inline std::shared_ptr<Node> operator-(complex_mp const& lhs,  std::shared_ptr<Node> rhs)
 	{
 		return SumOperator::Make(Complex::Make(lhs), true, rhs, false);
 	}
@@ -1251,22 +1251,22 @@ namespace node{
 	}
 	
 	
-	inline std::shared_ptr<Node> operator*(std::shared_ptr<Node> lhs, mpfr_float const& rhs)
+	inline std::shared_ptr<Node> operator*(std::shared_ptr<Node> lhs, real_mp const& rhs)
 	{
 		return MultOperator::Make(lhs,Complex::Make(rhs));
 	}
 
-	inline std::shared_ptr<Node> operator*(std::shared_ptr<Node> lhs, mpfr_complex const& rhs)
+	inline std::shared_ptr<Node> operator*(std::shared_ptr<Node> lhs, complex_mp const& rhs)
 	{
 		return MultOperator::Make(lhs,Complex::Make(rhs));
 	}
 	
-	inline std::shared_ptr<Node> operator*(mpfr_float const& lhs,  std::shared_ptr<Node> rhs)
+	inline std::shared_ptr<Node> operator*(real_mp const& lhs,  std::shared_ptr<Node> rhs)
 	{
 		return MultOperator::Make(Complex::Make(lhs), rhs);
 	}
 
-	inline std::shared_ptr<Node> operator*(mpfr_complex const& lhs,  std::shared_ptr<Node> rhs)
+	inline std::shared_ptr<Node> operator*(complex_mp const& lhs,  std::shared_ptr<Node> rhs)
 	{
 		return MultOperator::Make(Complex::Make(lhs), rhs);
 	}
@@ -1381,22 +1381,22 @@ namespace node{
 		return lhs/=rhs;
 	}
 	
-	inline std::shared_ptr<Node> operator/(std::shared_ptr<Node> lhs, mpfr_float rhs)
+	inline std::shared_ptr<Node> operator/(std::shared_ptr<Node> lhs, real_mp rhs)
 	{
 		return MultOperator::Make(lhs, true, Complex::Make(rhs), false);
 	}
 
-	inline std::shared_ptr<Node> operator/(std::shared_ptr<Node> lhs, mpfr_complex rhs)
+	inline std::shared_ptr<Node> operator/(std::shared_ptr<Node> lhs, complex_mp rhs)
 	{
 		return MultOperator::Make(lhs, true, Complex::Make(rhs), false);
 	}
 	
-	inline std::shared_ptr<Node> operator/(mpfr_float lhs,  std::shared_ptr<Node> rhs)
+	inline std::shared_ptr<Node> operator/(real_mp lhs,  std::shared_ptr<Node> rhs)
 	{
 		return MultOperator::Make(Complex::Make(lhs), true, rhs, false);
 	}
 
-	inline std::shared_ptr<Node> operator/(mpfr_complex lhs,  std::shared_ptr<Node> rhs)
+	inline std::shared_ptr<Node> operator/(complex_mp lhs,  std::shared_ptr<Node> rhs)
 	{
 		return MultOperator::Make(Complex::Make(lhs), true, rhs, false);
 	}

--- a/core/include/bertini2/function_tree/symbols/number.hpp
+++ b/core/include/bertini2/function_tree/symbols/number.hpp
@@ -253,7 +253,7 @@ namespace node{
 	/**
 	\brief A complex-number literal node in an expression tree.
 
-	Stores an arbitrary-precision **complex** value (mpfr_complex) -- a real-valued literal is just
+	Stores an arbitrary-precision **complex** value (complex_mp) -- a real-valued literal is just
 	the special case with zero imaginary part.  The value passed at construction time is held as the
 	'true value' at its authored precision, and evaluation down- or up-samples from it.  Despite the
 	historical "float" name this node carried, it is NOT real-only: it holds a full complex number.
@@ -287,7 +287,7 @@ namespace node{
 		/**
 		\brief Get the literal value this node represents, at its stored (highest) precision.
 		*/
-		mpfr_complex const& GetValue() const
+		complex_mp const& GetValue() const
 		{
 			return highest_precision_value_;
 		}
@@ -326,11 +326,11 @@ namespace node{
 	private:
 
 		explicit
-		Complex(mpfr_complex const& val) : highest_precision_value_(val)
+		Complex(complex_mp const& val) : highest_precision_value_(val)
 		{}
 
 		explicit
-		Complex(mpfr_float const& rval, mpfr_float const& ival = 0) : highest_precision_value_(rval,ival)
+		Complex(real_mp const& rval, real_mp const& ival = 0) : highest_precision_value_(rval,ival)
 		{}
 
 		explicit
@@ -343,14 +343,14 @@ namespace node{
 
 
 
-		mpfr_complex highest_precision_value_;
+		complex_mp highest_precision_value_;
 
 		friend class boost::serialization::access;
 		Complex() = default;
 		template <typename Archive>
 		void serialize(Archive& ar, const unsigned /*version*/) {
 			ar & boost::serialization::base_object<Number>(*this);
-			ar & const_cast<mpfr_complex &>(highest_precision_value_);
+			ar & const_cast<complex_mp &>(highest_precision_value_);
 		}
 	};
 
@@ -362,7 +362,7 @@ namespace node{
 	/**
 	\brief The Rational number type for Bertini2 expression trees.
 
-	The Rational number type for Bertini2 expression trees.  The `true value' is stored using two mpq_rational numbers from the Boost.Multiprecision library, and the ratio is converted into a double or a mpfr_complex at evaluate time.
+	The Rational number type for Bertini2 expression trees.  The `true value' is stored using two mpq_rational numbers from the Boost.Multiprecision library, and the ratio is converted into a double or a complex_mp at evaluate time.
 	*/
 	class Rational : public Number
 	{
@@ -442,13 +442,13 @@ namespace node{
 
 		Unlike Eval, this does no caching and never touches the node's stored working
 		value --- it is a pure read of the literal.  It matches the literal's conversion:
-		double truncation for dbl, and a value at the current thread precision for mpfr.
+		double truncation for complex_dbl, and a value at the current thread precision for mpfr.
 		*/
 		template<typename NumT>
 		NumT Value() const
 		{
-			if constexpr (std::is_same<NumT, dbl>::value)
-				return dbl(double(true_value_real_), double(true_value_imag_));
+			if constexpr (std::is_same<NumT, complex_dbl>::value)
+				return complex_dbl(double(true_value_real_), double(true_value_imag_));
 			else
 				return NumT(boost::multiprecision::mpfr_float(true_value_real_, ThreadPrecision()),
 				            boost::multiprecision::mpfr_float(true_value_imag_, ThreadPrecision()));

--- a/core/include/bertini2/io/classic_writer.hpp
+++ b/core/include/bertini2/io/classic_writer.hpp
@@ -168,7 +168,7 @@ namespace bertini{
 			out << "maxnumbersteps: "         << opt.maxnumbersteps         << ";\n";
 			out << "maxnewtonits: "           << opt.maxnewtonits           << ";\n";
 			out << "maxcrossedpathresolves: " << opt.maxcrossedpathresolves << ";\n";
-			out << "coefficientbound: "       << num(static_cast<double>(sys.CoefficientBound<dbl>())) << ";\n";
+			out << "coefficientbound: "       << num(static_cast<double>(sys.CoefficientBound<complex_dbl>())) << ";\n";
 			out << "degreebound: "            << sys.DegreeBound()          << ";\n";
 		}
 

--- a/core/include/bertini2/io/generators.hpp
+++ b/core/include/bertini2/io/generators.hpp
@@ -63,10 +63,10 @@ BOOST_MATH_STD_USING
 
 
 // BOOST_FUSION_ADAPT_ADT(
-//     bertini::mpfr_complex,
+//     bertini::complex_mp,
 //     (bool, bool, obj.imag() != 0, /**/)
-//     (bertini::mpfr_float, bertini::mpfr_float, obj.real(), /**/)
-//     (bertini::mpfr_float, bertini::mpfr_float, obj.imag(), /**/)
+//     (bertini::real_mp, bertini::real_mp, obj.real(), /**/)
+//     (bertini::real_mp, bertini::real_mp, obj.imag(), /**/)
 // )
 
 
@@ -87,12 +87,12 @@ namespace bertini{
 		};
 
 		template<>
-		struct BertiniNumPolicy<mpfr_float>  : public karma::real_policies<mpfr_float>
+		struct BertiniNumPolicy<real_mp>  : public karma::real_policies<real_mp>
 		{
 		    // we want the numbers always to be in scientific format
-		    static int floatfield(mpfr_float /*n*/) { return std::ios_base::scientific; }
+		    static int floatfield(real_mp /*n*/) { return std::ios_base::scientific; }
 
-		    static unsigned int precision(mpfr_float const& x) {
+		    static unsigned int precision(real_mp const& x) {
 		        return x.precision();
 		      }
 		};
@@ -103,7 +103,7 @@ namespace bertini{
 		using FullPrec = boost::spirit::karma::real_generator<Num, BertiniNumPolicy<Num> >;
 
 		FullPrec<double> const full_prec_d = FullPrec<double>();
-		FullPrec<mpfr_float> const full_prec_mp = FullPrec<mpfr_float>();
+		FullPrec<real_mp> const full_prec_mp = FullPrec<real_mp>();
 
 
 		struct Classic{
@@ -148,7 +148,7 @@ namespace bertini{
 
 
 			template <typename OutputIterator>
-			static bool generate(OutputIterator sink, mpfr_float const& c)
+			static bool generate(OutputIterator sink, real_mp const& c)
 			{
 	            using boost::spirit::karma::omit;
 	            using boost::spirit::karma::generate;
@@ -167,7 +167,7 @@ namespace bertini{
 
 
 			template <typename OutputIterator>
-			static bool generate(OutputIterator sink, mpfr_complex const& c)
+			static bool generate(OutputIterator sink, complex_mp const& c)
 			{
 	            using boost::spirit::karma::omit;
 	            using boost::spirit::karma::generate;

--- a/core/include/bertini2/io/parsing/number_parsers.hpp
+++ b/core/include/bertini2/io/parsing/number_parsers.hpp
@@ -37,7 +37,7 @@ namespace bertini{
 
 		namespace classic{
 			template<typename Iterator, typename Skipper = ascii::space_type>
-			struct MpfrFloatParser : qi::grammar<Iterator, mpfr_float(), boost::spirit::ascii::space_type>
+			struct MpfrFloatParser : qi::grammar<Iterator, real_mp(), boost::spirit::ascii::space_type>
 			{
 				MpfrFloatParser() : MpfrFloatParser::base_type(root_rule_,"MpfrFloatParser")
 				{
@@ -49,11 +49,11 @@ namespace bertini{
 					using qi::_4;
 					using qi::_val;
 
-					root_rule_.name("mpfr_float");
+					root_rule_.name("real_mp");
 					root_rule_ = mpfr_rules_.number_string_
 									[ phx::bind( 
 											[]
-											(mpfr_float & B, std::string const& P)
+											(real_mp & B, std::string const& P)
 											{
 												using std::max;
 												auto prev_prec = DefaultPrecision();
@@ -61,7 +61,7 @@ namespace bertini{
 												auto digits = max(P.size(),static_cast<decltype(P.size())>(asdf));
 
 												B.precision(static_cast<unsigned>(digits));
-												B = mpfr_float(P,static_cast<unsigned>(digits));
+												B = real_mp(P,static_cast<unsigned>(digits));
 											},
 											_val,_1
 										)
@@ -73,13 +73,13 @@ namespace bertini{
 					);
 				}
 
-				qi::rule<Iterator, mpfr_float(), Skipper > root_rule_;
+				qi::rule<Iterator, real_mp(), Skipper > root_rule_;
 				rules::LongNum<Iterator> mpfr_rules_;
 			};
 
 
 			template<typename Iterator, typename Skipper = ascii::space_type>
-			struct MpfrComplexParser : qi::grammar<Iterator, mpfr_complex(), boost::spirit::ascii::space_type>
+			struct MpfrComplexParser : qi::grammar<Iterator, complex_mp(), boost::spirit::ascii::space_type>
 			{
 				MpfrComplexParser() : MpfrComplexParser::base_type(root_rule_,"MpfrComplexParser")
 				{
@@ -93,7 +93,7 @@ namespace bertini{
 					(mpfr_float_ >> mpfr_float_)
 					[ phx::bind(
 								[]
-								(mpfr_complex & B, mpfr_float const& P, mpfr_float const& Q)
+								(complex_mp & B, real_mp const& P, real_mp const& Q)
 								{
 									auto digits = max(P.precision(),Q.precision());
 									
@@ -107,7 +107,7 @@ namespace bertini{
 					 ];
 				}
 				
-				qi::rule<Iterator, mpfr_complex(), Skipper > root_rule_;
+				qi::rule<Iterator, complex_mp(), Skipper > root_rule_;
 				MpfrFloatParser<Iterator> mpfr_float_;
 			};
 
@@ -164,7 +164,7 @@ namespace bertini{
 			
 			
 			template <typename Iterator>
-			static bool parse(Iterator first, Iterator last, mpfr_float& c)
+			static bool parse(Iterator first, Iterator last, real_mp& c)
 			{
 				using boost::spirit::qi::double_;
 				using boost::spirit::qi::_1;
@@ -174,7 +174,7 @@ namespace bertini{
 				
 				MpfrFloatParser<Iterator> S;
 				
-				mpfr_float rN {0};
+				real_mp rN {0};
 				bool r = phrase_parse(first, last,
 									  S,
 									  space,
@@ -193,7 +193,7 @@ namespace bertini{
 			
 			
 			template <typename Iterator>
-			static bool parse(Iterator first, Iterator last, mpfr_complex& c)
+			static bool parse(Iterator first, Iterator last, complex_mp& c)
 			{
 				using boost::spirit::qi::double_;
 				using boost::spirit::qi::_1;
@@ -203,7 +203,7 @@ namespace bertini{
 				
 				MpfrComplexParser<Iterator> S;
 				
-				mpfr_complex rN {};
+				complex_mp rN {};
 				bool r = phrase_parse(first, last,
 									  S,
 									  space,

--- a/core/include/bertini2/io/parsing/number_rules.hpp
+++ b/core/include/bertini2/io/parsing/number_rules.hpp
@@ -39,7 +39,7 @@
 
 
 BOOST_FUSION_ADAPT_ADT(
-		    bertini::mpfr_complex,
+		    bertini::complex_mp,
 		    (obj.real(), obj.real(val))
 		    (obj.imag(), obj.imag(val)))
 

--- a/core/include/bertini2/io/parsing/settings_parsers/algorithm.hpp
+++ b/core/include/bertini2/io/parsing/settings_parsers/algorithm.hpp
@@ -235,7 +235,7 @@ namespace bertini {
 					// string to a multiprecision real, then to a rational (the homotopy times are real).
 					auto str_to_rational = [](mpq_rational & num, std::string str)
 									   {
-										   num = mpq_rational(mpfr_float(str));
+										   num = mpq_rational(real_mp(str));
 									   };
 
 

--- a/core/include/bertini2/mpfr_complex.hpp
+++ b/core/include/bertini2/mpfr_complex.hpp
@@ -58,9 +58,9 @@ namespace bmp = boost::multiprecision;
 using bmp::backends::mpc_complex_backend;
 
 #ifdef BMP_EXPRESSION_TEMPLATES
-	using mpfr_complex = bmp::number<mpc_complex_backend<0>, bmp::et_on >;
+	using complex_mp = bmp::number<mpc_complex_backend<0>, bmp::et_on >;
 #else
-	using mpfr_complex = bmp::number<mpc_complex_backend<0>, bmp::et_off >;
+	using complex_mp = bmp::number<mpc_complex_backend<0>, bmp::et_off >;
 #endif
 
 	inline auto DefaultPrecisionPolicy(){
@@ -76,19 +76,19 @@ using bmp::backends::mpc_complex_backend;
 	{
 	   boost::multiprecision::variable_precision_options saved_options;
 
-	   scoped_mpfr_precision_options_this_thread(boost::multiprecision::variable_precision_options opts) : saved_options(mpfr_float::thread_default_variable_precision_options())
+	   scoped_mpfr_precision_options_this_thread(boost::multiprecision::variable_precision_options opts) : saved_options(real_mp::thread_default_variable_precision_options())
 	   {
-	      mpfr_float::thread_default_variable_precision_options(opts);
+	      real_mp::thread_default_variable_precision_options(opts);
 	   }
 
 	   ~scoped_mpfr_precision_options_this_thread()
 	   {
-	      mpfr_float::thread_default_variable_precision_options(saved_options);
+	      real_mp::thread_default_variable_precision_options(saved_options);
 	   }
 
 	   void reset(boost::multiprecision::variable_precision_options opts)
 	   {
-	      mpfr_float::thread_default_variable_precision_options(opts);
+	      real_mp::thread_default_variable_precision_options(opts);
 	   }
 
 	};
@@ -101,23 +101,23 @@ using bmp::backends::mpc_complex_backend;
 	   boost::multiprecision::variable_precision_options saved_options_this_thread;
 
 	   scoped_mpfr_precision_options_all_threads(boost::multiprecision::variable_precision_options opts) :
-	   		saved_options_all_threads(mpfr_float::default_variable_precision_options()),
-	   		saved_options_this_thread(mpfr_float::default_variable_precision_options())
+	   		saved_options_all_threads(real_mp::default_variable_precision_options()),
+	   		saved_options_this_thread(real_mp::default_variable_precision_options())
 	   {
-	      mpfr_float::default_variable_precision_options(opts);
-	      mpfr_float::thread_default_variable_precision_options(opts);
+	      real_mp::default_variable_precision_options(opts);
+	      real_mp::thread_default_variable_precision_options(opts);
 	   }
 
 	   ~scoped_mpfr_precision_options_all_threads()
 	   {
-	      mpfr_float::default_variable_precision_options(saved_options_all_threads);
-	      mpfr_float::thread_default_variable_precision_options(saved_options_this_thread);
+	      real_mp::default_variable_precision_options(saved_options_all_threads);
+	      real_mp::thread_default_variable_precision_options(saved_options_this_thread);
 	   }
 
 	   void reset(boost::multiprecision::variable_precision_options opts)
 	   {
-	      mpfr_float::default_variable_precision_options(opts);
-	      mpfr_float::thread_default_variable_precision_options(opts);
+	      real_mp::default_variable_precision_options(opts);
+	      real_mp::thread_default_variable_precision_options(opts);
 	   }
 
 	};
@@ -129,22 +129,22 @@ using bmp::backends::mpc_complex_backend;
 
 	inline auto DefaultPrecision()
 	{
-		auto p = mpfr_float::default_precision();
-		assert(p==mpfr_complex::default_precision() && "precision of real and complex multiprecision numbers have drifted...");
+		auto p = real_mp::default_precision();
+		assert(p==complex_mp::default_precision() && "precision of real and complex multiprecision numbers have drifted...");
 		return p;
 	}
 
 	inline void DefaultPrecision(unsigned prec)
 	{
-		mpfr_float::default_precision(prec);
-		mpfr_complex::default_precision(prec);
+		real_mp::default_precision(prec);
+		complex_mp::default_precision(prec);
 		// Boost.Multiprecision >= 1.87 reads thread_default_precision when
 		// default-constructing mpfr temporaries (including those created by
 		// boost::python const& extractors). If left at 0, mpfr_init2 aborts.
 		// Set both so that calls to default_precision() align thread-local
 		// with the static default. See commit 3111255b for original context.
-		mpfr_float::thread_default_precision(prec);
-		mpfr_complex::thread_default_precision(prec);
+		real_mp::thread_default_precision(prec);
+		complex_mp::thread_default_precision(prec);
 #ifdef BMP_EXPRESSION_TEMPLATES
 		// With ET on, the default global policy for mpc_complex_backend is preserve_related_precision
 		// and for mpfr_float_backend it is preserve_target_precision. Both differ from what we want.
@@ -153,12 +153,12 @@ using bmp::backends::mpc_complex_backend;
 		//   - mpc_complex copy ctor uses preserve_related_precision() (>= 3) to preserve source precision
 		//   - assign_components_set_precision uses preserve_component_precision() (>= 2) to resize
 		//     a complex from real components at higher-than-default precision
-		//   - mpc_complex = mpfr_float uses preserve_component_precision() (>= 2) to resize
+		//   - mpc_complex = real_mp uses preserve_component_precision() (>= 2) to resize
 		// preserve_related_precision satisfies all three thresholds.
-		// For mpfr_float, preserve_related_precision also enables source-precision-preserving copies.
-		mpfr_float::thread_default_variable_precision_options(
+		// For real_mp, preserve_related_precision also enables source-precision-preserving copies.
+		real_mp::thread_default_variable_precision_options(
 			bmp::variable_precision_options::preserve_related_precision);
-		mpfr_complex::thread_default_variable_precision_options(
+		complex_mp::thread_default_variable_precision_options(
 			bmp::variable_precision_options::preserve_related_precision);
 #endif
 	}
@@ -168,13 +168,13 @@ using bmp::backends::mpc_complex_backend;
 	// precisions. Use instead of DefaultPrecision() inside per-thread tracking loops.
 	inline void SetThreadPrecision(unsigned prec)
 	{
-		mpfr_float::thread_default_precision(prec);
-		mpfr_complex::thread_default_precision(prec);
+		real_mp::thread_default_precision(prec);
+		complex_mp::thread_default_precision(prec);
 	}
 
 	inline unsigned ThreadPrecision()
 	{
-		return static_cast<unsigned>(mpfr_float::thread_default_precision());
+		return static_cast<unsigned>(real_mp::thread_default_precision());
 	}
 
 }
@@ -222,10 +222,10 @@ namespace bertini{
 	/**
 	\brief Get the precision of a number.
 
-	For mpfr_floats, this calls the precision member method for mpfr_float.
+	For mpfr_floats, this calls the precision member method for real_mp.
 	*/
 	inline
-	auto Precision(mpfr_complex const& num)
+	auto Precision(complex_mp const& num)
 	{
 		return num.precision();
 	}
@@ -234,15 +234,15 @@ namespace bertini{
 	/**
 	\brief Change the precision of a number.
 
-	For mpfr_floats, this calls the precision member method for mpfr_float.
+	For mpfr_floats, this calls the precision member method for real_mp.
 	*/
-	inline void Precision(mpfr_complex & num, unsigned prec)
+	inline void Precision(complex_mp & num, unsigned prec)
 	{
 		num.precision(prec);
 	}
 
 	inline
-	bool isnan(mpfr_complex const& num){return isnan(num.real()) || isnan(num.imag());};
+	bool isnan(complex_mp const& num){return isnan(num.real()) || isnan(num.imag());};
 
 
 

--- a/core/include/bertini2/mpfr_extensions.hpp
+++ b/core/include/bertini2/mpfr_extensions.hpp
@@ -27,7 +27,7 @@
 
 \brief Extensions to the Boost.Multiprecision library.
 
-Particularly includes Boost.Serialize code for the mpfr_float, gmp_rational, and gmp_int types.
+Particularly includes Boost.Serialize code for the real_mp, gmp_rational, and gmp_int types.
 */
 
 #ifndef BERTINI_MPFR_EXTENSIONS_HPP
@@ -53,11 +53,11 @@ Particularly includes Boost.Serialize code for the mpfr_float, gmp_rational, and
 
 namespace bertini{
 #ifdef BMP_EXPRESSION_TEMPLATES
-	using mpfr_float = boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<0>, boost::multiprecision::et_on>; 
+	using real_mp = boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<0>, boost::multiprecision::et_on>; 
 	using mpz_int = boost::multiprecision::number<boost::multiprecision::backends::gmp_int, boost::multiprecision::et_on>;
 	using mpq_rational = boost::multiprecision::number<boost::multiprecision::backends::gmp_rational, boost::multiprecision::et_on>;
 #else
-	using mpfr_float = boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<0>, boost::multiprecision::et_off>; 
+	using real_mp = boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<0>, boost::multiprecision::et_off>; 
 	using mpz_int = boost::multiprecision::number<boost::multiprecision::backends::gmp_int, boost::multiprecision::et_off>;
 	using mpq_rational = boost::multiprecision::number<boost::multiprecision::backends::gmp_rational, boost::multiprecision::et_off>;
 #endif
@@ -65,10 +65,10 @@ namespace bertini{
 	/** 
 	\brief Get the precision of a real number.
 
-	For mpfr_floats, this calls the precision member method for mpfr_float.
+	For mpfr_floats, this calls the precision member method for real_mp.
 	*/
 	inline
-	auto Precision(mpfr_float const& num)
+	auto Precision(real_mp const& num)
 	{
 		return num.precision();
 	}
@@ -76,9 +76,9 @@ namespace bertini{
 	/** 
 	\brief Change the precision of a real number.
 
-	For mpfr_floats, this calls the precision member method for mpfr_float.
+	For mpfr_floats, this calls the precision member method for real_mp.
 	*/
-	inline void Precision(mpfr_float & num, unsigned prec)
+	inline void Precision(real_mp & num, unsigned prec)
 	{
 		num.precision(prec);
 	}
@@ -138,10 +138,10 @@ namespace bertini{
 
 
 
-// the following code block extends serialization to the mpfr_float class from boost::multiprecision
+// the following code block extends serialization to the real_mp class from boost::multiprecision
 namespace boost { namespace serialization {
 	/**
-	 Save a mpfr_float type to a boost archive.
+	 Save a real_mp type to a boost archive.
 	 */
 	template <typename Archive>
 	void save(Archive& ar, ::boost::multiprecision::backends::mpfr_float_backend<0> const& r, unsigned /*version*/)
@@ -153,7 +153,7 @@ namespace boost { namespace serialization {
 	}
 	
 	/**
-	 Load a mpfr_float type from a boost archive.
+	 Load a real_mp type from a boost archive.
 	 */
 	template <typename Archive>
 	void load(Archive& ar, ::boost::multiprecision::backends::mpfr_float_backend<0>& r, unsigned /*version*/)

--- a/core/include/bertini2/nag_algorithms/common/config.hpp
+++ b/core/include/bertini2/nag_algorithms/common/config.hpp
@@ -159,7 +159,7 @@ but the ambient/thread precision at double -- a mismatch the tracker rejects at 
 template<typename ComplexT>
 inline unsigned DefaultInitialAmbientPrecision()
 {
-	if constexpr (std::is_same<ComplexT, dbl_complex>::value)
+	if constexpr (std::is_same<ComplexT, complex_dbl>::value)
 		return DoublePrecision();
 	else
 		return DefaultPrecision();

--- a/core/include/bertini2/nag_algorithms/zero_dim_solve.hpp
+++ b/core/include/bertini2/nag_algorithms/zero_dim_solve.hpp
@@ -97,7 +97,7 @@ struct AnyZeroDim : public virtual AnyAlgorithm
 
 
 
-using SolnIndT = typename SolnCont<dbl_complex>::size_type;
+using SolnIndT = typename SolnCont<complex_dbl>::size_type;
 
 
 /// metadata structs
@@ -1162,7 +1162,7 @@ std::ostream& operator<<(std::ostream & out, const SolveReport & r)
 					// Double validates (its PrecisionSetup throws on any precision other than 16);
 					// fixed-multiple adopts the value into precision_.
 					GetTracker().PrecisionSetup(fp);
-					if constexpr (!std::is_same<BaseComplexT, dbl>::value)
+					if constexpr (!std::is_same<BaseComplexT, complex_dbl>::value)
 						if (fp.precision != 0)
 						{
 							ZeroDimConf zdc = this->template Get<ZeroDimConf>();

--- a/core/include/bertini2/num_traits.hpp
+++ b/core/include/bertini2/num_traits.hpp
@@ -82,11 +82,11 @@ namespace bertini
 		}
 
 		using Real = double;
-		using Complex = dbl_complex;
+		using Complex = complex_dbl;
 	};
 
 
-	template <> struct NumTraits<dbl_complex > 
+	template <> struct NumTraits<complex_dbl > 
 	{
 		inline static unsigned NumDigits()
 		{
@@ -99,25 +99,25 @@ namespace bertini
 		}
 
 		inline static 
-		dbl_complex FromString(std::string const& s)
+		complex_dbl FromString(std::string const& s)
 		{
-			return boost::lexical_cast<dbl_complex>(s);
+			return boost::lexical_cast<complex_dbl>(s);
 		}
 
 		inline static 
-		dbl_complex FromString(std::string const& s, std::string const& t)
+		complex_dbl FromString(std::string const& s, std::string const& t)
 		{
-			return dbl_complex(boost::lexical_cast<double>(s),boost::lexical_cast<double>(t));
+			return complex_dbl(boost::lexical_cast<double>(s),boost::lexical_cast<double>(t));
 		}
 
 		inline static
-		dbl_complex FromRational(mpq_rational const& n, unsigned /* precision */)
+		complex_dbl FromRational(mpq_rational const& n, unsigned /* precision */)
 		{
-			return dbl_complex(static_cast<double>(n),0);
+			return complex_dbl(static_cast<double>(n),0);
 		}
 
 		using Real = double;
-		using Complex = dbl_complex;
+		using Complex = complex_dbl;
 	};
 
 
@@ -176,7 +176,7 @@ namespace bertini
 	For complex doubles, this is trivially 16.
 	*/
 	inline
-	unsigned Precision(dbl_complex)
+	unsigned Precision(complex_dbl)
 	{
 		return DoublePrecision();
 	}
@@ -185,7 +185,7 @@ namespace bertini
 	For complex doubles, throw if the requested precision is not DoublePrecision.
 	*/
 	inline
-	void Precision(dbl_complex, unsigned prec)
+	void Precision(complex_dbl, unsigned prec)
 	{
 		if (prec!=DoublePrecision())
 		{
@@ -196,26 +196,26 @@ namespace bertini
 	}
 
 	inline
-	dbl_complex rand_complex()
+	complex_dbl rand_complex()
 	{
 		using std::abs;
 		using std::sqrt;
 		static thread_local std::uniform_real_distribution<double> distribution(-1.0,1.0);
-		dbl_complex returnme(distribution(ThreadEngine()), distribution(ThreadEngine()));
+		complex_dbl returnme(distribution(ThreadEngine()), distribution(ThreadEngine()));
 		return returnme / sqrt( abs(returnme));
 	}
 
 	template <> inline
-	dbl_complex RandomUnit<dbl_complex >()
+	complex_dbl RandomUnit<complex_dbl >()
 	{
 		static thread_local std::uniform_real_distribution<double> distribution(-1.0,1.0);
-		dbl_complex returnme(distribution(ThreadEngine()), distribution(ThreadEngine()));
+		complex_dbl returnme(distribution(ThreadEngine()), distribution(ThreadEngine()));
 		return returnme / abs(returnme);
 	}
 
 	template <> 
 	inline 
-	mpfr_complex RandomUnit<mpfr_complex>()
+	complex_mp RandomUnit<complex_mp>()
 	{
 		return multiprecision::RandomUnit();
 	}
@@ -236,7 +236,7 @@ namespace bertini {
 
 	
 	
-	template <> struct NumTraits<mpfr_float> 
+	template <> struct NumTraits<real_mp> 
 	{
 		inline static unsigned NumDigits()
 		{
@@ -249,31 +249,31 @@ namespace bertini {
 		}
 
 		inline
-		static unsigned TolToDigits(mpfr_float tol)
+		static unsigned TolToDigits(real_mp tol)
 		{
-			mpfr_float b = ceil(-log10(tol));
+			real_mp b = ceil(-log10(tol));
 			return b.convert_to<unsigned int>();
 		}
 
 		inline static 
-		mpfr_float FromString(std::string const& s)
+		real_mp FromString(std::string const& s)
 		{
-			return mpfr_float(s);
+			return real_mp(s);
 		}
 
 		inline static
-		mpfr_float FromRational(mpq_rational const& n, unsigned precision)
+		real_mp FromRational(mpq_rational const& n, unsigned precision)
 		{
-			return mpfr_float(n,precision);
+			return real_mp(n,precision);
 		}
 
-		using Real = mpfr_float;
-		using Complex = mpfr_complex;
+		using Real = real_mp;
+		using Complex = complex_mp;
 	};	
 
 
 
-	template <> struct NumTraits<mpfr_complex> 
+	template <> struct NumTraits<complex_mp> 
 	{
 		inline static unsigned NumDigits()
 		{
@@ -281,25 +281,25 @@ namespace bertini {
 		}
 
 		inline static 
-		mpfr_complex FromString(std::string const& s)
+		complex_mp FromString(std::string const& s)
 		{
-			return mpfr_complex(s);
+			return complex_mp(s);
 		}
 
 		inline static 
-		mpfr_complex FromString(std::string const& s, std::string const& t)
+		complex_mp FromString(std::string const& s, std::string const& t)
 		{
-			return mpfr_complex(s,t);
+			return complex_mp(s,t);
 		}
 
 		inline static
-		mpfr_complex FromRational(mpq_rational const& n, unsigned precision)
+		complex_mp FromRational(mpq_rational const& n, unsigned precision)
 		{
-			return mpfr_complex(n,0,precision);
+			return complex_mp(n,0,precision);
 		}
 
-		using Real = mpfr_float;
-		using Complex = mpfr_complex;
+		using Real = real_mp;
+		using Complex = complex_mp;
 	};
 
 	template <> struct NumTraits<mpq_rational>

--- a/core/include/bertini2/parallel/path_result.hpp
+++ b/core/include/bertini2/parallel/path_result.hpp
@@ -36,7 +36,7 @@ serialization for Eigen vectors and arbitrary-precision types.
 
 #include "bertini2/num_traits.hpp"
 #include "bertini2/eigen_extensions.hpp"   // defines Vec<T> and sets up Eigen serialization plugin
-#include "bertini2/mpfr_extensions.hpp"    // Boost.Serialization for mpfr_float, mpc_complex
+#include "bertini2/mpfr_extensions.hpp"    // Boost.Serialization for real_mp, mpc_complex
 #include "bertini2/common/config.hpp"      // SuccessCode (needs Vec<T> and <deque> first)
 
 #include <boost/serialization/vector.hpp>

--- a/core/include/bertini2/random.hpp
+++ b/core/include/bertini2/random.hpp
@@ -113,7 +113,7 @@ namespace bertini
 	 \tparam length_in_digits The length of the desired random number
 	 */
 	template <unsigned int length_in_digits>
-	mpfr_float RandomMp()
+	real_mp RandomMp()
 	{
 
 		using namespace boost::multiprecision;
@@ -126,7 +126,7 @@ namespace bertini
 		// ones), so SetGlobalSeed()/ReseedThisThread() control them all uniformly.
 		// The distribution fills the full mp mantissa from the 32-bit engine via
 		// generate_canonical.
-		mpfr_float a{distribution(ThreadEngine())};
+		real_mp a{distribution(ThreadEngine())};
 		return a;
 	}
 	
@@ -137,7 +137,7 @@ namespace bertini
 	 \param a the number which will be assigned in this call
 	 */
 	template <unsigned int length_in_digits>
-	void RandomMpAssign(mpfr_float & a)
+	void RandomMpAssign(real_mp & a)
 	{	
 		a = RandomMp<length_in_digits>();
 	}
@@ -151,7 +151,7 @@ namespace bertini
 	 \param b The right bound.
 	 */
 	template <unsigned int length_in_digits>
-	mpfr_float RandomMp(const mpfr_float & left, const mpfr_float & right)
+	real_mp RandomMp(const real_mp & left, const real_mp & right)
 	{
 		return (right-left)*RandomMp<length_in_digits>()+left;
 	}
@@ -161,31 +161,31 @@ namespace bertini
 	/**
 	 \brief create a random number, at the current default precision
 	 */
-	mpfr_float RandomMp();
+	real_mp RandomMp();
 
 	/**
 	 \brief create a random number, at the specified precision
 
 	 \param num_digits the precision that you desire.  
 	 */
-	mpfr_float RandomMp(unsigned num_digits);
+	real_mp RandomMp(unsigned num_digits);
 
 	/**
 	 \brief create a random number in a given interval, at the current default precision
 	*/
-	mpfr_float RandomMp(const mpfr_float & a, const mpfr_float & b);
+	real_mp RandomMp(const real_mp & a, const real_mp & b);
 
 	/**
 	 \brief create a random number in a given interval, at the specified precision
 	*/
-	mpfr_float RandomMp(const mpfr_float & a, const mpfr_float & b, unsigned num_digits);
+	real_mp RandomMp(const real_mp & a, const real_mp & b, unsigned num_digits);
 
 	/**
-	 \brief Set an existing mpfr_float to a random number, to a given precision.  
+	 \brief Set an existing real_mp to a random number, to a given precision.  
 
 	 This function is how to get random numbers at a precision different from the current default.
 	 */
-	void RandomMpAssign(mpfr_float & a, unsigned num_digits);
+	void RandomMpAssign(real_mp & a, unsigned num_digits);
 
 	
 
@@ -200,7 +200,7 @@ namespace bertini{
 namespace multiprecision{
 
 
-using complex = bertini::mpfr_complex;
+using complex = bertini::complex_mp;
 using bertini::RandomMp;
 
 
@@ -213,7 +213,7 @@ using bertini::RandomMp;
 	{
 		auto cached = ThreadPrecision();
 		SetThreadPrecision(num_digits);
-		complex temp(RandomMp(mpfr_float(-1),mpfr_float(1),num_digits)); // ,0
+		complex temp(RandomMp(real_mp(-1),real_mp(1),num_digits)); // ,0
 		a.swap(temp);
 		SetThreadPrecision(cached);
 	}
@@ -223,7 +223,7 @@ using bertini::RandomMp;
 	 */
 	inline complex RandomReal()
 	{
-		return complex(RandomMp(mpfr_float(-1),mpfr_float(1))); // ,0
+		return complex(RandomMp(real_mp(-1),real_mp(1))); // ,0
 	}
 	
 	/**
@@ -233,7 +233,7 @@ using bertini::RandomMp;
 	{
 		auto cached = ThreadPrecision();
 		SetThreadPrecision(num_digits);
-		auto result = complex(RandomMp(mpfr_float(-1),mpfr_float(1),num_digits));// ,0
+		auto result = complex(RandomMp(real_mp(-1),real_mp(1),num_digits));// ,0
 		SetThreadPrecision(cached);
 		return result;
 	}
@@ -249,7 +249,7 @@ using bertini::RandomMp;
 	 */
 	inline complex rand()
 	{
-		return complex( RandomMp(mpfr_float(-1),mpfr_float(1)), RandomMp(mpfr_float(-1),mpfr_float(1)) );
+		return complex( RandomMp(real_mp(-1),real_mp(1)), RandomMp(real_mp(-1),real_mp(1)) );
 	}
 
 
@@ -258,7 +258,7 @@ using bertini::RandomMp;
 	 */
 	inline complex rand_unit()
 	{
-		complex returnme( RandomMp(mpfr_float(-1),mpfr_float(1)), RandomMp(mpfr_float(-1),mpfr_float(1)) );
+		complex returnme( RandomMp(real_mp(-1),real_mp(1)), RandomMp(real_mp(-1),real_mp(1)) );
 		return returnme / abs(returnme);   // normalize to modulus 1 (NOT sqrt(abs), which left modulus sqrt|z|)
 	}
 
@@ -273,7 +273,7 @@ using bertini::RandomMp;
 		auto cached = ThreadPrecision();
 		SetThreadPrecision(num_digits);
 		
-		mpfr_complex temp( RandomMp(num_digits), RandomMp(num_digits) );
+		complex_mp temp( RandomMp(num_digits), RandomMp(num_digits) );
 		a = std::move(temp);
 		SetThreadPrecision(cached);
 	}

--- a/core/include/bertini2/system/blocks/blend_block.hpp
+++ b/core/include/bertini2/system/blocks/blend_block.hpp
@@ -290,7 +290,7 @@ private:
 	template <typename T>
 	void SyncPrecision(Vec<T> const& vars) const
 	{
-		if constexpr (!std::is_same<T, dbl>::value)
+		if constexpr (!std::is_same<T, complex_dbl>::value)
 		{
 			if (vars.size() > 0)
 			{
@@ -327,7 +327,7 @@ private:
 	Vec<T> EvalCoefficients(T const& path_value) const
 	{
 		auto& cs = EnsureCoefficientSystem();
-		if constexpr (!std::is_same<T, dbl>::value)
+		if constexpr (!std::is_same<T, complex_dbl>::value)
 			cs.precision(bertini::Precision(path_value));
 		Vec<T> t_point(1);
 		t_point(0) = path_value;

--- a/core/include/bertini2/system/blocks/block.hpp
+++ b/core/include/bertini2/system/blocks/block.hpp
@@ -27,7 +27,7 @@
 A System is composed of evaluation blocks held in a std::variant and dispatched by
 std::visit -- closed set, no type erasure.  Each block contributes a contiguous range
 of rows to the system's function vector / Jacobian.  Every block must provide, for each
-numeric type T in {dbl, mpfr_complex}:
+numeric type T in {complex_dbl, complex_mp}:
 
     template<typename T> void EvalInPlace(Eigen::Ref<Vec<T>> seg, Vec<T> const& vars, T const& t) const;
     template<typename T> void JacobianInPlace(Eigen::Ref<Mat<T>> blk, Vec<T> const& vars, T const& t) const;
@@ -79,7 +79,7 @@ namespace blocks {
 /**
 \brief Detection trait: does B satisfy the evaluation-block contract?
 
-Checks the dbl instantiation of the templated eval entry points plus the metadata
+Checks the complex_dbl instantiation of the templated eval entry points plus the metadata
 methods.  Adding a non-conforming type to the block variant then fails a one-line
 static_assert instead of producing a deep template error at the visit site.
 */
@@ -100,12 +100,12 @@ struct is_block<B, std::void_t<
 	// it is detected on a non-const B&.
 	decltype(std::declval<B&>().Homogenize(
 		std::declval<VariableGroup const&>(), std::declval<std::shared_ptr<node::Variable> const&>())),
-	decltype(std::declval<const B&>().template EvalInPlace<dbl>(
-		std::declval<Eigen::Ref<Vec<dbl>>>(), std::declval<Vec<dbl> const&>(), std::declval<dbl const&>())),
-	decltype(std::declval<const B&>().template JacobianInPlace<dbl>(
-		std::declval<Eigen::Ref<Mat<dbl>>>(), std::declval<Vec<dbl> const&>(), std::declval<dbl const&>())),
-	decltype(std::declval<const B&>().template TimeDerivInPlace<dbl>(
-		std::declval<Eigen::Ref<Vec<dbl>>>(), std::declval<Vec<dbl> const&>(), std::declval<dbl const&>()))
+	decltype(std::declval<const B&>().template EvalInPlace<complex_dbl>(
+		std::declval<Eigen::Ref<Vec<complex_dbl>>>(), std::declval<Vec<complex_dbl> const&>(), std::declval<complex_dbl const&>())),
+	decltype(std::declval<const B&>().template JacobianInPlace<complex_dbl>(
+		std::declval<Eigen::Ref<Mat<complex_dbl>>>(), std::declval<Vec<complex_dbl> const&>(), std::declval<complex_dbl const&>())),
+	decltype(std::declval<const B&>().template TimeDerivInPlace<complex_dbl>(
+		std::declval<Eigen::Ref<Vec<complex_dbl>>>(), std::declval<Vec<complex_dbl> const&>(), std::declval<complex_dbl const&>()))
 >> : std::true_type {};
 
 template <typename B>

--- a/core/include/bertini2/system/blocks/describe.hpp
+++ b/core/include/bertini2/system/blocks/describe.hpp
@@ -37,9 +37,9 @@ namespace bertini {
 namespace blocks {
 namespace describe_detail {
 
-/// Print one (mpfr_complex) coefficient compactly: a real prints as its real part, a pure imaginary
+/// Print one (complex_mp) coefficient compactly: a real prints as its real part, a pure imaginary
 /// as `b*i`, otherwise as `(a+b*i)`.
-inline void PrintCoeff(std::ostream& out, mpfr_complex const& c)
+inline void PrintCoeff(std::ostream& out, complex_mp const& c)
 {
 	const bool re0 = (c.real() == 0), im0 = (c.imag() == 0);
 	if (im0)            out << c.real();
@@ -69,14 +69,14 @@ inline void PrintAugmentedVars(std::ostream& out, VariableGroup const& vars, siz
 /// One affine linear form, row r of an augmented coefficient matrix M (num_vars+1 cols affine, or
 /// num_vars cols homogeneous).  Verbose prints the actual sum `2*x + 1*y - 1`; otherwise nothing
 /// (the caller prints the placeholder `c.[...]`).
-inline void PrintLinearFormVerbose(std::ostream& out, Mat<mpfr_complex> const& M, Eigen::Index r,
+inline void PrintLinearFormVerbose(std::ostream& out, Mat<complex_mp> const& M, Eigen::Index r,
                                    VariableGroup const& vars, size_t num_vars, bool homogeneous)
 {
 	bool first = true;
 	const size_t ncol = homogeneous ? num_vars : num_vars + 1;
 	for (size_t c = 0; c < ncol; ++c)
 	{
-		mpfr_complex const& coeff = M(r, static_cast<Eigen::Index>(c));
+		complex_mp const& coeff = M(r, static_cast<Eigen::Index>(c));
 		if (coeff.real() == 0 && coeff.imag() == 0)
 			continue;
 		if (!first) out << " + ";

--- a/core/include/bertini2/system/blocks/linear_forms_block.hpp
+++ b/core/include/bertini2/system/blocks/linear_forms_block.hpp
@@ -73,7 +73,7 @@ public:
 	\param coefficients The augmented coefficient matrix: one row per function, shape
 	(number-of-functions) x (num_vars + 1).
 	*/
-	LinearFormsBlock(size_t num_vars, Mat<mpfr_complex> coefficients)
+	LinearFormsBlock(size_t num_vars, Mat<complex_mp> coefficients)
 		: num_vars_(num_vars), coefficients_highest_precision_(std::move(coefficients)),
 		  precision_(DefaultPrecision())
 	{
@@ -107,7 +107,7 @@ public:
 			throw std::runtime_error("LinearFormsBlock::Homogenize: block is already homogenized "
 				"(multiple affine variable groups are not yet supported for linear-forms blocks)");
 		const auto& M = coefficients_highest_precision_;
-		Mat<mpfr_complex> Mh(M.rows(), M.cols());                                   // same #cols: n+1
+		Mat<complex_mp> Mh(M.rows(), M.cols());                                   // same #cols: n+1
 		Mh.col(0) = M.col(static_cast<Eigen::Index>(num_vars_));                    // constant -> h column (front)
 		Mh.rightCols(static_cast<Eigen::Index>(num_vars_)) =
 			M.leftCols(static_cast<Eigen::Index>(num_vars_));                       // original variable columns
@@ -123,7 +123,7 @@ public:
 	/// The master coefficient matrix (one row per form).  Affine: num_vars+1 columns, the last being
 	/// the constant term.  Homogeneous (post-Homogenize): num_vars columns, all variable columns.
 	/// Exposed for the function-tree expansion (System::NaturalFunctionsAsNodes).
-	Mat<mpfr_complex> const& Coefficients() const { return coefficients_highest_precision_; }
+	Mat<complex_mp> const& Coefficients() const { return coefficients_highest_precision_; }
 	/// Whether Homogenize has folded the constant column onto a homogenizing variable.
 	bool IsHomogenized() const { return homogeneous_; }
 
@@ -161,7 +161,7 @@ public:
 	{
 		if (new_precision > DoublePrecision())
 		{
-			auto& wm = std::get<Mat<mpfr_complex>>(coefficients_working_);
+			auto& wm = std::get<Mat<complex_mp>>(coefficients_working_);
 			for (Eigen::Index r = 0; r < wm.rows(); ++r)
 				for (Eigen::Index c = 0; c < wm.cols(); ++c)
 				{
@@ -234,7 +234,7 @@ private:
 		Vec<T> aug(static_cast<Eigen::Index>(num_vars_ + 1));
 		aug.head(static_cast<Eigen::Index>(num_vars_)) = vars;
 		T one(1);
-		if constexpr (!std::is_same<T, dbl>::value)
+		if constexpr (!std::is_same<T, complex_dbl>::value)
 			one.precision(precision_);
 		aug(static_cast<Eigen::Index>(num_vars_)) = one;
 		return aug;
@@ -243,22 +243,22 @@ private:
 	void BuildWorking() const
 	{
 		const auto& M = coefficients_highest_precision_;
-		auto& wd = std::get<Mat<dbl>>(coefficients_working_);
-		auto& wm = std::get<Mat<mpfr_complex>>(coefficients_working_);
+		auto& wd = std::get<Mat<complex_dbl>>(coefficients_working_);
+		auto& wm = std::get<Mat<complex_mp>>(coefficients_working_);
 		wd.resize(M.rows(), M.cols());
 		wm.resize(M.rows(), M.cols());
 		for (Eigen::Index r = 0; r < M.rows(); ++r)
 			for (Eigen::Index c = 0; c < M.cols(); ++c)
 			{
-				wd(r, c) = dbl(M(r, c));
+				wd(r, c) = complex_dbl(M(r, c));
 				wm(r, c) = M(r, c);
 			}
 	}
 
 	size_t num_vars_;
 	bool homogeneous_ = false; ///< false: augmented affine (M*[x;1]); true: post-Homogenize (M*x)
-	Mat<mpfr_complex> coefficients_highest_precision_; ///< master: rows = functions, cols = num_vars (homogeneous) or num_vars+1 (affine)
-	mutable std::tuple<Mat<dbl>, Mat<mpfr_complex>> coefficients_working_;
+	Mat<complex_mp> coefficients_highest_precision_; ///< master: rows = functions, cols = num_vars (homogeneous) or num_vars+1 (affine)
+	mutable std::tuple<Mat<complex_dbl>, Mat<complex_mp>> coefficients_working_;
 	mutable unsigned precision_;
 
 	friend class boost::serialization::access;

--- a/core/include/bertini2/system/blocks/products_of_linears_block.hpp
+++ b/core/include/bertini2/system/blocks/products_of_linears_block.hpp
@@ -71,7 +71,7 @@ public:
 	\param factors One augmented coefficient matrix per function; matrix i has shape
 	(number-of-factors_i) x (num_vars + 1).
 	*/
-	ProductsOfLinearsBlock(size_t num_vars, std::vector<Mat<mpfr_complex>> factors)
+	ProductsOfLinearsBlock(size_t num_vars, std::vector<Mat<complex_mp>> factors)
 		: num_vars_(num_vars), factors_highest_precision_(std::move(factors)), precision_(DefaultPrecision())
 	{
 #ifndef NDEBUG
@@ -107,7 +107,7 @@ public:
 	/// The master (highest-precision) coefficient matrices, one per function; matrix i is
 	/// (#factors_i) x (num_vars+1), the last column being the constant/augmenting term.  Exposed
 	/// so the function-tree expansion (System::ExpandToFunctionTree) can rebuild f_i = prod_r L_r.
-	std::vector<Mat<mpfr_complex>> const& Factors() const { return factors_highest_precision_; }
+	std::vector<Mat<complex_mp>> const& Factors() const { return factors_highest_precision_; }
 
 	/// Human-facing description: terse shows `prod of k linear forms`; verbose shows the actual
 	/// product of affine factors `(x - 1) * (x + 1)`.
@@ -154,7 +154,7 @@ public:
 	{
 		if (new_precision > DoublePrecision())
 		{
-			auto& wm = std::get<std::vector<Mat<mpfr_complex>>>(factors_working_);
+			auto& wm = std::get<std::vector<Mat<complex_mp>>>(factors_working_);
 			for (size_t i = 0; i < wm.size(); ++i)
 				for (Eigen::Index r = 0; r < wm[i].rows(); ++r)
 					for (Eigen::Index c = 0; c < wm[i].cols(); ++c)
@@ -272,7 +272,7 @@ private:
 		Vec<T> aug(static_cast<Eigen::Index>(num_vars_ + 1));
 		aug.head(static_cast<Eigen::Index>(num_vars_)) = vars;
 		T one(1);
-		if constexpr (!std::is_same<T, dbl>::value)
+		if constexpr (!std::is_same<T, complex_dbl>::value)
 			one.precision(precision_);
 		aug(static_cast<Eigen::Index>(num_vars_)) = one;
 		return aug;
@@ -280,8 +280,8 @@ private:
 
 	void BuildWorking() const
 	{
-		auto& wd = std::get<std::vector<Mat<dbl>>>(factors_working_);
-		auto& wm = std::get<std::vector<Mat<mpfr_complex>>>(factors_working_);
+		auto& wd = std::get<std::vector<Mat<complex_dbl>>>(factors_working_);
+		auto& wm = std::get<std::vector<Mat<complex_mp>>>(factors_working_);
 		const size_t n = factors_highest_precision_.size();
 		wd.resize(n);
 		wm.resize(n);
@@ -293,15 +293,15 @@ private:
 			for (Eigen::Index r = 0; r < M.rows(); ++r)
 				for (Eigen::Index c = 0; c < M.cols(); ++c)
 				{
-					wd[i](r, c) = dbl(M(r, c));
+					wd[i](r, c) = complex_dbl(M(r, c));
 					wm[i](r, c) = M(r, c);
 				}
 		}
 	}
 
 	size_t num_vars_;
-	std::vector<Mat<mpfr_complex>> factors_highest_precision_; ///< master coefficients, one matrix per function
-	mutable std::tuple<std::vector<Mat<dbl>>, std::vector<Mat<mpfr_complex>>> factors_working_;
+	std::vector<Mat<complex_mp>> factors_highest_precision_; ///< master coefficients, one matrix per function
+	mutable std::tuple<std::vector<Mat<complex_dbl>>, std::vector<Mat<complex_mp>>> factors_working_;
 	mutable unsigned precision_;
 
 	friend class boost::serialization::access;

--- a/core/include/bertini2/system/blocks/randomization_block.hpp
+++ b/core/include/bertini2/system/blocks/randomization_block.hpp
@@ -92,7 +92,7 @@ public:
 	\param num_groups           The number of (affine) variable groups G.
 	*/
 	RandomizationBlock(OperandPtr operand,
-	                   Mat<mpfr_complex> coefficients,
+	                   Mat<complex_mp> coefficients,
 	                   std::vector<std::vector<int>> target_multidegrees,
 	                   std::vector<std::vector<int>> operand_multidegrees,
 	                   size_t num_groups)
@@ -219,7 +219,7 @@ public:
 	/// The overdetermined operand, for the function-tree expansion oracle and the matrix getter.
 	OperandPtr const& Operand() const { return operand_; }
 	/// The randomization matrix R (master, highest precision); n x N, row i column j is c_ij.
-	Mat<mpfr_complex> const& RandomizationMatrix() const { return coefficients_highest_precision_; }
+	Mat<complex_mp> const& RandomizationMatrix() const { return coefficients_highest_precision_; }
 
 	// Accessors for the function-tree expansion oracle (System::NaturalFunctionsAsNodes), which
 	// rebuilds g_i = sum_j c_ij * node(f_j) * prod_g h_g^{(D_{i,g}-d_{j,g})}.
@@ -267,7 +267,7 @@ public:
 	{
 		if (new_precision > DoublePrecision())
 		{
-			auto& wm = std::get<Mat<mpfr_complex>>(coefficients_working_);
+			auto& wm = std::get<Mat<complex_mp>>(coefficients_working_);
 			for (Eigen::Index r = 0; r < wm.rows(); ++r)
 				for (Eigen::Index c = 0; c < wm.cols(); ++c)
 				{
@@ -372,12 +372,12 @@ private:
 	T Zero() const
 	{
 		T z(0);
-		if constexpr (!std::is_same<T, dbl>::value) z.precision(precision_);
+		if constexpr (!std::is_same<T, complex_dbl>::value) z.precision(precision_);
 		return z;
 	}
 
-	static bool IsZero(dbl const& c) { return c == dbl(0); }
-	static bool IsZero(mpfr_complex const& c) { return c.real() == 0 && c.imag() == 0; }
+	static bool IsZero(complex_dbl const& c) { return c == complex_dbl(0); }
+	static bool IsZero(complex_mp const& c) { return c.real() == 0 && c.imag() == 0; }
 
 	/// The (signed) degree deficit of operand function j against row i's target, in group g.
 	int Deficit(size_t i, size_t j, size_t g) const
@@ -390,7 +390,7 @@ private:
 	T HPower(size_t i, size_t j, Vec<T> const& vars) const
 	{
 		T w(1);
-		if constexpr (!std::is_same<T, dbl>::value) w.precision(precision_);
+		if constexpr (!std::is_same<T, complex_dbl>::value) w.precision(precision_);
 		if (!homogenized_)
 			return w;
 		for (size_t g = 0; g < num_groups_; ++g)
@@ -409,7 +409,7 @@ private:
 	{
 		const int eg = Deficit(i, j, g);
 		T d(eg);
-		if constexpr (!std::is_same<T, dbl>::value) d.precision(precision_);
+		if constexpr (!std::is_same<T, complex_dbl>::value) d.precision(precision_);
 		d *= IntPow<T>(vars(hom_var_index_[g]), eg - 1);
 		for (size_t g2 = 0; g2 < num_groups_; ++g2)
 		{
@@ -428,7 +428,7 @@ private:
 	static T IntPow(T const& base, int e)
 	{
 		T result(1);
-		if constexpr (!std::is_same<T, dbl>::value) result.precision(bertini::Precision(base));
+		if constexpr (!std::is_same<T, complex_dbl>::value) result.precision(bertini::Precision(base));
 		for (int k = 0; k < e; ++k)
 			result *= base;
 		return result;
@@ -456,7 +456,7 @@ private:
 	template <typename T>
 	void SyncPrecision(Vec<T> const& vars) const
 	{
-		if constexpr (!std::is_same<T, dbl>::value)
+		if constexpr (!std::is_same<T, complex_dbl>::value)
 		{
 			if (vars.size() > 0)
 			{
@@ -470,21 +470,21 @@ private:
 	void BuildWorking() const
 	{
 		const auto& M = coefficients_highest_precision_;
-		auto& wd = std::get<Mat<dbl>>(coefficients_working_);
-		auto& wm = std::get<Mat<mpfr_complex>>(coefficients_working_);
+		auto& wd = std::get<Mat<complex_dbl>>(coefficients_working_);
+		auto& wm = std::get<Mat<complex_mp>>(coefficients_working_);
 		wd.resize(M.rows(), M.cols());
 		wm.resize(M.rows(), M.cols());
 		for (Eigen::Index r = 0; r < M.rows(); ++r)
 			for (Eigen::Index c = 0; c < M.cols(); ++c)
 			{
-				wd(r, c) = dbl(M(r, c));
+				wd(r, c) = complex_dbl(M(r, c));
 				wm(r, c) = M(r, c);
 			}
 	}
 
 	OperandPtr operand_;
-	Mat<mpfr_complex> coefficients_highest_precision_;             ///< master n x N randomization matrix
-	mutable std::tuple<Mat<dbl>, Mat<mpfr_complex>> coefficients_working_;
+	Mat<complex_mp> coefficients_highest_precision_;             ///< master n x N randomization matrix
+	mutable std::tuple<Mat<complex_dbl>, Mat<complex_mp>> coefficients_working_;
 	std::vector<std::vector<int>> target_multidegrees_;            ///< n x G
 	std::vector<std::vector<int>> operand_multidegrees_;           ///< N x G
 	size_t num_groups_;                                            ///< G (affine variable groups)

--- a/core/include/bertini2/system/eval_expression.hpp
+++ b/core/include/bertini2/system/eval_expression.hpp
@@ -59,7 +59,7 @@ namespace bertini {
 	name must appear in the expression; either kind of mismatch throws.  The latter is a
 	guard against typos --- a value silently going nowhere is almost always a mistake.
 
-	\tparam T The evaluation number type (`dbl` or `mpfr_complex`).
+	\tparam T The evaluation number type (`complex_dbl` or `complex_mp`).
 	\param expr The expression to evaluate.
 	\param variable_values A map from variable name to the value to substitute.
 	\return The value of the expression at the given point.
@@ -111,7 +111,7 @@ namespace bertini {
 		// evaluation Memory, so concurrent evaluations of the same cached expression do not race.
 		StraightLineProgram slp = *cached;
 
-		if constexpr (!std::is_same<T, dbl>::value)
+		if constexpr (!std::is_same<T, complex_dbl>::value)
 			if (vars.size() > 0)
 				slp.precision(Precision(point));
 

--- a/core/include/bertini2/system/patch.hpp
+++ b/core/include/bertini2/system/patch.hpp
@@ -67,8 +67,8 @@ namespace bertini {
 
 	Patch p(s);
 
-	Vec<mpfr_complex> v(5);
-	v << mpfr_complex(1),  mpfr_complex(1),  mpfr_complex(1),  mpfr_complex(1),  mpfr_complex(1);
+	Vec<complex_mp> v(5);
+	v << complex_mp(1),  complex_mp(1),  complex_mp(1),  complex_mp(1),  complex_mp(1);
 
 	auto v_rescaled = p.RescalePoint(v);
 
@@ -105,8 +105,8 @@ namespace bertini {
 			precision_ = DefaultPrecision();
 
 			// a little shorthand unpacking the tuple
-			std::vector<Vec<mpfr_complex> >& coefficients_mpfr = std::get<std::vector<Vec<mpfr_complex> > >(this->coefficients_working_);
-			std::vector<Vec<dbl> >& coefficients_dbl = std::get<std::vector<Vec<dbl> > >(this->coefficients_working_);
+			std::vector<Vec<complex_mp> >& coefficients_mpfr = std::get<std::vector<Vec<complex_mp> > >(this->coefficients_working_);
+			std::vector<Vec<complex_dbl> >& coefficients_dbl = std::get<std::vector<Vec<complex_dbl> > >(this->coefficients_working_);
 
 			coefficients_highest_precision_.resize(other.NumVariableGroups());
 			coefficients_mpfr.resize(variable_group_sizes_.size());
@@ -126,8 +126,8 @@ namespace bertini {
 
 					coefficients_highest_precision_[ii](jj) = other.coefficients_highest_precision_[ii](jj);
 
-					coefficients_dbl[ii](jj) = dbl(coefficients_highest_precision_[ii](jj));
-					coefficients_mpfr[ii](jj) = mpfr_complex(coefficients_highest_precision_[ii](jj));
+					coefficients_dbl[ii](jj) = complex_dbl(coefficients_highest_precision_[ii](jj));
+					coefficients_mpfr[ii](jj) = complex_mp(coefficients_highest_precision_[ii](jj));
 
 					assert(coefficients_highest_precision_[ii](jj) == other.coefficients_highest_precision_[ii](jj));
 				}
@@ -155,8 +155,8 @@ namespace bertini {
 			using bertini::Precision;
 			using bertini::multiprecision::RandomComplex;
 
-			std::vector<Vec<mpfr_complex> >& coefficients_mpfr = std::get<std::vector<Vec<mpfr_complex> > >(coefficients_working_);
-			std::vector<Vec<dbl> >& coefficients_dbl = std::get<std::vector<Vec<dbl> > >(coefficients_working_);
+			std::vector<Vec<complex_mp> >& coefficients_mpfr = std::get<std::vector<Vec<complex_mp> > >(coefficients_working_);
+			std::vector<Vec<complex_dbl> >& coefficients_dbl = std::get<std::vector<Vec<complex_dbl> > >(coefficients_working_);
 
 			coefficients_highest_precision_.resize(sizes.size());
 			coefficients_dbl.resize(sizes.size());
@@ -174,7 +174,7 @@ namespace bertini {
 				coefficients_dbl[ii].resize(sizes[ii]);
 				for (unsigned jj=0; jj<sizes[ii]; ++jj)
 				{
-					coefficients_dbl[ii](jj) = dbl(coefficients_highest_precision_[ii](jj));
+					coefficients_dbl[ii](jj) = complex_dbl(coefficients_highest_precision_[ii](jj));
 				}
 
 				// assignment preserves precision of source.  
@@ -214,8 +214,8 @@ namespace bertini {
 
 			
 
-			std::vector<Vec<mpfr_complex> >& coefficients_mpfr = std::get<std::vector<Vec<mpfr_complex> > >(p.coefficients_working_);
-			std::vector<Vec<dbl> >& coefficients_dbl = std::get<std::vector<Vec<dbl> > >(p.coefficients_working_);
+			std::vector<Vec<complex_mp> >& coefficients_mpfr = std::get<std::vector<Vec<complex_mp> > >(p.coefficients_working_);
+			std::vector<Vec<complex_dbl> >& coefficients_dbl = std::get<std::vector<Vec<complex_dbl> > >(p.coefficients_working_);
 
 			p.coefficients_highest_precision_.resize(sizes.size());
 			coefficients_mpfr.resize(sizes.size());
@@ -233,7 +233,7 @@ namespace bertini {
 
 				coefficients_dbl[ii].resize(sizes[ii]);
 				for (unsigned jj=0; jj<sizes[ii]; ++jj)
-					coefficients_dbl[ii](jj) = dbl(p.coefficients_highest_precision_[ii](jj));
+					coefficients_dbl[ii](jj) = complex_dbl(p.coefficients_highest_precision_[ii](jj));
 			}
 
 			return p;
@@ -263,7 +263,7 @@ namespace bertini {
 				return;
 
 			using bertini::Precision;
-			std::vector<Vec<mpfr_complex> >& coefficients_mpfr = std::get<std::vector<Vec<mpfr_complex> > >(coefficients_working_);
+			std::vector<Vec<complex_mp> >& coefficients_mpfr = std::get<std::vector<Vec<complex_mp> > >(coefficients_working_);
 
 			for (unsigned ii = 0; ii < NumVariableGroups(); ++ii)
 			{
@@ -527,9 +527,9 @@ namespace bertini {
 		//
 		//////////////////
 
-		std::vector< Vec< mpfr_complex > > coefficients_highest_precision_; ///< the highest-precision coefficients for the patch
+		std::vector< Vec< complex_mp > > coefficients_highest_precision_; ///< the highest-precision coefficients for the patch
 
-		mutable std::tuple< std::vector< Vec< mpfr_complex > >, std::vector< Vec< dbl > > > coefficients_working_; ///< the current working coefficients of the patch.  changing precision affects these, particularly the mpfr_complex coefficients, which are down-sampled from the highest_precision coefficients.  the doubles are only down-sampled at time of creation or modification.
+		mutable std::tuple< std::vector< Vec< complex_mp > >, std::vector< Vec< complex_dbl > > > coefficients_working_; ///< the current working coefficients of the patch.  changing precision affects these, particularly the complex_mp coefficients, which are down-sampled from the highest_precision coefficients.  the doubles are only down-sampled at time of creation or modification.
 
 		std::vector<unsigned> variable_group_sizes_; ///< the sizes of the groups.  In principle, these must be at least 2.
 

--- a/core/include/bertini2/system/slice.hpp
+++ b/core/include/bertini2/system/slice.hpp
@@ -85,7 +85,7 @@ namespace bertini {
 		       the trailing column is each form's constant term (zero, for a homogeneous slice).
 		\param homogeneous Whether the slice was authored without constant terms.
 		*/
-		static Slice FromCoefficients(VariableGroup const& v, Mat<mpfr_complex> const& augmented_coefficients, bool homogeneous = false)
+		static Slice FromCoefficients(VariableGroup const& v, Mat<complex_mp> const& augmented_coefficients, bool homogeneous = false)
 		{
 			assert(static_cast<size_t>(augmented_coefficients.cols()) == v.size() + 1 &&
 			       "a slice coefficient matrix must have (num_variables + 1) columns");
@@ -101,7 +101,7 @@ namespace bertini {
 		*/
 		static Slice RandomReal(VariableGroup const& v, unsigned dim, bool homogeneous = false, bool orthogonal = true)
 		{
-			typedef void (*funtype) (mpfr_complex&, unsigned); // the type for number generation
+			typedef void (*funtype) (complex_mp&, unsigned); // the type for number generation
 			funtype gen = bertini::multiprecision::RandomRealAssign;
 			return Make(v, dim, homogeneous, orthogonal, gen);
 		}
@@ -111,7 +111,7 @@ namespace bertini {
 		*/
 		static Slice RandomComplex(VariableGroup const& v, unsigned dim, bool homogeneous = false, bool orthogonal = true)
 		{
-			typedef void (*funtype) (mpfr_complex&, unsigned); // the type for number generation
+			typedef void (*funtype) (complex_mp&, unsigned); // the type for number generation
 			funtype gen = bertini::multiprecision::RandomComplexAssign;
 			return Make(v, dim, homogeneous, orthogonal, gen);
 		}
@@ -121,11 +121,11 @@ namespace bertini {
 		orthonormalized by a QR factorization) and the constant column, then assembles the augmented
 		matrix the LinearFormsBlock holds.
 		*/
-		static Slice Make(VariableGroup const& v, unsigned dim, bool homogeneous, bool orthogonal, std::function<void(mpfr_complex&, unsigned)> gen)
+		static Slice Make(VariableGroup const& v, unsigned dim, bool homogeneous, bool orthogonal, std::function<void(complex_mp&, unsigned)> gen)
 		{
 			const unsigned num_vars = static_cast<unsigned>(v.size());
 
-			Mat<mpfr_complex> coeffs(dim, num_vars); // the variable coefficients (one row per form)
+			Mat<complex_mp> coeffs(dim, num_vars); // the variable coefficients (one row per form)
 
 			if (orthogonal)
 			{
@@ -146,8 +146,8 @@ namespace bertini {
 				auto prev_precision = DefaultPrecision();
 				DefaultPrecision(MaxPrecisionAllowed());
 
-				auto QR_factorization = Eigen::HouseholderQR<Mat<mpfr_complex> >(coeffs);
-				coeffs = QR_factorization.householderQ() * Mat<mpfr_complex>::Identity(maxdim, mindim);
+				auto QR_factorization = Eigen::HouseholderQR<Mat<complex_mp> >(coeffs);
+				coeffs = QR_factorization.householderQ() * Mat<complex_mp>::Identity(maxdim, mindim);
 
 				if (need_transpose)
 					coeffs.transposeInPlace();
@@ -166,7 +166,7 @@ namespace bertini {
 
 			// Assemble the augmented matrix: [ coeffs | constants ].  A homogeneous slice's constant
 			// column is zero; otherwise it is freshly generated.
-			Mat<mpfr_complex> augmented(dim, num_vars + 1);
+			Mat<complex_mp> augmented(dim, num_vars + 1);
 			augmented.leftCols(num_vars) = coeffs;
 			if (homogeneous)
 				augmented.col(num_vars).setZero();
@@ -230,7 +230,7 @@ namespace bertini {
 		These rows are also factor rows for a ProductsOfLinearsBlock, so a slice composes directly into
 		the product-of-linears form regeneration uses.
 		*/
-		Mat<mpfr_complex> const& Coefficients() const
+		Mat<complex_mp> const& Coefficients() const
 		{
 			return block_.Coefficients();
 		}
@@ -261,9 +261,9 @@ namespace bertini {
 			if (NumVariables() != other.NumVariables())
 				throw std::runtime_error("Slice::Concatenate requires both slices to be on the same number of variables");
 
-			Mat<mpfr_complex> const& A = Coefficients();
-			Mat<mpfr_complex> const& B = other.Coefficients();
-			Mat<mpfr_complex> stacked(A.rows() + B.rows(), A.cols());
+			Mat<complex_mp> const& A = Coefficients();
+			Mat<complex_mp> const& B = other.Coefficients();
+			Mat<complex_mp> stacked(A.rows() + B.rows(), A.cols());
 			stacked.topRows(A.rows()) = A;
 			stacked.bottomRows(B.rows()) = B;
 
@@ -296,8 +296,8 @@ namespace bertini {
 		*/
 		Slice Rows(std::vector<unsigned> const& indices) const
 		{
-			Mat<mpfr_complex> const& C = Coefficients();
-			Mat<mpfr_complex> sub(static_cast<Eigen::Index>(indices.size()), C.cols());
+			Mat<complex_mp> const& C = Coefficients();
+			Mat<complex_mp> sub(static_cast<Eigen::Index>(indices.size()), C.cols());
 			for (size_t ii = 0; ii < indices.size(); ++ii)
 			{
 				if (indices[ii] >= Dimension())

--- a/core/include/bertini2/system/start/mhom.hpp
+++ b/core/include/bertini2/system/start/mhom.hpp
@@ -104,14 +104,14 @@ namespace bertini
 
 			Called by the base StartSystem's StartPoint(index) method.
 			*/
-			Vec<dbl> GenerateStartPoint(dbl,unsigned long long index) const override;
+			Vec<complex_dbl> GenerateStartPoint(complex_dbl,unsigned long long index) const override;
 
 			/**
 			Get the ith start point, in current default precision.
 
 			Called by the base StartSystem's StartPoint(index) method.
 			*/
-			Vec<mpfr_complex> GenerateStartPoint(mpfr_complex,unsigned long long index) const override;
+			Vec<complex_mp> GenerateStartPoint(complex_mp,unsigned long long index) const override;
 			
 			/**
 			 A local version of GenerateStartPoint that can be templated
@@ -130,11 +130,11 @@ namespace bertini
 			/// constant (0 for projective groups -- their factors are homogeneous).  This is the
 			/// data the retired node::LinearProduct used to hold; the products-of-linears block
 			/// and the start-point solve read it directly.
-			Mat<Mat<mpfr_complex>> linear_coeffs_;
+			Mat<Mat<complex_mp>> linear_coeffs_;
 			std::vector< std::vector<size_t> > variable_cols_; ///< The columns associated with each variable.  The first index is the variable group, the second index is the particular variable in the group.
 			size_t num_hom_groups_ = 0; ///< how many of the leading entries of var_groups_ are projective (homogeneous) groups; the rest are affine.  A projective group of size k spans P^{k-1}: dimension k-1, so it takes k-1 functions and its start-point component is a homogeneous vector.
 
-			mutable Vec<mpfr_complex> temp_v_mp_;
+			mutable Vec<complex_mp> temp_v_mp_;
 
 			friend class boost::serialization::access;
 

--- a/core/include/bertini2/system/start/total_degree.hpp
+++ b/core/include/bertini2/system/start/total_degree.hpp
@@ -119,14 +119,14 @@ namespace bertini
 
 			Called by the base StartSystem's StartPoint(index) method.
 			*/
-			Vec<dbl> GenerateStartPoint(dbl,unsigned long long index) const override;
+			Vec<complex_dbl> GenerateStartPoint(complex_dbl,unsigned long long index) const override;
 
 			/**
 			Get the ith start point, in current default precision.
 
 			Called by the base StartSystem's StartPoint(index) method.
 			*/
-			Vec<mpfr_complex> GenerateStartPoint(mpfr_complex,unsigned long long index) const override;
+			Vec<complex_mp> GenerateStartPoint(complex_mp,unsigned long long index) const override;
 
 			std::vector<std::shared_ptr<node::Rational> > random_values_; ///< stores the random values for the start functions.  x^d-r, where r is stored in this vector.
 			std::vector<unsigned long long> degrees_; ///< stores the degrees of the functions.

--- a/core/include/bertini2/system/start/user.hpp
+++ b/core/include/bertini2/system/start/user.hpp
@@ -70,8 +70,8 @@ namespace bertini
 			/**
 			 Constructor for making a user-provided start system from another.
 			*/
-			User(System const& s, SampCont<dbl> const& solns);
-			User(System const& s, SampCont<mpfr_complex> const& solns);
+			User(System const& s, SampCont<complex_dbl> const& solns);
+			User(System const& s, SampCont<complex_mp> const& solns);
 
 
 
@@ -91,14 +91,14 @@ namespace bertini
 
 			Called by the base StartSystem's StartPoint(index) method.
 			*/
-			Vec<dbl> GenerateStartPoint(dbl,unsigned long long index) const override;
+			Vec<complex_dbl> GenerateStartPoint(complex_dbl,unsigned long long index) const override;
 
 			/**
 			Get the ith start point, in current default precision.
 
 			Called by the base StartSystem's StartPoint(index) method.
 			*/
-			Vec<mpfr_complex> GenerateStartPoint(mpfr_complex,unsigned long long index) const override;
+			Vec<complex_mp> GenerateStartPoint(complex_mp,unsigned long long index) const override;
 
 
 			friend class boost::serialization::access;
@@ -110,7 +110,7 @@ namespace bertini
 			}
 
 			const bertini::System& user_system_;
-			std::tuple<SampCont<dbl>, SampCont<mpfr_complex>> solns_;
+			std::tuple<SampCont<complex_dbl>, SampCont<complex_mp>> solns_;
 			bool solns_in_dbl_;
 		};
 	}
@@ -143,13 +143,13 @@ inline void load_construct_data(
 
     if (solns_in_dbl)
     {
-    	bertini::SampCont<bertini::dbl> solns;
+    	bertini::SampCont<bertini::complex_dbl> solns;
     	ar >> solns;
     	::new(t)bertini::start_system::User(sys, solns);
     }
 	else
 	{
-		bertini::SampCont<bertini::mpfr_complex> solns;
+		bertini::SampCont<bertini::complex_mp> solns;
 		ar >> solns;
 		::new(t)bertini::start_system::User(sys, solns);
 	}

--- a/core/include/bertini2/system/start_base.hpp
+++ b/core/include/bertini2/system/start_base.hpp
@@ -62,8 +62,8 @@ namespace bertini
 			virtual ~StartSystem() = default;
 			
 		private:
-			virtual Vec<dbl> GenerateStartPoint(dbl,unsigned long long index) const = 0;
-			virtual Vec<mpfr_complex> GenerateStartPoint(mpfr_complex,unsigned long long index) const = 0;
+			virtual Vec<complex_dbl> GenerateStartPoint(complex_dbl,unsigned long long index) const = 0;
+			virtual Vec<complex_mp> GenerateStartPoint(complex_mp,unsigned long long index) const = 0;
 
 			friend class boost::serialization::access;
 

--- a/core/include/bertini2/system/straight_line_program.hpp
+++ b/core/include/bertini2/system/straight_line_program.hpp
@@ -270,7 +270,7 @@ namespace bertini {
 		Kind kind = Kind::Integer;
 		mpz_int      int_value;             //< Kind::Integer  (exact)
 		mpq_rational rat_real, rat_imag;    //< Kind::Rational (exact)
-		mpfr_complex float_value;           //< Kind::Complex (authored-precision literal; also a fixed variable's value)
+		complex_mp float_value;           //< Kind::Complex (authored-precision literal; also a fixed variable's value)
 		size_t slot = 0;                    //< where this constant lives in the register file
 
 		/// Produce the constant's value at the ambient working precision (ThreadPrecision), matching
@@ -310,7 +310,7 @@ namespace bertini {
 
 		//< The register file.  Numbers and variables, plus temp results and output locations.  It's
 		//  all one block per number type.  That's why it's called a SLP!
-		mutable std::tuple< std::vector<dbl_complex>, std::vector<mpfr_complex> > registers_;
+		mutable std::tuple< std::vector<complex_dbl>, std::vector<complex_mp> > registers_;
 
 		mutable unsigned precision_ = 16; //< The current working number of digits
 		mutable bool is_evaluated_ = false;
@@ -325,8 +325,8 @@ namespace bertini {
 
 		template <typename Archive>
 		void serialize(Archive& ar, const unsigned /*version*/) {
-			ar & std::get<std::vector<dbl_complex>>(registers_);
-			ar & std::get<std::vector<mpfr_complex>>(registers_);
+			ar & std::get<std::vector<complex_dbl>>(registers_);
+			ar & std::get<std::vector<complex_mp>>(registers_);
 			ar & precision_;
 			ar & is_evaluated_;
 			// frozen_valid_* are transient (recomputed on first eval); not serialized.
@@ -715,7 +715,7 @@ namespace bertini {
 // && _WIN32
 			// An empty variable vector (a constant program with no variables) has no
 			// precision to read or check.
-			if (!std::is_same<NumT,dbl_complex>::value && variable_values.size() > 0 && Precision(variable_values)!=memory_.precision_){
+			if (!std::is_same<NumT,complex_dbl>::value && variable_values.size() > 0 && Precision(variable_values)!=memory_.precision_){
 				std::stringstream err_msg;
 				err_msg << "variable_values and SLP must be of same precision.  respective precisions: " << Precision(variable_values) << " " << memory_.precision_ << std::endl;
 				throw std::runtime_error(err_msg.str());

--- a/core/include/bertini2/system/system.hpp
+++ b/core/include/bertini2/system/system.hpp
@@ -137,7 +137,7 @@ namespace bertini {
 		/**
 		Change the precision of the entire system's functions, subfunctions, and all other nodes.
 
-		\param new_precision The new precision, in digits, to work in.  This only affects the mpfr_complex types, not double.  To use low-precision (doubles), use that number type in the templated functions.
+		\param new_precision The new precision, in digits, to work in.  This only affects the complex_mp types, not double.  To use low-precision (doubles), use that number type in the templated functions.
 		*/
 		void precision(unsigned new_precision) const;
 
@@ -213,7 +213,7 @@ namespace bertini {
 		 
 		 
 		 \throws std::runtime_error, if a path variable IS defined, but you didn't pass it a value.  Also throws if the number of variables doesn't match.
-		 \tparam T the number-type for return.  Probably dbl=std::complex<double>, or mpfr_complex=bertini::mpfr_complex.
+		 \tparam T the number-type for return.  Probably complex_dbl=std::complex<double>, or complex_mp=bertini::complex_mp.
 		 \param variable_values The values of the variables, for the evaluation.
 		 */
 		template<typename T, typename Derived>
@@ -244,7 +244,7 @@ namespace bertini {
 
 
 		\throws std::runtime_error, if a path variable IS defined, but you didn't pass it a value.  Also throws if the number of variables doesn't match.
-		\tparam T the number-type for return.  Probably dbl=std::complex<double>, or mpfr_complex=bertini::mpfr_complex.
+		\tparam T the number-type for return.  Probably complex_dbl=std::complex<double>, or complex_mp=bertini::complex_mp.
 		\param variable_values The values of the variables, for the evaluation.
 		*/
 		template<typename Derived>
@@ -274,7 +274,7 @@ namespace bertini {
 		 Evaluate the system, provided a path variable is defined for the system, in place.
 
 		 \throws std::runtime_error, if a path variable is NOT defined, and you passed it a value.  Also throws if the number of variables doesn't match.
-		 \tparam T the number-type for return.  Probably dbl=std::complex<double>, or mpfr_complex=bertini::mpfr_complex.
+		 \tparam T the number-type for return.  Probably complex_dbl=std::complex<double>, or complex_mp=bertini::complex_mp.
 		 
 		 \param variable_values The values of the variables, for the evaluation.
 		 \param path_variable_value The current value of the path variable.
@@ -310,7 +310,7 @@ namespace bertini {
 		 Evaluate the system, provided a path variable is defined for the system.
 
 		 \throws std::runtime_error, if a path variable is NOT defined, and you passed it a value.  Also throws if the number of variables doesn't match.
-		 \tparam T the number-type for return.  Probably dbl=std::complex<double>, or mpfr_complex=bertini::mpfr_complex.
+		 \tparam T the number-type for return.  Probably complex_dbl=std::complex<double>, or complex_mp=bertini::complex_mp.
 		 
 		 \param variable_values The values of the variables, for the evaluation.
 		 \param path_variable_value The current value of the path variable.
@@ -339,7 +339,7 @@ namespace bertini {
 		/**
 		 \brief Evaluate the Jacobian matrix of the system, using the previous space and time values, in place.
 
-		\tparam T the number-type for return.  Probably dbl=std::complex<double>, or mpfr_complex=bertini::mpfr_complex.
+		\tparam T the number-type for return.  Probably complex_dbl=std::complex<double>, or complex_mp=bertini::complex_mp.
 
 		This is analogous to J = sys.JacobianInPlace();
 
@@ -374,7 +374,7 @@ namespace bertini {
 		/**
 		Evaluate the Jacobian matrix of the system, using the previous space and time values.
 
-		\tparam T the number-type for return.  Probably dbl=std::complex<double>, or mpfr_complex=bertini::mpfr_complex.
+		\tparam T the number-type for return.  Probably complex_dbl=std::complex<double>, or complex_mp=bertini::complex_mp.
 		*/
 		template<typename T>
 		Mat<T> Jacobian() const
@@ -393,7 +393,7 @@ namespace bertini {
 		 Evaluate the Jacobian matrix of the system, provided the system has no path variable defined.
 		 
 		 \throws std::runtime_error, if a path variable IS defined, but you didn't pass it a value.  Also throws if the number of variables doesn't match.
-		 \tparam T the number-type for return.  Probably dbl=std::complex<double>, or mpfr_complex=bertini::mpfr_complex.
+		 \tparam T the number-type for return.  Probably complex_dbl=std::complex<double>, or complex_mp=bertini::complex_mp.
 		 
 		 \param variable_values The values of the variables, for the evaluation.
 		 */
@@ -421,7 +421,7 @@ namespace bertini {
 		Evaluate the Jacobian matrix of the system, provided the system has no path variable defined.
 
 		\throws std::runtime_error, if a path variable IS defined, but you didn't pass it a value.  Also throws if the number of variables doesn't match.
-		\tparam T the number-type for return.  Probably dbl=std::complex<double>, or mpfr_complex=bertini::mpfr_complex.
+		\tparam T the number-type for return.  Probably complex_dbl=std::complex<double>, or complex_mp=bertini::complex_mp.
 		
 		\param variable_values The values of the variables, for the evaluation.
 		*/
@@ -451,7 +451,7 @@ namespace bertini {
 		 \param variable_values The values of the variables, for the evaluation.
 		 \param path_variable_value The current value of the path variable.
 
-		 \tparam T the number-type for return.  Probably dbl=std::complex<double>, or mpfr_complex=bertini::mpfr_complex.
+		 \tparam T the number-type for return.  Probably complex_dbl=std::complex<double>, or complex_mp=bertini::complex_mp.
 		 */
 		template<typename Derived, typename T>
 		void JacobianInPlace(Mat<T> & J, const Eigen::MatrixBase<Derived> & variable_values, const T & path_variable_value) const
@@ -482,7 +482,7 @@ namespace bertini {
 		 \param variable_values The values of the variables, for the evaluation.
 		 \param path_variable_value The current value of the path variable.
 
-		 \tparam T the number-type for return.  Probably dbl=std::complex<double>, or mpfr_complex=bertini::mpfr_complex.
+		 \tparam T the number-type for return.  Probably complex_dbl=std::complex<double>, or complex_mp=bertini::complex_mp.
 		 */
 		template<typename Derived, typename T>
 		Mat<T> Jacobian(const Eigen::MatrixBase<Derived> & variable_values, const T & path_variable_value) const
@@ -521,7 +521,7 @@ namespace bertini {
 		
 		If \f$S\f$ is the system, and \f$t\f$ is the path variable this computes \f$\frac{dS}{dt}\f$.
 
-		\tparam T The number-type for return.  Probably dbl=std::complex<double>, or mpfr_complex=bertini::mpfr_complex.
+		\tparam T The number-type for return.  Probably complex_dbl=std::complex<double>, or complex_mp=bertini::complex_mp.
 		\throws std::runtime error if the system does not have a path variable defined.
 		*/
 		template<typename Derived, typename T>
@@ -546,7 +546,7 @@ namespace bertini {
 		
 		If \f$S\f$ is the system, and \f$t\f$ is the path variable this computes \f$\frac{dS}{dt}\f$.
 
-		\tparam T The number-type for return.  Probably dbl=std::complex<double>, or mpfr_complex=bertini::mpfr_complex.
+		\tparam T The number-type for return.  Probably complex_dbl=std::complex<double>, or complex_mp=bertini::complex_mp.
 		\throws std::runtime error if the system does not have a path variable defined.
 		*/
 		template<typename Derived, typename T>
@@ -586,7 +586,7 @@ namespace bertini {
 		
 		If \f$S\f$ is the system, and \f$t\f$ is the path variable this computes \f$\frac{dS}{dt}\f$.
 
-		\tparam T The number-type for return.  Probably dbl=std::complex<double>, or mpfr_complex=bertini::mpfr_complex.
+		\tparam T The number-type for return.  Probably complex_dbl=std::complex<double>, or complex_mp=bertini::complex_mp.
 		\throws std::runtime error if the system does not have a path variable defined.
 		*/
 		template<typename Derived, typename T>
@@ -635,7 +635,7 @@ namespace bertini {
 		
 		If \f$S\f$ is the system, and \f$t\f$ is the path variable this computes \f$\frac{dS}{dt}\f$.
 
-		\tparam T The number-type for return.  Probably dbl=std::complex<double>, or mpfr_complex=bertini::mpfr_complex.
+		\tparam T The number-type for return.  Probably complex_dbl=std::complex<double>, or complex_mp=bertini::complex_mp.
 		\throws std::runtime error if the system does not have a path variable defined.
 		*/
 		template<typename T>
@@ -782,7 +782,7 @@ namespace bertini {
 		/**
 		 Set the values of the variables to be equal to the input values
 
-		 \tparam T the number-type for return.  Probably dbl=std::complex<double>, or mpfr_complex=bertini::mpfr_complex.
+		 \tparam T the number-type for return.  Probably complex_dbl=std::complex<double>, or complex_mp=bertini::complex_mp.
 		 \throws std::runtime_error if the number of variables doesn't match.
 
 		 The ordering of the variables matters.  
@@ -810,7 +810,7 @@ namespace bertini {
 				// precision to read from it, so skip the check.
 				if (new_values.size() > 0)
 				{
-					if constexpr (!std::is_same<T,dbl>::value) {
+					if constexpr (!std::is_same<T,complex_dbl>::value) {
 						if (Precision(new_values) != this->precision())
 							throw std::runtime_error("precision of input point in SetVariables (" + std::to_string(Precision(new_values)) + ") must match the precision of the system (" + std::to_string(this->precision()) + ").");
 					}
@@ -830,7 +830,7 @@ namespace bertini {
 		 Set the current value of the path variable.
 		
 		 \throws std::runtime_error, if a path variable is not defined.
-		 \tparam T the number-type for return.  Probably dbl=std::complex<double>, or mpfr_complex=bertini::mpfr_complex.
+		 \tparam T the number-type for return.  Probably complex_dbl=std::complex<double>, or complex_mp=bertini::complex_mp.
 
 		 \param new_value The new updated values for the path variable.
 		 */
@@ -1079,7 +1079,7 @@ namespace bertini {
 
 		\throws std::runtime_error if R's column count does not equal this system's natural-function count.
 		*/
-		System Randomize(Mat<mpfr_complex> const& R) const;
+		System Randomize(Mat<complex_mp> const& R) const;
 
 		/**
 		\brief The randomization matrix R of a system produced by Randomize() (its first
@@ -1087,7 +1087,7 @@ namespace bertini {
 
 		\throws std::runtime_error if this system carries no randomization block.
 		*/
-		Mat<mpfr_complex> RandomizationMatrix() const;
+		Mat<complex_mp> RandomizationMatrix() const;
 
 
 
@@ -1163,7 +1163,7 @@ namespace bertini {
 		/**
 		\brief Dehomogenize a point, using the variable grouping / structure of the system.
 		
-		\tparam T the number-type for return.  Probably dbl=std::complex<double>, or mpfr_complex=bertini::mpfr_complex.
+		\tparam T the number-type for return.  Probably complex_dbl=std::complex<double>, or complex_mp=bertini::complex_mp.
 
 		\throws std::runtime_error, if there is a mismatch between the number of variables in the input point, and the total number of var
 		*/
@@ -1220,7 +1220,7 @@ namespace bertini {
 		This is the inverse of DehomogenizePoint: DehomogenizePoint(HomogenizePoint(p)) == p.
 		On an unhomogenized, unpatched system this is the identity.
 
-		\tparam T the number-type.  Probably dbl=std::complex<double>, or mpfr_complex=bertini::mpfr_complex.
+		\tparam T the number-type.  Probably complex_dbl=std::complex<double>, or complex_mp=bertini::complex_mp.
 
 		\throws std::runtime_error, if there is a mismatch between the number of variables in the input point, and the number of natural variables of the system.
 		*/
@@ -1538,7 +1538,7 @@ namespace bertini {
 		/// Shared back end of the Randomize overloads: given the overdetermined operand (already a
 		/// copy, sorted or not) and a finished coefficient matrix, compute the per-row target
 		/// multidegrees, build the RandomizationBlock, and return a new system carrying it.
-		System AssembleRandomized(std::shared_ptr<System> operand, Mat<mpfr_complex> coefficients) const;
+		System AssembleRandomized(std::shared_ptr<System> operand, Mat<complex_mp> coefficients) const;
 
 		/**
 		\brief Get the sizes according to the FIFO ordering.
@@ -1556,7 +1556,7 @@ namespace bertini {
 		/**
 		\brief Dehomogenize a point according to the FIFO variable ordering.
 	
-		\tparam T the number-type for return.  Probably dbl=std::complex<double>, or mpfr_complex=bertini::mpfr_complex.
+		\tparam T the number-type for return.  Probably complex_dbl=std::complex<double>, or complex_mp=bertini::complex_mp.
 
 		\see FIFOVariableOrdering
 		*/
@@ -1758,7 +1758,7 @@ namespace bertini {
 		void CoerceBlockOutputPrecision(Eigen::MatrixBase<Derived>& result) const
 		{
 			using Scalar = typename Derived::Scalar;
-			if constexpr (!std::is_same<Scalar, dbl>::value)
+			if constexpr (!std::is_same<Scalar, complex_dbl>::value)
 			{
 				using bertini::Precision;
 				Precision(result, precision_);
@@ -1840,8 +1840,8 @@ namespace bertini {
 
 		std::vector< VariableGroupType > time_order_of_variable_groups_;
 
-		mutable std::tuple< Vec<dbl>, Vec<mpfr_complex> > current_variable_values_;
-		mutable std::tuple< dbl, mpfr_complex > current_path_value_{}; ///< per-thread path value (node-free; read by CurrentPathValue, written by SetPathVariable)
+		mutable std::tuple< Vec<complex_dbl>, Vec<complex_mp> > current_variable_values_;
+		mutable std::tuple< complex_dbl, complex_mp > current_path_value_{}; ///< per-thread path value (node-free; read by CurrentPathValue, written by SetPathVariable)
 
 		mutable VariableGroup variable_ordering_; ///< The assembled ordering of the variables in the system.
 		mutable bool have_ordering_ = false;
@@ -1896,12 +1896,12 @@ namespace bertini {
 
 
 			// if (Archive::is_loading::value == true){
-        	// 	std::get<Vec<dbl>>(current_variable_values_).resize(NumVariables());
-        	// 	std::get<Vec<mpfr_complex>>(current_variable_values_).resize(NumVariables());
+        	// 	std::get<Vec<complex_dbl>>(current_variable_values_).resize(NumVariables());
+        	// 	std::get<Vec<complex_mp>>(current_variable_values_).resize(NumVariables());
 			// }
 			// // next two lines no matter what
-			// ar & std::get<Vec<dbl>>(current_variable_values_);
-			// ar & std::get<Vec<mpfr_complex>>(current_variable_values_);
+			// ar & std::get<Vec<complex_dbl>>(current_variable_values_);
+			// ar & std::get<Vec<complex_mp>>(current_variable_values_);
 
 		}
 
@@ -1986,41 +1986,41 @@ namespace bertini {
 	// Suppresses re-instantiation of the heavy Eval/Jacobian/Set template bodies
 	// (with their eval_method_ switch trees) in every including TU.
 
-	extern template void System::EvalInPlace<dbl>(Vec<dbl>&) const;
-	extern template void System::EvalInPlace<mpfr_complex>(Vec<mpfr_complex>&) const;
+	extern template void System::EvalInPlace<complex_dbl>(Vec<complex_dbl>&) const;
+	extern template void System::EvalInPlace<complex_mp>(Vec<complex_mp>&) const;
 
-	extern template Vec<dbl> System::Eval<dbl>() const;
-	extern template Vec<mpfr_complex> System::Eval<mpfr_complex>() const;
+	extern template Vec<complex_dbl> System::Eval<complex_dbl>() const;
+	extern template Vec<complex_mp> System::Eval<complex_mp>() const;
 
-	extern template void System::JacobianInPlace<dbl>(Mat<dbl>&) const;
-	extern template void System::JacobianInPlace<mpfr_complex>(Mat<mpfr_complex>&) const;
+	extern template void System::JacobianInPlace<complex_dbl>(Mat<complex_dbl>&) const;
+	extern template void System::JacobianInPlace<complex_mp>(Mat<complex_mp>&) const;
 
-	extern template Mat<dbl> System::Jacobian<dbl>() const;
-	extern template Mat<mpfr_complex> System::Jacobian<mpfr_complex>() const;
+	extern template Mat<complex_dbl> System::Jacobian<complex_dbl>() const;
+	extern template Mat<complex_mp> System::Jacobian<complex_mp>() const;
 
-	extern template Mat<dbl> System::Jacobian<dbl>(const Vec<dbl>&) const;
-	extern template Mat<mpfr_complex> System::Jacobian<mpfr_complex>(const Vec<mpfr_complex>&) const;
+	extern template Mat<complex_dbl> System::Jacobian<complex_dbl>(const Vec<complex_dbl>&) const;
+	extern template Mat<complex_mp> System::Jacobian<complex_mp>(const Vec<complex_mp>&) const;
 
-	extern template void System::JacobianInPlace<dbl>(Mat<dbl>&, const Vec<dbl>&) const;
-	extern template void System::JacobianInPlace<mpfr_complex>(Mat<mpfr_complex>&, const Vec<mpfr_complex>&) const;
+	extern template void System::JacobianInPlace<complex_dbl>(Mat<complex_dbl>&, const Vec<complex_dbl>&) const;
+	extern template void System::JacobianInPlace<complex_mp>(Mat<complex_mp>&, const Vec<complex_mp>&) const;
 
-	extern template void System::TimeDerivativeInPlace<dbl>(Vec<dbl>&) const;
-	extern template void System::TimeDerivativeInPlace<mpfr_complex>(Vec<mpfr_complex>&) const;
+	extern template void System::TimeDerivativeInPlace<complex_dbl>(Vec<complex_dbl>&) const;
+	extern template void System::TimeDerivativeInPlace<complex_mp>(Vec<complex_mp>&) const;
 
-	extern template Vec<dbl> System::TimeDerivative<dbl>() const;
-	extern template Vec<mpfr_complex> System::TimeDerivative<mpfr_complex>() const;
+	extern template Vec<complex_dbl> System::TimeDerivative<complex_dbl>() const;
+	extern template Vec<complex_mp> System::TimeDerivative<complex_mp>() const;
 
-	extern template void System::SetVariables<dbl>(const Vec<dbl>&) const;
-	extern template void System::SetVariables<mpfr_complex>(const Vec<mpfr_complex>&) const;
+	extern template void System::SetVariables<complex_dbl>(const Vec<complex_dbl>&) const;
+	extern template void System::SetVariables<complex_mp>(const Vec<complex_mp>&) const;
 
-	extern template void System::SetPathVariable<dbl>(dbl const&) const;
-	extern template void System::SetPathVariable<mpfr_complex>(mpfr_complex const&) const;
+	extern template void System::SetPathVariable<complex_dbl>(complex_dbl const&) const;
+	extern template void System::SetPathVariable<complex_mp>(complex_mp const&) const;
 
-	extern template void System::SetAndReset<dbl>(Vec<dbl> const&, dbl const&) const;
-	extern template void System::SetAndReset<mpfr_complex>(Vec<mpfr_complex> const&, mpfr_complex const&) const;
+	extern template void System::SetAndReset<complex_dbl>(Vec<complex_dbl> const&, complex_dbl const&) const;
+	extern template void System::SetAndReset<complex_mp>(Vec<complex_mp> const&, complex_mp const&) const;
 
-	extern template void System::SetAndReset<dbl>(Vec<dbl> const&) const;
-	extern template void System::SetAndReset<mpfr_complex>(Vec<mpfr_complex> const&) const;
+	extern template void System::SetAndReset<complex_dbl>(Vec<complex_dbl> const&) const;
+	extern template void System::SetAndReset<complex_mp>(Vec<complex_mp> const&) const;
 
 }
 

--- a/core/include/bertini2/trackers/adaptive_precision_utilities.hpp
+++ b/core/include/bertini2/trackers/adaptive_precision_utilities.hpp
@@ -45,7 +45,7 @@ namespace bertini{ namespace tracking { namespace adaptive{
 \param prec The new precision the samples should have.
 */
 inline
-void SetPrecision(SampCont<mpfr_complex> & samples, unsigned prec)
+void SetPrecision(SampCont<complex_mp> & samples, unsigned prec)
 {
 	for (auto& s : samples)
 		for (unsigned ii=0; ii<s.size(); ii++)
@@ -59,7 +59,7 @@ void SetPrecision(SampCont<mpfr_complex> & samples, unsigned prec)
 \param prec The new precision the times should have.
 */
 inline
-void SetPrecision(TimeCont<mpfr_complex> & times, unsigned prec)
+void SetPrecision(TimeCont<complex_mp> & times, unsigned prec)
 {
 	for (auto& t : times)
 		t.precision(prec);
@@ -74,7 +74,7 @@ This is computed based on the first coordinate.  Length-zero samples will cause 
 \return The maximum precision among those samples.
 */
 inline
-unsigned MaxPrecision(SampCont<mpfr_complex> const& samples)
+unsigned MaxPrecision(SampCont<complex_mp> const& samples)
 {
 	unsigned max_precision = 0;
 	for (const auto& s : samples)
@@ -90,7 +90,7 @@ unsigned MaxPrecision(SampCont<mpfr_complex> const& samples)
 \return The maximum precision among those times.
 */
 inline
-unsigned MaxPrecision(TimeCont<mpfr_complex> const& times)
+unsigned MaxPrecision(TimeCont<complex_mp> const& times)
 {
 	unsigned max_precision = 0;
 	for (const auto& t : times)
@@ -111,14 +111,14 @@ Cannot change precision of fixed precision hardware doubles.  This function is p
 \return The precision, which is now uniform.
 */
 inline
-unsigned EnsureAtUniformPrecision(TimeCont<dbl> & /*times*/, SampCont<dbl> & /*samples*/)
+unsigned EnsureAtUniformPrecision(TimeCont<complex_dbl> & /*times*/, SampCont<complex_dbl> & /*samples*/)
 {
 	return DoublePrecision();
 }
 
 
 /**
-\brief Changes precision of mpfr_complex to highest needed precision for the samples.
+\brief Changes precision of complex_mp to highest needed precision for the samples.
 
 \param times Some times \f$\in \mathbb{C}\f$.
 \param samples Some space samples \f$\in \mathbb{C}^n\f$.
@@ -126,7 +126,7 @@ unsigned EnsureAtUniformPrecision(TimeCont<dbl> & /*times*/, SampCont<dbl> & /*s
 \return The precision, which is now uniform.
 */
 inline
-unsigned EnsureAtUniformPrecision(TimeCont<mpfr_complex> & times, SampCont<mpfr_complex> & samples)
+unsigned EnsureAtUniformPrecision(TimeCont<complex_mp> & times, SampCont<complex_mp> & samples)
 {
 	auto def_prec = ThreadPrecision();
 	if (std::any_of(begin(times),end(times),[=](auto const& p){return Precision(p)!=def_prec;}) 
@@ -146,7 +146,7 @@ unsigned EnsureAtUniformPrecision(TimeCont<mpfr_complex> & times, SampCont<mpfr_
 
 
 /**
-\brief Changes precision of mpfr_complex to highest needed precision for the samples.
+\brief Changes precision of complex_mp to highest needed precision for the samples.
 
 This function does NOT do any refinement, it merely changes the precision of default, and of the input objects.
 
@@ -157,7 +157,7 @@ This function does NOT do any refinement, it merely changes the precision of def
 \return The precision changed to.
 */
 inline
-unsigned EnsureAtUniformPrecision(TimeCont<mpfr_complex> & times, SampCont<mpfr_complex> & samples, SampCont<mpfr_complex> & derivatives)
+unsigned EnsureAtUniformPrecision(TimeCont<complex_mp> & times, SampCont<complex_mp> & samples, SampCont<complex_mp> & derivatives)
 {
 	auto def_prec = ThreadPrecision();
 	if (std::any_of(begin(samples),end(samples),[=](auto const& p){return Precision(p)!=def_prec;}) 

--- a/core/include/bertini2/trackers/amp_tracker.hpp
+++ b/core/include/bertini2/trackers/amp_tracker.hpp
@@ -65,11 +65,11 @@ namespace bertini{
 		\todo This function has a hardcoded value which should be replaced
 		*/
 		inline
-		mpfr_float MinTimeForCurrentPrecision(unsigned precision, mpfr_float const& time_to_go, int safety_digits = 3)
+		real_mp MinTimeForCurrentPrecision(unsigned precision, real_mp const& time_to_go, int safety_digits = 3)
 		{
-			mpfr_float t = pow( mpfr_float(10), safety_digits-long(precision)) * time_to_go;
+			real_mp t = pow( real_mp(10), safety_digits-long(precision)) * time_to_go;
 			if (precision==DoublePrecision() && t<1e-150)
-				return mpfr_float("1e-150");
+				return real_mp("1e-150");
 			else
 				return t;
 		}
@@ -84,7 +84,7 @@ namespace bertini{
 		\return The smallest permissible stepsize
 		*/
 		inline
-		mpfr_float MinStepSizeForPrecision(unsigned precision, mpfr_float const& time_to_go, int safety_digits = 3)
+		real_mp MinStepSizeForPrecision(unsigned precision, real_mp const& time_to_go, int safety_digits = 3)
 		{
 			return MinTimeForCurrentPrecision(precision, time_to_go, safety_digits);
 		}
@@ -101,7 +101,7 @@ namespace bertini{
 
 		 Calibrated by benchmarking three operations representative of path tracking
 		 (dot product / SLP evaluation, dense matvec, LU factorization+solve) using
-		 GNU MPC (\c mpfr_complex) vs \c std::complex<double> on modern hardware.
+		 GNU MPC (\c complex_mp) vs \c std::complex<double> on modern hardware.
 		 See \c tuning/arithmetic_cost.cpp for the methodology and compile instructions.
 
 		 The paper \cite AMP2 reports \f$C(P) = 10.35 + 0.04 P_\mathrm{bits}\f$ (measured on
@@ -157,7 +157,7 @@ namespace bertini{
 		\return An integral number of necessary digits to use
 		*/
 		inline
-		unsigned MinDigitsForLogOfStepsize(mpfr_float const& log_of_stepsize, mpfr_float const& time_to_go, unsigned safety_digits = 3)
+		unsigned MinDigitsForLogOfStepsize(real_mp const& log_of_stepsize, real_mp const& time_to_go, unsigned safety_digits = 3)
 		{
 			return (ceil(log_of_stepsize) + ceil(log10(abs(time_to_go))) + safety_digits).convert_to<unsigned>();
 		}
@@ -173,7 +173,7 @@ namespace bertini{
 		This function assumes you are going to time=0, or that you have taken care of that difference.  That is, time_to_go should be a duration, not the current time, unless you are tracking to t=0, in which case current time is the duration left to go.  Dig it?
 		*/
 		inline
-		unsigned MinDigitsForStepsizeInterval(mpfr_float const& min_stepsize, mpfr_float const& max_stepsize, mpfr_float const& time_to_go)
+		unsigned MinDigitsForStepsizeInterval(real_mp const& min_stepsize, real_mp const& max_stepsize, real_mp const& time_to_go)
 		{
 			return max(MinDigitsForLogOfStepsize(-log10(min_stepsize),time_to_go),
 				       MinDigitsForLogOfStepsize(-log10(max_stepsize),time_to_go));
@@ -376,22 +376,22 @@ namespace bertini{
 
 		// 3. Get the settings into the tracker 
 		tracker.Setup(Predictor::Euler,
-		              	mpfr_float("1e-5"),
-						mpfr_float("1e5"),
+		              	real_mp("1e-5"),
+						real_mp("1e5"),
 						stepping_preferences,
 						newton_preferences);
 
 		tracker.PrecisionSetup(AMP);
 	
 		//  4. Create a start and end time.  These are complex numbers.
-		mpfr_complex t_start("1.0");
-		mpfr_complex t_end("0");
+		complex_mp t_start("1.0");
+		complex_mp t_end("0");
 		
 		//  5. Create a start point, and container for the end point.
-		Vec<mpfr_complex> start_point(2);
-		start_point << mpfr_complex("1"), mpfr_complex("1.414");  // set the value of the start point.  This is Eigen syntax.
+		Vec<complex_mp> start_point(2);
+		start_point << complex_mp("1"), complex_mp("1.414");  // set the value of the start point.  This is Eigen syntax.
 
-		Vec<mpfr_complex> end_point;
+		Vec<complex_mp> end_point;
 
 		// 6. actually do the tracking
 		SuccessCode tracking_success = tracker.TrackPath(end_point,
@@ -473,20 +473,20 @@ namespace bertini{
 			virtual ~AMPTracker() = default;
 
 
-			Vec<mpfr_complex> CurrentPoint() const override
+			Vec<complex_mp> CurrentPoint() const override
 			{
 				if (this->CurrentPrecision()==DoublePrecision())
 				{
-					const auto& curr_vector = std::get<Vec<dbl>>(this->current_space_);
-					Vec<mpfr_complex> returnme(NumVariables());
+					const auto& curr_vector = std::get<Vec<complex_dbl>>(this->current_space_);
+					Vec<complex_mp> returnme(NumVariables());
 					for (unsigned ii = 0; ii < NumVariables(); ++ii)
 					{
-						returnme(ii) = mpfr_complex(curr_vector(ii));
+						returnme(ii) = complex_mp(curr_vector(ii));
 					}
 					return returnme;
 				}
 				else
-					return std::get<Vec<mpfr_complex>>(this->current_space_);
+					return std::get<Vec<complex_mp>>(this->current_space_);
 			}
 
 			
@@ -502,9 +502,9 @@ namespace bertini{
 			\param end_time The time to which to track.
 			\param start_point The space values from which to start tracking.
 			*/
-			SuccessCode TrackerLoopInitialization(mpfr_complex const& start_time,
-			                               mpfr_complex const& end_time,
-										   Vec<mpfr_complex> const& start_point) const override
+			SuccessCode TrackerLoopInitialization(complex_mp const& start_time,
+			                               complex_mp const& end_time,
+										   Vec<complex_mp> const& start_point) const override
 			{
 				initial_precision_ = override_start_precision_.value_or(Precision(start_point(0)));
 
@@ -517,7 +517,7 @@ namespace bertini{
 				         );
 				#endif
 
-				NotifyObservers(Initializing<AMPTracker,mpfr_complex>(*this,start_time, end_time, start_point));
+				NotifyObservers(Initializing<AMPTracker,complex_mp>(*this,start_time, end_time, start_point));
 				SetThreadPrecision(initial_precision_);
 				// set up the master current time and the current step size
 				
@@ -534,8 +534,8 @@ namespace bertini{
 				current_stepsize_.precision(initial_precision_);
 				if (reinitialize_stepsize_)
 				{
-					mpfr_float segment_length = abs(start_time-end_time)/Get<Stepping>().min_num_steps;
-					SetStepSize(min(mpfr_float(Get<Stepping>().initial_step_size, current_precision_),segment_length));
+					real_mp segment_length = abs(start_time-end_time)/Get<Stepping>().min_num_steps;
+					SetStepSize(min(real_mp(Get<Stepping>().initial_step_size, current_precision_),segment_length));
 				}
 
 				// populate the current space value with the start point, in appropriate precision
@@ -552,10 +552,10 @@ namespace bertini{
 
 				#ifndef BERTINI_DISABLE_ASSERTS
 				if (initial_precision_==DoublePrecision()){
-					PrecisionSanityCheck<dbl>();
+					PrecisionSanityCheck<complex_dbl>();
 				}
 				else{
-					PrecisionSanityCheck<mpfr_complex>();
+					PrecisionSanityCheck<complex_mp>();
 				}
 				#endif
 
@@ -643,7 +643,7 @@ namespace bertini{
 
 			\param[out] solution_at_endtime The solution at the end time
 			*/
-			void CopyFinalSolution(Vec<mpfr_complex> & solution_at_endtime) const override
+			void CopyFinalSolution(Vec<complex_mp> & solution_at_endtime) const override
 			{
 
 				// the current precision is the precision of the output solution point.
@@ -652,7 +652,7 @@ namespace bertini{
 					unsigned num_vars = static_cast<unsigned>(GetSystem().NumVariables());
 					solution_at_endtime.resize(num_vars);
 					for (unsigned ii=0; ii<num_vars; ii++)
-						solution_at_endtime(ii) = mpfr_complex(std::get<Vec<dbl> >(current_space_)(ii));
+						solution_at_endtime(ii) = complex_mp(std::get<Vec<complex_dbl> >(current_space_)(ii));
 				}
 				else
 				{
@@ -660,7 +660,7 @@ namespace bertini{
 					solution_at_endtime.resize(num_vars);
 					for (unsigned ii=0; ii<num_vars; ii++)
 					{
-						solution_at_endtime(ii) = std::get<Vec<mpfr_complex> >(current_space_)(ii);
+						solution_at_endtime(ii) = std::get<Vec<complex_mp> >(current_space_)(ii);
 						solution_at_endtime(ii).precision(current_precision_);
 					}
 				}
@@ -679,9 +679,9 @@ namespace bertini{
 			SuccessCode TrackerIteration() const override
 			{
 				if (current_precision_==DoublePrecision())
-					return TrackerIteration<dbl>();
+					return TrackerIteration<complex_dbl>();
 				else
-					return TrackerIteration<mpfr_complex>();
+					return TrackerIteration<complex_mp>();
 			}
 
 
@@ -784,9 +784,9 @@ namespace bertini{
 			SuccessCode CheckGoingToInfinity() const override
 			{
 				if (current_precision_ == DoublePrecision())
-					return Base::CheckGoingToInfinity<dbl>();
+					return Base::CheckGoingToInfinity<complex_dbl>();
 				else
-					return Base::CheckGoingToInfinity<mpfr_complex>();
+					return Base::CheckGoingToInfinity<complex_mp>();
 			}
 
 			/**
@@ -858,8 +858,8 @@ namespace bertini{
 				//      (ExtraDigitsBeforePrecisionDecrease).  The single StepsForIncrease setting
 				//      (SteppingConfig::consecutive_successful_steps_before_stepsize_increase) governs both
 				//      gates -- the old, duplicate AMP-config precision-decrease setting was removed.
-				mpfr_float min_stepsize = current_stepsize_ * mpfr_float(Get<Stepping>().step_size_fail_factor, current_precision_);
-				mpfr_float max_stepsize = min( current_stepsize_ * mpfr_float(Get<Stepping>().step_size_success_factor, current_precision_),  mpfr_float(Get<Stepping>().max_step_size, current_precision_));
+				real_mp min_stepsize = current_stepsize_ * real_mp(Get<Stepping>().step_size_fail_factor, current_precision_);
+				real_mp max_stepsize = min( current_stepsize_ * real_mp(Get<Stepping>().step_size_success_factor, current_precision_),  real_mp(Get<Stepping>().max_step_size, current_precision_));
 
 				const unsigned steps_for_increase = Get<Stepping>().consecutive_successful_steps_before_stepsize_increase; // B1 StepsForIncrease
 
@@ -954,7 +954,7 @@ namespace bertini{
 			{
 				next_precision_ = current_precision_;
 
-				next_stepsize_ = mpfr_float(Get<Stepping>().step_size_fail_factor, CurrentPrecision())*current_stepsize_;
+				next_stepsize_ = real_mp(Get<Stepping>().step_size_fail_factor, CurrentPrecision())*current_stepsize_;
 				while (next_stepsize_ < MinStepSizeForPrecision(next_precision_, abs(current_time_ - endtime_)))
 				{
 					if (next_precision_==DoublePrecision())
@@ -992,15 +992,15 @@ namespace bertini{
 					min_next_precision = current_precision_ + (1+num_consecutive_failed_steps_)*PrecisionIncrement(); // precision increases
 
 
-				mpfr_float min_stepsize = MinStepSizeForPrecision(current_precision_, abs(current_time_ - endtime_));
-				mpfr_float max_stepsize = current_stepsize_ * mpfr_float(Get<Stepping>().step_size_fail_factor, current_precision_);  // Stepsize decreases.
+				real_mp min_stepsize = MinStepSizeForPrecision(current_precision_, abs(current_time_ - endtime_));
+				real_mp max_stepsize = current_stepsize_ * real_mp(Get<Stepping>().step_size_fail_factor, current_precision_);  // Stepsize decreases.
 
 				if (min_stepsize > max_stepsize)
 				{
 					// stepsizes are incompatible, must increase precision
 					next_precision_ = min_next_precision;
 					// decrease stepsize somewhat less than the fail factor
-					next_stepsize_ = max(current_stepsize_ * (1+mpfr_float(Get<Stepping>().step_size_fail_factor, current_precision_))/2, min_stepsize);
+					next_stepsize_ = max(current_stepsize_ * (1+real_mp(Get<Stepping>().step_size_fail_factor, current_precision_))/2, min_stepsize);
 				}
 				else
 				{
@@ -1291,15 +1291,15 @@ namespace bertini{
 				SuccessCode code;
 				if (current_precision_==DoublePrecision())
 				{
-					code = RefineImpl<dbl>(std::get<Vec<dbl> >(temporary_space_),std::get<Vec<dbl> >(current_space_), dbl(current_time_));
+					code = RefineImpl<complex_dbl>(std::get<Vec<complex_dbl> >(temporary_space_),std::get<Vec<complex_dbl> >(current_space_), complex_dbl(current_time_));
 					if (code == SuccessCode::Success)
-						std::get<Vec<dbl> >(current_space_) = std::get<Vec<dbl> >(temporary_space_);
+						std::get<Vec<complex_dbl> >(current_space_) = std::get<Vec<complex_dbl> >(temporary_space_);
 				}
 				else
 				{
-					code = RefineImpl<mpfr_complex>(std::get<Vec<mpfr_complex> >(temporary_space_),std::get<Vec<mpfr_complex> >(current_space_), current_time_);
+					code = RefineImpl<complex_mp>(std::get<Vec<complex_mp> >(temporary_space_),std::get<Vec<complex_mp> >(current_space_), current_time_);
 					if (code == SuccessCode::Success)
-						std::get<Vec<mpfr_complex> >(current_space_) = std::get<Vec<mpfr_complex> >(temporary_space_);
+						std::get<Vec<complex_mp> >(current_space_) = std::get<Vec<complex_mp> >(temporary_space_);
 				}
 				return code;
 			}
@@ -1448,14 +1448,14 @@ namespace bertini{
 					// convert from double to multiple precision
 					DoubleToMultiple(new_precision);
 					#ifndef BERTINI_DISABLE_ASSERTS
-					assert(PrecisionSanityCheck<mpfr_complex>() && "precision sanity check failed.  some internal variable is not in correct precision");
+					assert(PrecisionSanityCheck<complex_mp>() && "precision sanity check failed.  some internal variable is not in correct precision");
 					#endif
 				}
 				else
 				{
 					MultipleToMultiple(new_precision);
 					#ifndef BERTINI_DISABLE_ASSERTS
-					assert(PrecisionSanityCheck<mpfr_complex>() && "precision sanity check failed.  some internal variable is not in correct precision");
+					assert(PrecisionSanityCheck<complex_mp>() && "precision sanity check failed.  some internal variable is not in correct precision");
 					#endif
 				}
 
@@ -1478,7 +1478,7 @@ namespace bertini{
 
 			\param source_point The point into which to copy to the internally stored current space point.
 			*/
-			void DoubleToDouble(Vec<dbl> const& source_point) const
+			void DoubleToDouble(Vec<complex_dbl> const& source_point) const
 			{	
 				#ifndef BERTINI_DISABLE_ASSERTS
 				assert(source_point.size() == GetSystem().NumVariables() && "source point for converting to multiple precision is not the same size as the number of variables in the system being solved.");
@@ -1489,7 +1489,7 @@ namespace bertini{
 
 				GetSystem().precision(16);
 
-				std::get<Vec<dbl> >(current_space_) = source_point;
+				std::get<Vec<complex_dbl> >(current_space_) = source_point;
 			}
 
 			/**
@@ -1499,7 +1499,7 @@ namespace bertini{
 			*/
 			void DoubleToDouble() const
 			{
-				DoubleToDouble(std::get<Vec<dbl> >(current_space_));
+				DoubleToDouble(std::get<Vec<complex_dbl> >(current_space_));
 			}
 			
 
@@ -1511,7 +1511,7 @@ namespace bertini{
 
 			\param source_point The point into which to copy to the internally stored current space point.
 			*/
-			void MultipleToDouble(Vec<mpfr_complex> const& source_point) const
+			void MultipleToDouble(Vec<complex_mp> const& source_point) const
 			{	
 				#ifndef BERTINI_DISABLE_ASSERTS
 				assert(source_point.size() == GetSystem().NumVariables() && "source point for converting to multiple precision is not the same size as the number of variables in the system being solved.");
@@ -1522,11 +1522,11 @@ namespace bertini{
 				GetSystem().precision(DoublePrecision()); 
 
 				// copy the current space in.
-				if (std::get<Vec<dbl> >(current_space_).size()!=source_point.size())
-					std::get<Vec<dbl> >(current_space_).resize(source_point.size());
+				if (std::get<Vec<complex_dbl> >(current_space_).size()!=source_point.size())
+					std::get<Vec<complex_dbl> >(current_space_).resize(source_point.size());
 
 				for (unsigned ii=0; ii<source_point.size(); ii++)
-					std::get<Vec<dbl> >(current_space_)(ii) = dbl(source_point(ii));
+					std::get<Vec<complex_dbl> >(current_space_)(ii) = complex_dbl(source_point(ii));
 
 				endtime_.precision(DoublePrecision()); // i question this one  2021-04-12
 			}
@@ -1538,7 +1538,7 @@ namespace bertini{
 			*/
 			void MultipleToDouble() const
 			{
-				MultipleToDouble(std::get<Vec<mpfr_complex> >(current_space_));
+				MultipleToDouble(std::get<Vec<complex_mp> >(current_space_));
 			}
 
 
@@ -1553,7 +1553,7 @@ namespace bertini{
 			\param new_precision The new precision.
 			\param source_point The point into which to copy to the internally stored current space point.
 			*/
-			void DoubleToMultiple(unsigned new_precision, Vec<dbl> const& source_point) const
+			void DoubleToMultiple(unsigned new_precision, Vec<complex_dbl> const& source_point) const
 			{	
 				#ifndef BERTINI_DISABLE_ASSERTS
 				assert(source_point.size() == GetSystem().NumVariables() && "source point for converting to multiple precision is not the same size as the number of variables in the system being solved.");
@@ -1566,7 +1566,7 @@ namespace bertini{
 				AdjustTemporariesPrecision(new_precision);
 
 				#ifndef BERTINI_DISABLE_ASSERTS
-				PrecisionSanityCheck<mpfr_complex>();
+				PrecisionSanityCheck<complex_mp>();
 				#endif
 			}
 
@@ -1581,7 +1581,7 @@ namespace bertini{
 			*/
 			void DoubleToMultiple(unsigned new_precision) const
 			{
-				DoubleToMultiple( new_precision, std::get<Vec<dbl> >(current_space_));
+				DoubleToMultiple( new_precision, std::get<Vec<complex_dbl> >(current_space_));
 			}
 
 
@@ -1597,7 +1597,7 @@ namespace bertini{
 			\param new_precision The new precision.
 			\param source_point The point into which to copy to the internally stored current space point.
 			*/
-			void MultipleToMultiple(unsigned new_precision, Vec<mpfr_complex> const& source_point) const
+			void MultipleToMultiple(unsigned new_precision, Vec<complex_mp> const& source_point) const
 			{	
 				#ifndef BERTINI_DISABLE_ASSERTS
 				assert(source_point.size() == GetSystem().NumVariables() && "source point for converting to multiple precision is not the same size as the number of variables in the system being solved.");
@@ -1610,7 +1610,7 @@ namespace bertini{
 				AdjustTemporariesPrecision(new_precision);
 
 				#ifndef BERTINI_DISABLE_ASSERTS
-				PrecisionSanityCheck<mpfr_complex>();
+				PrecisionSanityCheck<complex_mp>();
 				#endif
 			}
 
@@ -1624,7 +1624,7 @@ namespace bertini{
 			*/
 			void MultipleToMultiple(unsigned new_precision) const
 			{
-				MultipleToMultiple( new_precision, std::get<Vec<mpfr_complex> >(current_space_));
+				MultipleToMultiple( new_precision, std::get<Vec<complex_mp> >(current_space_));
 			}
 
 
@@ -1639,18 +1639,18 @@ namespace bertini{
 			}
 
 			
-			void CopyToCurrentSpace(Vec<dbl> const& source_point) const
+			void CopyToCurrentSpace(Vec<complex_dbl> const& source_point) const
 			{
-				auto& space = std::get<Vec<mpfr_complex> >(current_space_);
+				auto& space = std::get<Vec<complex_mp> >(current_space_);
 				if (space.size()!=source_point.size())
 					space.resize(source_point.size());
 				for (unsigned ii=0; ii<source_point.size(); ii++)
-					space(ii) = mpfr_complex(source_point(ii));
+					space(ii) = complex_mp(source_point(ii));
 			}
 
-			void CopyToCurrentSpace(Vec<mpfr_complex> const& source_point) const
+			void CopyToCurrentSpace(Vec<complex_mp> const& source_point) const
 			{
-				auto& space = std::get<Vec<mpfr_complex> >(current_space_);
+				auto& space = std::get<Vec<complex_mp> >(current_space_);
 				if (space.size()!=source_point.size())
 					space.resize(source_point.size());
 				space = source_point;
@@ -1669,7 +1669,7 @@ namespace bertini{
 				delta_t_.precision(new_precision);
 				current_time_.precision(new_precision);
 
-				Precision(std::get<Vec<mpfr_complex> >(current_space_),new_precision);
+				Precision(std::get<Vec<complex_mp> >(current_space_),new_precision);
 			}
 
 			/**
@@ -1684,11 +1684,11 @@ namespace bertini{
 				const auto num_vars = GetSystem().NumVariables();
 
 				//  the current_space value is adjusted in the appropriate ChangePrecision function
-				std::get<Vec<mpfr_complex> >(tentative_space_).resize(static_cast<Eigen::Index>(num_vars));
-				Precision(std::get<Vec<mpfr_complex> >(tentative_space_), new_precision);
+				std::get<Vec<complex_mp> >(tentative_space_).resize(static_cast<Eigen::Index>(num_vars));
+				Precision(std::get<Vec<complex_mp> >(tentative_space_), new_precision);
 
-				std::get<Vec<mpfr_complex> >(temporary_space_).resize(static_cast<Eigen::Index>(num_vars));
-				Precision(std::get<Vec<mpfr_complex> >(temporary_space_), new_precision);
+				std::get<Vec<complex_mp> >(temporary_space_).resize(static_cast<Eigen::Index>(num_vars));
+				Precision(std::get<Vec<complex_mp> >(temporary_space_), new_precision);
 			}
 
 
@@ -1703,17 +1703,17 @@ namespace bertini{
 			bool PrecisionSanityCheck() const
 			{	
 
-				if constexpr (std::is_same<ComplexT, dbl>::value){
+				if constexpr (std::is_same<ComplexT, complex_dbl>::value){
 					return true;
 				}
 
-				if constexpr (std::is_same<ComplexT, mpfr_complex>::value){
+				if constexpr (std::is_same<ComplexT, complex_mp>::value){
 					assert(ThreadPrecision()==current_precision_ && "current precision differs from the thread-local default precision");
 					assert(GetSystem().precision() == current_precision_ && "tracked system is out of precision");
 					
-					assert(std::get<Vec<mpfr_complex> >(current_space_)(0).precision() == current_precision_ && "current space out of precision");
-					assert(std::get<Vec<mpfr_complex> >(tentative_space_)(0).precision() == current_precision_ && "tentative space out of precision");
-					assert(std::get<Vec<mpfr_complex> >(temporary_space_)(0).precision() == current_precision_ && "temporary space out of precision");
+					assert(std::get<Vec<complex_mp> >(current_space_)(0).precision() == current_precision_ && "current space out of precision");
+					assert(std::get<Vec<complex_mp> >(tentative_space_)(0).precision() == current_precision_ && "tentative space out of precision");
+					assert(std::get<Vec<complex_mp> >(temporary_space_)(0).precision() == current_precision_ && "temporary space out of precision");
 					assert(Precision(current_stepsize_) == current_precision_ && "current_stepsize_ out of precision");
 					assert(Precision(delta_t_) == current_precision_ && "delta_t_ out of precision");
 					assert(Precision(endtime_) == current_precision_ && "endtime_ out of precision");
@@ -1753,7 +1753,7 @@ namespace bertini{
 			mutable unsigned initial_precision_; ///< The precision at the start of tracking.
 			mutable unsigned num_successful_steps_since_precision_decrease_; ///< Consecutive successful steps since precision last decreased; gated by B1's StepsForIncrease.
 
-			mutable mpfr_complex endtime_highest_precision_;
+			mutable complex_mp endtime_highest_precision_;
 
 		public:
 

--- a/core/include/bertini2/trackers/base_predictor.hpp
+++ b/core/include/bertini2/trackers/base_predictor.hpp
@@ -461,8 +461,8 @@ namespace bertini{
 				
 				Predictor predictor_;
 				unsigned p_;
-				std::tuple< Mat<dbl>, Mat<mpfr> > dh_dx_;
-				std::tuple< Eigen::PartialPivLU<Mat<dbl>>, Eigen::PartialPivLU<Mat<mpfr>> > LU_;
+				std::tuple< Mat<complex_dbl>, Mat<mpfr> > dh_dx_;
+				std::tuple< Eigen::PartialPivLU<Mat<complex_dbl>>, Eigen::PartialPivLU<Mat<mpfr>> > LU_;
 				
 
 				

--- a/core/include/bertini2/trackers/base_tracker.hpp
+++ b/core/include/bertini2/trackers/base_tracker.hpp
@@ -263,7 +263,7 @@ namespace bertini{
 
 				NotifyObservers(TrackingStarted<typename TrackerTraits<D>::EventEmitterType>(static_cast<typename TrackerTraits<D>::EventEmitterType const&>(*this)));
 
-				// as precondition to this while loop, the correct container, either dbl or mpfr, must have the correct data.
+				// as precondition to this while loop, the correct container, either complex_dbl or mpfr, must have the correct data.
 				while (!IsSymmRelDiffSmall(current_time_,endtime_, Eigen::NumTraits<ComplexT>::epsilon()))
 				{
 					SuccessCode pre_iteration_code = PreIterationCheck();
@@ -478,7 +478,7 @@ namespace bertini{
 			void CopyFinalSolution(Vec<ComplexT> & solution_at_endtime) const = 0;
 
 			// virtual
-			// void CopyFinalSolution(Vec<dbl> & solution_at_endtime) const = 0;
+			// void CopyFinalSolution(Vec<complex_dbl> & solution_at_endtime) const = 0;
 
 
 		protected:

--- a/core/include/bertini2/trackers/config.hpp
+++ b/core/include/bertini2/trackers/config.hpp
@@ -76,7 +76,7 @@ namespace tracking{
 	struct SteppingConfig
 	{
 		// mpq_rational: exact rationals with no MPFR precision state — safe in DefaultConstruct<T>::value statics.
-		// mpfr_float fields here would be initialized at BMP's startup precision (20) and contaminate
+		// real_mp fields here would be initialized at BMP's startup precision (20) and contaminate
 		// tracker arithmetic when target precision < 20 via preserve_related_precision.
 		mpq_rational initial_step_size{1, 10}; ///< The length of the first time step when calling TrackPath.  StepInitSize
 		mpq_rational max_step_size{1, 10};     ///<  The largest allowed step size.  MaxStepSize
@@ -207,7 +207,7 @@ namespace tracking{
 
 			epsilon = pow(NumErrorT(sys.NumVariables()),2);
 			degree_bound = sys.DegreeBound();
-			coefficient_bound = sys.CoefficientBound<dbl>();
+			coefficient_bound = sys.CoefficientBound<complex_dbl>();
 		}
 		
 
@@ -292,7 +292,7 @@ namespace tracking{
 	template<>
 	struct TrackerTraits<DoublePrecisionTracker>
 	{
-		using BaseComplexT = dbl;
+		using BaseComplexT = complex_dbl;
 		using BaseRealT = double;
 		using EventEmitterType = FixedPrecisionTracker<DoublePrecisionTracker>;
 		using PrecisionConfig = FixedPrecisionConfig;
@@ -301,7 +301,7 @@ namespace tracking{
 			IsAdaptivePrec = 0
 		};
 
-		using NeededTypes = detail::TypeList<dbl>;
+		using NeededTypes = detail::TypeList<complex_dbl>;
 		using NeededConfigs = detail::TypeList<
 			SteppingConfig, 
 			NewtonConfig,
@@ -313,8 +313,8 @@ namespace tracking{
 	template<>
 	struct TrackerTraits<MultiplePrecisionTracker>
 	{
-		using BaseComplexT = mpfr_complex;
-		using BaseRealT = mpfr_float;
+		using BaseComplexT = complex_mp;
+		using BaseRealT = real_mp;
 		using EventEmitterType = FixedPrecisionTracker<MultiplePrecisionTracker>;
 		using PrecisionConfig = FixedPrecisionConfig;
 
@@ -323,7 +323,7 @@ namespace tracking{
 			IsAdaptivePrec = 0
 		};
 
-		using NeededTypes = detail::TypeList<mpfr_complex>;
+		using NeededTypes = detail::TypeList<complex_mp>;
 
 		using NeededConfigs = detail::TypeList<
 			SteppingConfig, 
@@ -337,8 +337,8 @@ namespace tracking{
 	template<>
 	struct TrackerTraits<AMPTracker>
 	{
-		using BaseComplexT = mpfr_complex;
-		using BaseRealT = mpfr_float;
+		using BaseComplexT = complex_mp;
+		using BaseRealT = real_mp;
 		using EventEmitterType = AMPTracker;
 		using PrecisionConfig = AdaptiveMultiplePrecisionConfig;
 
@@ -347,7 +347,7 @@ namespace tracking{
 			IsAdaptivePrec = 1
 		};
 
-		using NeededTypes = detail::TypeList<dbl, mpfr_complex>;
+		using NeededTypes = detail::TypeList<complex_dbl, complex_mp>;
 
 		using NeededConfigs = detail::TypeList<
 			SteppingConfig, 

--- a/core/include/bertini2/trackers/explicit_predictors.hpp
+++ b/core/include/bertini2/trackers/explicit_predictors.hpp
@@ -223,9 +223,9 @@ namespace bertini{
 							crefd.resize(s_); crefd(0) = 0;
 							arefd.resize(s_,s_); arefd(0,0) = 0;
 							brefd.resize(s_); brefd(0) = 0;
-							Mat<mpfr_float>& arefmp = std::get< Mat<mpfr_float> >(a_);
-							Vec<mpfr_float>& brefmp = std::get< Vec<mpfr_float> >(b_);
-							Vec<mpfr_float>& crefmp = std::get< Vec<mpfr_float> >(c_);
+							Mat<real_mp>& arefmp = std::get< Mat<real_mp> >(a_);
+							Vec<real_mp>& brefmp = std::get< Vec<real_mp> >(b_);
+							Vec<real_mp>& crefmp = std::get< Vec<real_mp> >(c_);
 							crefmp.resize(s_); crefmp(0) = 0;
 							arefmp.resize(s_,s_); arefmp(0,0) = 0;
 							brefmp.resize(s_); brefmp(0) = 0;
@@ -242,12 +242,12 @@ namespace bertini{
 							crefd.resize(s_); crefd(0) = static_cast<double>(cEuler_(0));
 							arefd.resize(s_,s_); arefd(0,0) = static_cast<double>(aEuler_(0,0));
 							brefd.resize(s_); brefd(0) = static_cast<double>(bEuler_(0));
-							Mat<mpfr_float>& arefmp = std::get< Mat<mpfr_float> >(a_);
-							Vec<mpfr_float>& brefmp = std::get< Vec<mpfr_float> >(b_);
-							Vec<mpfr_float>& crefmp = std::get< Vec<mpfr_float> >(c_);
-							crefmp.resize(s_); crefmp(0) = static_cast<mpfr_float>(cEuler_(0));
-							arefmp.resize(s_,s_); arefmp(0,0) = static_cast<mpfr_float>(aEuler_(0,0));
-							brefmp.resize(s_); brefmp(0) = static_cast<mpfr_float>(bEuler_(0));
+							Mat<real_mp>& arefmp = std::get< Mat<real_mp> >(a_);
+							Vec<real_mp>& brefmp = std::get< Vec<real_mp> >(b_);
+							Vec<real_mp>& crefmp = std::get< Vec<real_mp> >(c_);
+							crefmp.resize(s_); crefmp(0) = static_cast<real_mp>(cEuler_(0));
+							arefmp.resize(s_,s_); arefmp(0,0) = static_cast<real_mp>(aEuler_(0,0));
+							brefmp.resize(s_); brefmp(0) = static_cast<real_mp>(bEuler_(0));
 							uses_embedded_ = false;
 							break;
 						}
@@ -256,7 +256,7 @@ namespace bertini{
 							s_ = 2;
 							
 							FillButcherTable<double>(static_cast<int>(s_),aHeunEuler_, bHeunEuler_, b_minus_bstarHeunEuler_, cHeunEuler_);
-							FillButcherTable<mpfr_float>(static_cast<int>(s_),aHeunEuler_, bHeunEuler_, b_minus_bstarHeunEuler_, cHeunEuler_);
+							FillButcherTable<real_mp>(static_cast<int>(s_),aHeunEuler_, bHeunEuler_, b_minus_bstarHeunEuler_, cHeunEuler_);
 							
 							break;
 						}
@@ -265,7 +265,7 @@ namespace bertini{
 							s_ = 4;
 							
 							FillButcherTable<double>(static_cast<int>(s_),aRK4_, bRK4_, cRK4_);
-							FillButcherTable<mpfr_float>(static_cast<int>(s_),aRK4_, bRK4_, cRK4_);
+							FillButcherTable<real_mp>(static_cast<int>(s_),aRK4_, bRK4_, cRK4_);
 							
 							break;
 						}
@@ -275,7 +275,7 @@ namespace bertini{
 							s_ = 6;
 							
 							FillButcherTable<double>(static_cast<int>(s_),aRKF45_, bRKF45_, b_minus_bstarRKF45_, cRKF45_);
-							FillButcherTable<mpfr_float>(static_cast<int>(s_),aRKF45_, bRKF45_, b_minus_bstarRKF45_, cRKF45_);
+							FillButcherTable<real_mp>(static_cast<int>(s_),aRKF45_, bRKF45_, b_minus_bstarRKF45_, cRKF45_);
 							
 							break;
 						}
@@ -285,7 +285,7 @@ namespace bertini{
 							s_ = 6;
 							
 							FillButcherTable<double>(static_cast<int>(s_),aRKCK45_, bRKCK45_, b_minus_bstarRKCK45_, cRKCK45_);
-							FillButcherTable<mpfr_float>(static_cast<int>(s_),aRKCK45_, bRKCK45_, b_minus_bstarRKCK45_, cRKCK45_);
+							FillButcherTable<real_mp>(static_cast<int>(s_),aRKCK45_, bRKCK45_, b_minus_bstarRKCK45_, cRKCK45_);
 							
 							break;
 						}
@@ -295,7 +295,7 @@ namespace bertini{
 							s_ = 8;
 							
 							FillButcherTable<double>(static_cast<int>(s_),aRKDP56_, bRKDP56_, b_minus_bstarRKDP56_, cRKDP56_);
-							FillButcherTable<mpfr_float>(static_cast<int>(s_),aRKDP56_, bRKDP56_, b_minus_bstarRKDP56_, cRKDP56_);
+							FillButcherTable<real_mp>(static_cast<int>(s_),aRKDP56_, bRKDP56_, b_minus_bstarRKDP56_, cRKDP56_);
 							
 							break;
 						}
@@ -305,7 +305,7 @@ namespace bertini{
 							s_ = 10;
 							
 							FillButcherTable<double>(static_cast<int>(s_),aRKV67_, bRKV67_, b_minus_bstarRKV67_, cRKV67_);
-							FillButcherTable<mpfr_float>(static_cast<int>(s_),aRKV67_, bRKV67_, b_minus_bstarRKV67_, cRKV67_);
+							FillButcherTable<real_mp>(static_cast<int>(s_),aRKV67_, bRKV67_, b_minus_bstarRKV67_, cRKV67_);
 							
 							break;
 						}
@@ -332,18 +332,18 @@ namespace bertini{
 					numTotalFunctions_ = static_cast<unsigned>(S.NumTotalFunctions());
 					numVariables_ = static_cast<unsigned>(S.NumVariables());
 					// you cannot set K_ here, because s_ may not have been set
-					std::get< Mat<dbl> >(dh_dx_0_).resize(numTotalFunctions_, numVariables_);
-					std::get< Mat<mpfr_complex> >(dh_dx_0_).resize(numTotalFunctions_, numVariables_);
-					std::get< Mat<dbl> >(dh_dx_temp_).resize(numTotalFunctions_, numVariables_);
-					std::get< Mat<mpfr_complex> >(dh_dx_temp_).resize(numTotalFunctions_, numVariables_);
-					std::get< Vec<dbl> >(dh_dt_temp_).resize(numTotalFunctions_);
-					std::get< Vec<mpfr_complex> >(dh_dt_temp_).resize(numTotalFunctions_);
-					std::get< Vec<dbl> >(step_temp_).resize(numTotalFunctions_);
-					std::get< Vec<mpfr_complex> >(step_temp_).resize(numTotalFunctions_);
-					std::get< Vec<dbl> >(rand_temp_) = RandomOfUnits<dbl>(numVariables_);
-					std::get< Vec<mpfr_complex> >(rand_temp_) = RandomOfUnits<mpfr_complex>(numVariables_);
-					std::get< Vec<dbl> >(solve_temp_).resize(numVariables_);
-					std::get< Vec<mpfr_complex> >(solve_temp_).resize(numVariables_);
+					std::get< Mat<complex_dbl> >(dh_dx_0_).resize(numTotalFunctions_, numVariables_);
+					std::get< Mat<complex_mp> >(dh_dx_0_).resize(numTotalFunctions_, numVariables_);
+					std::get< Mat<complex_dbl> >(dh_dx_temp_).resize(numTotalFunctions_, numVariables_);
+					std::get< Mat<complex_mp> >(dh_dx_temp_).resize(numTotalFunctions_, numVariables_);
+					std::get< Vec<complex_dbl> >(dh_dt_temp_).resize(numTotalFunctions_);
+					std::get< Vec<complex_mp> >(dh_dt_temp_).resize(numTotalFunctions_);
+					std::get< Vec<complex_dbl> >(step_temp_).resize(numTotalFunctions_);
+					std::get< Vec<complex_mp> >(step_temp_).resize(numTotalFunctions_);
+					std::get< Vec<complex_dbl> >(rand_temp_) = RandomOfUnits<complex_dbl>(numVariables_);
+					std::get< Vec<complex_mp> >(rand_temp_) = RandomOfUnits<complex_mp>(numVariables_);
+					std::get< Vec<complex_dbl> >(solve_temp_).resize(numVariables_);
+					std::get< Vec<complex_mp> >(solve_temp_).resize(numVariables_);
 
 					ResizeK();
 				}
@@ -351,8 +351,8 @@ namespace bertini{
 				
 				void ResizeK()
 				{
-					std::get< Mat<dbl> >(K_).resize(numTotalFunctions_, s_);
-					std::get< Mat<mpfr_complex> >(K_).resize(numTotalFunctions_, s_);
+					std::get< Mat<complex_dbl> >(K_).resize(numTotalFunctions_, s_);
+					std::get< Mat<complex_mp> >(K_).resize(numTotalFunctions_, s_);
 				}
 				
 				
@@ -372,19 +372,19 @@ namespace bertini{
 				 */
 				void ChangePrecision(unsigned new_precision)
 				{
-					Precision(std::get< Mat<mpfr_complex> >(K_),new_precision);
+					Precision(std::get< Mat<complex_mp> >(K_),new_precision);
 
-					Precision(std::get< Vec<mpfr_complex> >(dh_dt_temp_),new_precision);
-					Precision(std::get< Mat<mpfr_complex> >(dh_dx_0_),new_precision);
-					Precision(std::get< Mat<mpfr_complex> >(dh_dx_temp_),new_precision);
-					Precision(std::get< Vec<mpfr_complex> >(step_temp_),new_precision);
-					Precision(std::get< Vec<mpfr_complex> >(rand_temp_),new_precision);
-					Precision(std::get< Vec<mpfr_complex> >(solve_temp_),new_precision);
+					Precision(std::get< Vec<complex_mp> >(dh_dt_temp_),new_precision);
+					Precision(std::get< Mat<complex_mp> >(dh_dx_0_),new_precision);
+					Precision(std::get< Mat<complex_mp> >(dh_dx_temp_),new_precision);
+					Precision(std::get< Vec<complex_mp> >(step_temp_),new_precision);
+					Precision(std::get< Vec<complex_mp> >(rand_temp_),new_precision);
+					Precision(std::get< Vec<complex_mp> >(solve_temp_),new_precision);
 
-					Precision(std::get< Mat<mpfr_float> >(a_),new_precision);
-					Precision(std::get< Vec<mpfr_float> >(b_),new_precision);
-					Precision(std::get< Vec<mpfr_float> >(b_minus_bstar_),new_precision);
-					Precision(std::get< Vec<mpfr_float> >(c_),new_precision);
+					Precision(std::get< Mat<real_mp> >(a_),new_precision);
+					Precision(std::get< Vec<real_mp> >(b_),new_precision);
+					Precision(std::get< Vec<real_mp> >(b_minus_bstar_),new_precision);
+					Precision(std::get< Vec<real_mp> >(c_),new_precision);
 
 					PredictorMethod(predictor_);
 
@@ -400,14 +400,14 @@ namespace bertini{
 					// where precision is set via SetThreadPrecision (thread-local only).
 					assert(current_precision_==ThreadPrecision());
 
-					Vec<mpfr_complex>& dhdttemp = std::get< Vec<mpfr_complex> >(dh_dt_temp_);
-					Mat<mpfr_complex>& dhdx0 = std::get< Mat<mpfr_complex> >(dh_dx_0_); 
-					Mat<mpfr_complex>& dhdxtemp = std::get< Mat<mpfr_complex> >(dh_dx_temp_); 
+					Vec<complex_mp>& dhdttemp = std::get< Vec<complex_mp> >(dh_dt_temp_);
+					Mat<complex_mp>& dhdx0 = std::get< Mat<complex_mp> >(dh_dx_0_); 
+					Mat<complex_mp>& dhdxtemp = std::get< Mat<complex_mp> >(dh_dx_temp_); 
 
-					Mat<mpfr_float>& a = std::get< Mat<mpfr_float> >(a_); 
-					Vec<mpfr_float>& b = std::get< Vec<mpfr_float> >(b_); 
-					Vec<mpfr_float>& bstar = std::get< Vec<mpfr_float> >(b_minus_bstar_); 
-					Vec<mpfr_float>& c = std::get< Vec<mpfr_float> >(c_);
+					Mat<real_mp>& a = std::get< Mat<real_mp> >(a_); 
+					Vec<real_mp>& b = std::get< Vec<real_mp> >(b_); 
+					Vec<real_mp>& bstar = std::get< Vec<real_mp> >(b_minus_bstar_); 
+					Vec<real_mp>& c = std::get< Vec<real_mp> >(c_);
 
 
 
@@ -827,7 +827,7 @@ namespace bertini{
 				{
 
 
-					if (std::is_same<ComplexT, mpfr_complex>::value)
+					if (std::is_same<ComplexT, complex_mp>::value)
 						PrecisionSanityCheck();
 
 					if(stage == 0)
@@ -835,7 +835,7 @@ namespace bertini{
 						Eigen::PartialPivLU<Mat<ComplexT>>& LUref = std::get< Eigen::PartialPivLU<Mat<ComplexT>> >(LU_);
 						Mat<ComplexT>& dhdxref = std::get< Mat<ComplexT> >(dh_dx_0_);
 
-						if (!std::is_same<ComplexT,dbl>::value)
+						if (!std::is_same<ComplexT,complex_dbl>::value)
 						{
 							assert(ThreadPrecision()==current_precision_);
 
@@ -847,7 +847,7 @@ namespace bertini{
 						S.SetAndReset<ComplexT>(space, time);
 						S.JacobianInPlace(dhdxref);
 						LUref.compute(dhdxref);
-						if (!std::is_same<ComplexT,dbl>::value)
+						if (!std::is_same<ComplexT,complex_dbl>::value)
 						{
 							assert(Precision(dhdxref)==current_precision_);
 							assert(Precision(LUref.matrixLU())==current_precision_);
@@ -1009,27 +1009,27 @@ namespace bertini{
 				
 				unsigned numTotalFunctions_; // Number of total functions for the current system
 				unsigned numVariables_;  // Number of variables for the current system
-				mutable std::tuple< Mat<dbl>, Mat<mpfr_complex> > K_;  // All the stage variables.  Each column represents a different stage.
+				mutable std::tuple< Mat<complex_dbl>, Mat<complex_mp> > K_;  // All the stage variables.  Each column represents a different stage.
 				Predictor predictor_;  // Method for prediction
 				unsigned p_;  //Order of the prediction method
-				mutable std::tuple< Mat<dbl>, Mat<mpfr_complex> > dh_dx_0_;  // Jacobian for the initial stage.  Use for AMP testing
-				mutable std::tuple< Mat<dbl>, Mat<mpfr_complex> > dh_dx_temp_;  // Temporary jacobian for all other stages
-				mutable std::tuple< Vec<dbl>, Vec<mpfr_complex> > dh_dt_temp_;  // Temporary time derivative used for all stages
-				// std::tuple< Eigen::PartialPivLU<Mat<dbl>>, Eigen::PartialPivLU<Mat<mpfr_complex>> > LU_0_;  // LU from the intial stage used for AMP testing
+				mutable std::tuple< Mat<complex_dbl>, Mat<complex_mp> > dh_dx_0_;  // Jacobian for the initial stage.  Use for AMP testing
+				mutable std::tuple< Mat<complex_dbl>, Mat<complex_mp> > dh_dx_temp_;  // Temporary jacobian for all other stages
+				mutable std::tuple< Vec<complex_dbl>, Vec<complex_mp> > dh_dt_temp_;  // Temporary time derivative used for all stages
+				// std::tuple< Eigen::PartialPivLU<Mat<complex_dbl>>, Eigen::PartialPivLU<Mat<complex_mp>> > LU_0_;  // LU from the intial stage used for AMP testing
 
-				mutable std::tuple< Eigen::PartialPivLU<Mat<dbl>>, Eigen::PartialPivLU<Mat<mpfr_complex>> > LU_;
+				mutable std::tuple< Eigen::PartialPivLU<Mat<complex_dbl>>, Eigen::PartialPivLU<Mat<complex_mp>> > LU_;
 
-				mutable std::tuple< Vec<dbl>, Vec<mpfr_complex> > step_temp_;  // reused scratch for FullStep stage accumulation
-				mutable std::tuple< Vec<dbl>, Vec<mpfr_complex> > rand_temp_;  // reused scratch: random RHS for norm_J_inverse
-				mutable std::tuple< Vec<dbl>, Vec<mpfr_complex> > solve_temp_; // reused scratch: LU solve result
+				mutable std::tuple< Vec<complex_dbl>, Vec<complex_mp> > step_temp_;  // reused scratch for FullStep stage accumulation
+				mutable std::tuple< Vec<complex_dbl>, Vec<complex_mp> > rand_temp_;  // reused scratch: random RHS for norm_J_inverse
+				mutable std::tuple< Vec<complex_dbl>, Vec<complex_mp> > solve_temp_; // reused scratch: LU solve result
 				
 				
 				// Butcher Table (notation from https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods )
 				mutable unsigned s_; // Number of stages
-				mutable std::tuple< Mat<double>, Mat<mpfr_float> > a_;
-				mutable std::tuple< Vec<double>, Vec<mpfr_float> > b_;
-				mutable std::tuple< Vec<double>, Vec<mpfr_float> > b_minus_bstar_;
-				mutable std::tuple< Vec<double>, Vec<mpfr_float> > c_;
+				mutable std::tuple< Mat<double>, Mat<real_mp> > a_;
+				mutable std::tuple< Vec<double>, Vec<real_mp> > b_;
+				mutable std::tuple< Vec<double>, Vec<real_mp> > b_minus_bstar_;
+				mutable std::tuple< Vec<double>, Vec<real_mp> > c_;
 				
 				mutable bool uses_embedded_;
 				mutable unsigned current_precision_;
@@ -1117,65 +1117,65 @@ namespace bertini{
 			
 		// Explicit instantiation declarations — suppress re-instantiation in every
 		// including TU.  The definitions live in core/src/tracking/explicit_predictors.cpp.
-		// Concrete types: dbl = std::complex<double>, mpfr_complex (multiprecision).
+		// Concrete types: complex_dbl = std::complex<double>, complex_mp (multiprecision).
 		// NumErrorT = double (from bertini2/common/config.hpp).
 
-		extern template SuccessCode ExplicitRKPredictor::Predict<dbl>(
-		    Vec<dbl>&, System const&, Vec<dbl> const&, dbl, dbl const&,
+		extern template SuccessCode ExplicitRKPredictor::Predict<complex_dbl>(
+		    Vec<complex_dbl>&, System const&, Vec<complex_dbl> const&, complex_dbl, complex_dbl const&,
 		    double&, unsigned&, unsigned, double const&);
-		extern template SuccessCode ExplicitRKPredictor::Predict<mpfr_complex>(
-		    Vec<mpfr_complex>&, System const&, Vec<mpfr_complex> const&, mpfr_complex, mpfr_complex const&,
+		extern template SuccessCode ExplicitRKPredictor::Predict<complex_mp>(
+		    Vec<complex_mp>&, System const&, Vec<complex_mp> const&, complex_mp, complex_mp const&,
 		    double&, unsigned&, unsigned, double const&);
 
-		extern template SuccessCode ExplicitRKPredictor::Predict<dbl>(
-		    Vec<dbl>&, double&, double&, double&,
-		    System const&, Vec<dbl> const&, dbl, dbl const&,
+		extern template SuccessCode ExplicitRKPredictor::Predict<complex_dbl>(
+		    Vec<complex_dbl>&, double&, double&, double&,
+		    System const&, Vec<complex_dbl> const&, complex_dbl, complex_dbl const&,
 		    double&, unsigned&, unsigned, double const&, AdaptiveMultiplePrecisionConfig const&);
-		extern template SuccessCode ExplicitRKPredictor::Predict<mpfr_complex>(
-		    Vec<mpfr_complex>&, double&, double&, double&,
-		    System const&, Vec<mpfr_complex> const&, mpfr_complex, mpfr_complex const&,
-		    double&, unsigned&, unsigned, double const&, AdaptiveMultiplePrecisionConfig const&);
-
-		extern template SuccessCode ExplicitRKPredictor::Predict<dbl>(
-		    Vec<dbl>&, double&, double&, double&, double&,
-		    System const&, Vec<dbl> const&, dbl, dbl const&,
-		    double&, unsigned&, unsigned, double const&, AdaptiveMultiplePrecisionConfig const&);
-		extern template SuccessCode ExplicitRKPredictor::Predict<mpfr_complex>(
-		    Vec<mpfr_complex>&, double&, double&, double&, double&,
-		    System const&, Vec<mpfr_complex> const&, mpfr_complex, mpfr_complex const&,
+		extern template SuccessCode ExplicitRKPredictor::Predict<complex_mp>(
+		    Vec<complex_mp>&, double&, double&, double&,
+		    System const&, Vec<complex_mp> const&, complex_mp, complex_mp const&,
 		    double&, unsigned&, unsigned, double const&, AdaptiveMultiplePrecisionConfig const&);
 
-		extern template SuccessCode ExplicitRKPredictor::FullStep<dbl>(
-		    Vec<dbl>&, System const&, Vec<dbl> const&, dbl const&, dbl const&);
-		extern template SuccessCode ExplicitRKPredictor::FullStep<mpfr_complex>(
-		    Vec<mpfr_complex>&, System const&, Vec<mpfr_complex> const&, mpfr_complex const&, mpfr_complex const&);
+		extern template SuccessCode ExplicitRKPredictor::Predict<complex_dbl>(
+		    Vec<complex_dbl>&, double&, double&, double&, double&,
+		    System const&, Vec<complex_dbl> const&, complex_dbl, complex_dbl const&,
+		    double&, unsigned&, unsigned, double const&, AdaptiveMultiplePrecisionConfig const&);
+		extern template SuccessCode ExplicitRKPredictor::Predict<complex_mp>(
+		    Vec<complex_mp>&, double&, double&, double&, double&,
+		    System const&, Vec<complex_mp> const&, complex_mp, complex_mp const&,
+		    double&, unsigned&, unsigned, double const&, AdaptiveMultiplePrecisionConfig const&);
 
-		extern template void ExplicitRKPredictor::SetNormsCond<dbl>(
+		extern template SuccessCode ExplicitRKPredictor::FullStep<complex_dbl>(
+		    Vec<complex_dbl>&, System const&, Vec<complex_dbl> const&, complex_dbl const&, complex_dbl const&);
+		extern template SuccessCode ExplicitRKPredictor::FullStep<complex_mp>(
+		    Vec<complex_mp>&, System const&, Vec<complex_mp> const&, complex_mp const&, complex_mp const&);
+
+		extern template void ExplicitRKPredictor::SetNormsCond<complex_dbl>(
 		    double&, double&, double&, unsigned, unsigned);
-		extern template void ExplicitRKPredictor::SetNormsCond<mpfr_complex>(
+		extern template void ExplicitRKPredictor::SetNormsCond<complex_mp>(
 		    double&, double&, double&, unsigned, unsigned);
 
-		extern template SuccessCode ExplicitRKPredictor::SetErrorEstimate<dbl>(double&, dbl const&);
-		extern template SuccessCode ExplicitRKPredictor::SetErrorEstimate<mpfr_complex>(double&, mpfr_complex const&);
+		extern template SuccessCode ExplicitRKPredictor::SetErrorEstimate<complex_dbl>(double&, complex_dbl const&);
+		extern template SuccessCode ExplicitRKPredictor::SetErrorEstimate<complex_mp>(double&, complex_mp const&);
 
-		extern template SuccessCode ExplicitRKPredictor::SetSizeProportion<dbl>(double&, dbl const&);
-		extern template SuccessCode ExplicitRKPredictor::SetSizeProportion<mpfr_complex>(double&, mpfr_complex const&);
+		extern template SuccessCode ExplicitRKPredictor::SetSizeProportion<complex_dbl>(double&, complex_dbl const&);
+		extern template SuccessCode ExplicitRKPredictor::SetSizeProportion<complex_mp>(double&, complex_mp const&);
 
-		extern template SuccessCode ExplicitRKPredictor::EvalRHS<dbl>(
-		    System const&, Vec<dbl> const&, dbl const&, Mat<dbl>&, unsigned);
-		extern template SuccessCode ExplicitRKPredictor::EvalRHS<mpfr_complex>(
-		    System const&, Vec<mpfr_complex> const&, mpfr_complex const&, Mat<mpfr_complex>&, unsigned);
+		extern template SuccessCode ExplicitRKPredictor::EvalRHS<complex_dbl>(
+		    System const&, Vec<complex_dbl> const&, complex_dbl const&, Mat<complex_dbl>&, unsigned);
+		extern template SuccessCode ExplicitRKPredictor::EvalRHS<complex_mp>(
+		    System const&, Vec<complex_mp> const&, complex_mp const&, Mat<complex_mp>&, unsigned);
 
 		extern template void ExplicitRKPredictor::FillButcherTable<double>(
 		    int, Mat<mpq_rational> const&, Mat<mpq_rational> const&,
 		    Mat<mpq_rational> const&, Mat<mpq_rational> const&);
-		extern template void ExplicitRKPredictor::FillButcherTable<mpfr_float>(
+		extern template void ExplicitRKPredictor::FillButcherTable<real_mp>(
 		    int, Mat<mpq_rational> const&, Mat<mpq_rational> const&,
 		    Mat<mpq_rational> const&, Mat<mpq_rational> const&);
 
 		extern template void ExplicitRKPredictor::FillButcherTable<double>(
 		    int, Mat<mpq_rational> const&, Mat<mpq_rational> const&, Mat<mpq_rational> const&);
-		extern template void ExplicitRKPredictor::FillButcherTable<mpfr_float>(
+		extern template void ExplicitRKPredictor::FillButcherTable<real_mp>(
 		    int, Mat<mpq_rational> const&, Mat<mpq_rational> const&, Mat<mpq_rational> const&);
 
 		} // re: predict

--- a/core/include/bertini2/trackers/fixed_precision_tracker.hpp
+++ b/core/include/bertini2/trackers/fixed_precision_tracker.hpp
@@ -415,7 +415,7 @@ namespace bertini{
 		class DoublePrecisionTracker : public FixedPrecisionTracker<DoublePrecisionTracker>
 		{
 		public:
-			using BaseComplexT = dbl;
+			using BaseComplexT = complex_dbl;
 			using BaseRealT = double;
 
 			using EmitterType = typename TrackerTraits<DoublePrecisionTracker>::EventEmitterType;
@@ -494,8 +494,8 @@ namespace bertini{
 		class MultiplePrecisionTracker : public FixedPrecisionTracker<MultiplePrecisionTracker>
 		{
 		public:
-			using BaseComplexT = mpfr_complex;
-			using BaseRealT = mpfr_float;
+			using BaseComplexT = complex_mp;
+			using BaseRealT = real_mp;
 
 			using EmitterType = FixedPrecisionTracker<MultiplePrecisionTracker>;
 
@@ -605,7 +605,7 @@ namespace bertini{
 				this->endtime_ = end_time;
 				std::get<Vec<BaseComplexT> >(this->current_space_) = start_point;
 				if (this->reinitialize_stepsize_)
-					this->SetStepSize(min(mpfr_float(Get<Stepping>().initial_step_size),mpfr_float(abs(start_time-end_time)/Get<Stepping>().min_num_steps)));
+					this->SetStepSize(min(real_mp(Get<Stepping>().initial_step_size),real_mp(abs(start_time-end_time)/Get<Stepping>().min_num_steps)));
 
 				ResetCounters();
 
@@ -616,9 +616,9 @@ namespace bertini{
 			{	
 				return GetSystem().precision() == precision_ &&
 						ThreadPrecision()==precision_ &&
-						std::get<Vec<mpfr_complex> >(current_space_)(0).precision() == precision_ &&
-						std::get<Vec<mpfr_complex> >(tentative_space_)(0).precision() == precision_ &&
-						std::get<Vec<mpfr_complex> >(temporary_space_)(0).precision() == precision_ &&
+						std::get<Vec<complex_mp> >(current_space_)(0).precision() == precision_ &&
+						std::get<Vec<complex_mp> >(tentative_space_)(0).precision() == precision_ &&
+						std::get<Vec<complex_mp> >(temporary_space_)(0).precision() == precision_ &&
 						Precision(this->endtime_)==precision_
 						        ;				
 			}

--- a/core/include/bertini2/trackers/fixed_precision_utilities.hpp
+++ b/core/include/bertini2/trackers/fixed_precision_utilities.hpp
@@ -32,7 +32,7 @@ namespace bertini{ namespace tracking {
 namespace fixed{
 
 inline
-void SetPrecision(SampCont<mpfr_complex> & samples, unsigned prec)
+void SetPrecision(SampCont<complex_mp> & samples, unsigned prec)
 {
 	for (auto& s : samples)
 		for (unsigned ii=0; ii<s.size(); ii++)
@@ -40,14 +40,14 @@ void SetPrecision(SampCont<mpfr_complex> & samples, unsigned prec)
 }
 
 inline
-void SetPrecision(TimeCont<mpfr_complex> & times, unsigned prec)
+void SetPrecision(TimeCont<complex_mp> & times, unsigned prec)
 {
 	for (auto& t : times)
 		t.precision(prec);
 }
 
 inline
-unsigned MaxPrecision(SampCont<mpfr_complex> const& samples)
+unsigned MaxPrecision(SampCont<complex_mp> const& samples)
 {
 	unsigned max_precision = 0;
 	for (auto& s : samples)
@@ -57,7 +57,7 @@ unsigned MaxPrecision(SampCont<mpfr_complex> const& samples)
 }
 
 inline
-unsigned MaxPrecision(TimeCont<mpfr_complex> const& times)
+unsigned MaxPrecision(TimeCont<complex_mp> const& times)
 {
 	unsigned max_precision = 0;
 	for (auto& t : times)
@@ -69,21 +69,21 @@ unsigned MaxPrecision(TimeCont<mpfr_complex> const& times)
 
 //does not a thing, because cannot.
 inline
-unsigned EnsureAtUniformPrecision(TimeCont<dbl> const & /*times*/, SampCont<dbl> const & /*derivatives*/)
+unsigned EnsureAtUniformPrecision(TimeCont<complex_dbl> const & /*times*/, SampCont<complex_dbl> const & /*derivatives*/)
 {
 	return DoublePrecision();
 }
 
 inline
-unsigned EnsureAtUniformPrecision(TimeCont<dbl> const & /*times*/, SampCont<dbl> const & /*samples*/, SampCont<dbl> const & /*derivatives*/)
+unsigned EnsureAtUniformPrecision(TimeCont<complex_dbl> const & /*times*/, SampCont<complex_dbl> const & /*samples*/, SampCont<complex_dbl> const & /*derivatives*/)
 {
 	return DoublePrecision(); 
 }
 
 
-//changes precision of mpfr_complex to highest needed precision for the samples.
+//changes precision of complex_mp to highest needed precision for the samples.
 inline
-unsigned EnsureAtUniformPrecision(TimeCont<mpfr_complex> const & /*times*/, SampCont<mpfr_complex> const & samples)
+unsigned EnsureAtUniformPrecision(TimeCont<complex_mp> const & /*times*/, SampCont<complex_mp> const & samples)
 {
 	return MaxPrecision(samples);
 }
@@ -91,7 +91,7 @@ unsigned EnsureAtUniformPrecision(TimeCont<mpfr_complex> const & /*times*/, Samp
 
 //returns max precision of all samples.
 inline
-unsigned EnsureAtUniformPrecision(TimeCont<mpfr_complex> const & /*times*/, SampCont<mpfr_complex> const & samples, SampCont<mpfr_complex> const & derivatives)
+unsigned EnsureAtUniformPrecision(TimeCont<complex_mp> const & /*times*/, SampCont<complex_mp> const & samples, SampCont<complex_mp> const & derivatives)
 {
 	return max(MaxPrecision(samples),
 	           MaxPrecision(derivatives)); 

--- a/core/include/bertini2/trackers/newton_corrector.hpp
+++ b/core/include/bertini2/trackers/newton_corrector.hpp
@@ -81,11 +81,11 @@ namespace bertini{
 				 */
 				void ChangePrecision(unsigned new_precision)
 				{
-					Precision(std::get< Vec<mpfr_complex> >(f_temp_), new_precision);
-					Precision(std::get< Vec<mpfr_complex> >(step_temp_), new_precision);
-					Precision(std::get< Mat<mpfr_complex> >(J_temp_), new_precision);
-					Precision(std::get< Vec<mpfr_complex> >(rand_temp_), new_precision);
-					Precision(std::get< Vec<mpfr_complex> >(solve_temp_), new_precision);
+					Precision(std::get< Vec<complex_mp> >(f_temp_), new_precision);
+					Precision(std::get< Vec<complex_mp> >(step_temp_), new_precision);
+					Precision(std::get< Mat<complex_mp> >(J_temp_), new_precision);
+					Precision(std::get< Vec<complex_mp> >(rand_temp_), new_precision);
+					Precision(std::get< Vec<complex_mp> >(solve_temp_), new_precision);
 
 					current_precision_ = new_precision;
 				}
@@ -106,14 +106,14 @@ namespace bertini{
 				{
 					numTotalFunctions_ = static_cast<unsigned>(S.NumTotalFunctions());
 					numVariables_ = static_cast<unsigned>(S.NumVariables());
-					std::get< Mat<dbl> >(J_temp_).resize(numTotalFunctions_, numVariables_);
-					std::get< Mat<mpfr_complex> >(J_temp_).resize(numTotalFunctions_, numVariables_);
-					std::get< Vec<dbl> >(f_temp_).resize(numTotalFunctions_);
-					std::get< Vec<mpfr_complex> >(f_temp_).resize(numTotalFunctions_);
-					std::get< Vec<dbl> >(step_temp_).resize(numTotalFunctions_);
-					std::get< Vec<mpfr_complex> >(step_temp_).resize(numTotalFunctions_);
-					std::get< Vec<dbl> >(solve_temp_).resize(numVariables_);
-					std::get< Vec<mpfr_complex> >(solve_temp_).resize(numVariables_);
+					std::get< Mat<complex_dbl> >(J_temp_).resize(numTotalFunctions_, numVariables_);
+					std::get< Mat<complex_mp> >(J_temp_).resize(numTotalFunctions_, numVariables_);
+					std::get< Vec<complex_dbl> >(f_temp_).resize(numTotalFunctions_);
+					std::get< Vec<complex_mp> >(f_temp_).resize(numTotalFunctions_);
+					std::get< Vec<complex_dbl> >(step_temp_).resize(numTotalFunctions_);
+					std::get< Vec<complex_mp> >(step_temp_).resize(numTotalFunctions_);
+					std::get< Vec<complex_dbl> >(solve_temp_).resize(numVariables_);
+					std::get< Vec<complex_mp> >(solve_temp_).resize(numVariables_);
 					RefreshRandomDirection();
 				}
 
@@ -130,8 +130,8 @@ namespace bertini{
 				 */
 				void RefreshRandomDirection()
 				{
-					std::get< Vec<dbl> >(rand_temp_) = RandomOfUnits<dbl>(numVariables_);
-					std::get< Vec<mpfr_complex> >(rand_temp_) = RandomOfUnits<mpfr_complex>(numVariables_);
+					std::get< Vec<complex_dbl> >(rand_temp_) = RandomOfUnits<complex_dbl>(numVariables_);
+					std::get< Vec<complex_mp> >(rand_temp_) = RandomOfUnits<complex_mp>(numVariables_);
 				}
 
 				
@@ -407,13 +407,13 @@ namespace bertini{
 				unsigned numTotalFunctions_; // Number of total functions for the current system
 				unsigned numVariables_;  // Number of variables for the current system
 				
-				std::tuple< Vec<dbl>, Vec<mpfr_complex> > f_temp_;
-				std::tuple< Vec<dbl>, Vec<mpfr_complex> > step_temp_;
-				std::tuple< Mat<dbl>, Mat<mpfr_complex> > J_temp_;
-				std::tuple< Vec<dbl>, Vec<mpfr_complex> > rand_temp_;  // reused scratch: random RHS for norm_J_inverse
-				std::tuple< Vec<dbl>, Vec<mpfr_complex> > solve_temp_; // reused scratch: LU solve result
+				std::tuple< Vec<complex_dbl>, Vec<complex_mp> > f_temp_;
+				std::tuple< Vec<complex_dbl>, Vec<complex_mp> > step_temp_;
+				std::tuple< Mat<complex_dbl>, Mat<complex_mp> > J_temp_;
+				std::tuple< Vec<complex_dbl>, Vec<complex_mp> > rand_temp_;  // reused scratch: random RHS for norm_J_inverse
+				std::tuple< Vec<complex_dbl>, Vec<complex_mp> > solve_temp_; // reused scratch: LU solve result
 
-				std::tuple< Eigen::PartialPivLU<Mat<dbl>>, Eigen::PartialPivLU<Mat<mpfr_complex>> > LU_;
+				std::tuple< Eigen::PartialPivLU<Mat<complex_dbl>>, Eigen::PartialPivLU<Mat<complex_mp>> > LU_;
 				
 				unsigned current_precision_;
 

--- a/core/include/bertini2/trackers/observers.hpp
+++ b/core/include/bertini2/trackers/observers.hpp
@@ -209,7 +209,7 @@ namespace bertini {
 				return ObserveResult::KeepObserving;
 			}
 
-			const std::vector<Vec<mpfr_complex> >& Path() const
+			const std::vector<Vec<complex_mp> >& Path() const
 			{
 				return path_;
 			}
@@ -217,7 +217,7 @@ namespace bertini {
 			virtual ~AMPPathAccumulator() = default;
 
 		private:
-			std::vector<Vec<mpfr_complex> > path_;
+			std::vector<Vec<complex_mp> > path_;
 		};
 
 
@@ -235,7 +235,7 @@ namespace bertini {
 			{
 
 
-				if (auto p = dynamic_cast<const Initializing<EmitterT,dbl>*>(&e))
+				if (auto p = dynamic_cast<const Initializing<EmitterT,complex_dbl>*>(&e))
 				{
 					BOOST_LOG_TRIVIAL(severity_level::debug) << std::setprecision(static_cast<int>(p->Get().GetSystem().precision()))
 						<< "initializing in double, tracking path\nfrom\tt = "
@@ -243,7 +243,7 @@ namespace bertini {
 						<< "\n from\tx = \n" << p->StartPoint()
 						<< "\n tracking system " << p->Get().GetSystem() << "\n\n";
 				}
-				else if (auto p = dynamic_cast<const Initializing<EmitterT,mpfr_complex>*>(&e))
+				else if (auto p = dynamic_cast<const Initializing<EmitterT,complex_mp>*>(&e))
 				{
 					BOOST_LOG_TRIVIAL(severity_level::debug) << std::setprecision(static_cast<int>(p->Get().GetSystem().precision()))
 						 << "initializing in multiprecision, tracking path\nfrom\tt = " << p->StartTime() << "\nto\tt = " << p->EndTime() << "\n from\tx = \n" << p->StartPoint()
@@ -292,22 +292,22 @@ namespace bertini {
 
 
 
-				else if (auto p = dynamic_cast<const SuccessfulPredict<EmitterT,mpfr_complex>*>(&e))
+				else if (auto p = dynamic_cast<const SuccessfulPredict<EmitterT,complex_mp>*>(&e))
 				{
-					BOOST_LOG_TRIVIAL(severity_level::trace) << std::setprecision(static_cast<int>(Precision(p->ResultingPoint()))) << "prediction successful (mpfr_complex), result:\n" << p->ResultingPoint();
+					BOOST_LOG_TRIVIAL(severity_level::trace) << std::setprecision(static_cast<int>(Precision(p->ResultingPoint()))) << "prediction successful (complex_mp), result:\n" << p->ResultingPoint();
 				}
-				else if (auto p = dynamic_cast<const SuccessfulPredict<EmitterT,dbl>*>(&e))
+				else if (auto p = dynamic_cast<const SuccessfulPredict<EmitterT,complex_dbl>*>(&e))
 				{
-					BOOST_LOG_TRIVIAL(severity_level::trace) << std::setprecision(static_cast<int>(Precision(p->ResultingPoint()))) << "prediction successful (dbl), result:\n" << p->ResultingPoint();
+					BOOST_LOG_TRIVIAL(severity_level::trace) << std::setprecision(static_cast<int>(Precision(p->ResultingPoint()))) << "prediction successful (complex_dbl), result:\n" << p->ResultingPoint();
 				}
 
-				else if (auto p = dynamic_cast<const SuccessfulCorrect<EmitterT,mpfr_complex>*>(&e))
+				else if (auto p = dynamic_cast<const SuccessfulCorrect<EmitterT,complex_mp>*>(&e))
 				{
-					BOOST_LOG_TRIVIAL(severity_level::trace) << std::setprecision(static_cast<int>(Precision(p->ResultingPoint()))) << "correction successful (mpfr_complex), result:\n" << p->ResultingPoint();
+					BOOST_LOG_TRIVIAL(severity_level::trace) << std::setprecision(static_cast<int>(Precision(p->ResultingPoint()))) << "correction successful (complex_mp), result:\n" << p->ResultingPoint();
 				}
-				else if (auto p = dynamic_cast<const SuccessfulCorrect<EmitterT,dbl>*>(&e))
+				else if (auto p = dynamic_cast<const SuccessfulCorrect<EmitterT,complex_dbl>*>(&e))
 				{
-					BOOST_LOG_TRIVIAL(severity_level::trace) << std::setprecision(static_cast<int>(Precision(p->ResultingPoint()))) << "correction successful (dbl), result:\n" << p->ResultingPoint();
+					BOOST_LOG_TRIVIAL(severity_level::trace) << std::setprecision(static_cast<int>(Precision(p->ResultingPoint()))) << "correction successful (complex_dbl), result:\n" << p->ResultingPoint();
 				}
 
 

--- a/core/src/basics/random.cpp
+++ b/core/src/basics/random.cpp
@@ -123,7 +123,7 @@ unsigned long DerivedWorkerSeed(uint64_t worker_index)
 
 
 
-	mpfr_float RandomMp()
+	real_mp RandomMp()
 	{
 		// ThreadPrecision (thread-local) rather than DefaultPrecision (global):
 		// random numbers are generated during tracking, which may run on a
@@ -131,10 +131,10 @@ unsigned long DerivedWorkerSeed(uint64_t worker_index)
 		return RandomMp(bertini::ThreadPrecision());
 	}
 
-	mpfr_float RandomMp(unsigned num_digits)
+	real_mp RandomMp(unsigned num_digits)
 	{
 		
-		mpfr_float a;
+		real_mp a;
 		if (num_digits<=50)
 			a = RandomMp<50>();
 		else if (num_digits<=100)
@@ -174,11 +174,11 @@ unsigned long DerivedWorkerSeed(uint64_t worker_index)
 	}
 
 
-	void RandomMpAssign(mpfr_float & a, unsigned num_digits)
+	void RandomMpAssign(real_mp & a, unsigned num_digits)
 	{
 		
 
-		mpfr_float temp;
+		real_mp temp;
 		temp = RandomMp(num_digits);
 		a = std::move(temp);
 	}
@@ -186,16 +186,16 @@ unsigned long DerivedWorkerSeed(uint64_t worker_index)
 
 
 
-	mpfr_float RandomMp(const mpfr_float & a, const mpfr_float & b)
+	real_mp RandomMp(const real_mp & a, const real_mp & b)
 	{
 		// see RandomMp() above for why ThreadPrecision rather than DefaultPrecision
 		return RandomMp(a,b,bertini::ThreadPrecision());
 	}
 
-	mpfr_float RandomMp(const mpfr_float & a, const mpfr_float & b, unsigned num_digits)
+	real_mp RandomMp(const real_mp & a, const real_mp & b, unsigned num_digits)
 	{
 		
-		mpfr_float result;
+		real_mp result;
 		if (num_digits<=50)
 			result = RandomMp<50>(a,b);
 		else if (num_digits<=100)

--- a/core/src/blackbox/algorithm_builder.cpp
+++ b/core/src/blackbox/algorithm_builder.cpp
@@ -53,7 +53,7 @@ int AlgoBuilder::ClassicBuild(std::string const& config_str, std::string const& 
 
 	// Parse all configuration structs (double precision versions suffice for
 	// choosing algorithm types; mpfr versions would be used for mp-specific defaults)
-	using AllConfsD = config::Configs::All<dbl>::type;
+	using AllConfsD = config::Configs::All<complex_dbl>::type;
 	decltype(parsing::classic::ConfigParser<AllConfsD>::Parse(config_str)) cfgs_d;
 	try {
 		cfgs_d = parsing::classic::ConfigParser<AllConfsD>::Parse(config_str);

--- a/core/src/function_tree/operators/arithmetic.cpp
+++ b/core/src/function_tree/operators/arithmetic.cpp
@@ -882,12 +882,12 @@ namespace {
 	// constant exponent is a non-negative integer.  Returns NaN for anything that is not a plain
 	// numeric literal, so the integer test fails (the conservative answer).  Node evaluation is gone,
 	// so this reads the literal directly rather than evaluating.
-	dbl ConstantExponentValue(std::shared_ptr<Node> const& n)
+	complex_dbl ConstantExponentValue(std::shared_ptr<Node> const& n)
 	{
-		if (auto i = std::dynamic_pointer_cast<Integer const>(n))  return dbl(double(i->GetValue()), 0);
-		if (auto f = std::dynamic_pointer_cast<Complex const>(n))    return dbl(f->GetValue());
-		if (auto r = std::dynamic_pointer_cast<Rational const>(n)) return r->Value<dbl>();
-		return dbl(std::numeric_limits<double>::quiet_NaN(), 0);
+		if (auto i = std::dynamic_pointer_cast<Integer const>(n))  return complex_dbl(double(i->GetValue()), 0);
+		if (auto f = std::dynamic_pointer_cast<Complex const>(n))    return complex_dbl(f->GetValue());
+		if (auto r = std::dynamic_pointer_cast<Rational const>(n)) return r->Value<complex_dbl>();
+		return complex_dbl(std::numeric_limits<double>::quiet_NaN(), 0);
 	}
 }
 
@@ -899,7 +899,7 @@ int PowerOperator::Degree(std::shared_ptr<Variable> const& v) const
 	
 	if (exp_deg==0)
 	{
-		dbl exp_val = ConstantExponentValue(exponent_);
+		complex_dbl exp_val = ConstantExponentValue(exponent_);
 		bool exp_is_int = false;
 		
 		if (fabs(imag(exp_val))< 10*std::numeric_limits<double>::epsilon()) // so a real thresholding step
@@ -908,7 +908,7 @@ int PowerOperator::Degree(std::shared_ptr<Variable> const& v) const
 		
 		if (exp_is_int)
 		{
-			if (abs(exp_val-dbl(0.0))< 10*std::numeric_limits<double>::epsilon())
+			if (abs(exp_val-complex_dbl(0.0))< 10*std::numeric_limits<double>::epsilon())
 				return 0;
 			else if (real(exp_val)<0)
 				return -1;
@@ -1073,7 +1073,7 @@ bool PowerOperator::IsHomogeneous(std::shared_ptr<Variable> const& v) const
 	// the only hope this has of being homogeneous, is that the degree of the exponent is 0 (it's constant), and that it's an integer
 	if (exponent_->Degree(v)==0)
 	{
-		dbl exp_val = ConstantExponentValue(exponent_);
+		complex_dbl exp_val = ConstantExponentValue(exponent_);
 		if (fabs(imag(exp_val)) < 10*std::numeric_limits<double>::epsilon())
 			if (fabs(std::round(real(exp_val)) - real(exp_val)) < 10*std::numeric_limits<double>::epsilon())
 				if (real(exp_val) >=0 )
@@ -1088,7 +1088,7 @@ bool PowerOperator::IsHomogeneous(VariableGroup const& v) const
 	// the only hope this has of being homogeneous, is that the degree of the exponent is 0 (it's constant), and that it's an integer
 	if (exponent_->Degree(v)==0)
 	{
-		dbl exp_val = ConstantExponentValue(exponent_);
+		complex_dbl exp_val = ConstantExponentValue(exponent_);
 		if (fabs(imag(exp_val)) < 10*std::numeric_limits<double>::epsilon())
 			if (fabs(std::round(real(exp_val)) - real(exp_val)) < 10*std::numeric_limits<double>::epsilon())
 				if (real(exp_val) >=0 )

--- a/core/src/system/start/mhom.cpp
+++ b/core/src/system/start/mhom.cpp
@@ -81,7 +81,7 @@ namespace bertini
 				auto const saved_prec = DefaultPrecision();
 				DefaultPrecision(MaxPrecisionAllowed());
 
-				linear_coeffs_ = Mat<Mat<mpfr_complex>>(degree_matrix_.rows(), degree_matrix_.cols());
+				linear_coeffs_ = Mat<Mat<complex_mp>>(degree_matrix_.rows(), degree_matrix_.cols());
 				for (Eigen::Index ii = 0; ii < degree_matrix_.rows(); ++ii)
 					for (Eigen::Index jj = 0; jj < degree_matrix_.cols(); ++jj)
 					{
@@ -90,13 +90,13 @@ namespace bertini
 							continue;
 						const Eigen::Index gsize = static_cast<Eigen::Index>(var_groups_[static_cast<size_t>(jj)].size());
 						const bool projective = (static_cast<size_t>(jj) < s.NumHomVariableGroups());
-						Mat<mpfr_complex> C(d, gsize + 1);
+						Mat<complex_mp> C(d, gsize + 1);
 						for (Eigen::Index f = 0; f < d; ++f)
 						{
 							for (Eigen::Index k = 0; k < gsize; ++k)
-								C(f, k) = mpfr_complex(mpfr_float(RandomRat()), mpfr_float(RandomRat()));
-							C(f, gsize) = projective ? mpfr_complex(0)
-							                         : mpfr_complex(mpfr_float(RandomRat()), mpfr_float(RandomRat()));
+								C(f, k) = complex_mp(real_mp(RandomRat()), real_mp(RandomRat()));
+							C(f, gsize) = projective ? complex_mp(0)
+							                         : complex_mp(real_mp(RandomRat()), real_mp(RandomRat()));
 						}
 						linear_coeffs_(ii, jj) = std::move(C);
 					}
@@ -134,19 +134,19 @@ namespace bertini
 					col_of[vars[static_cast<size_t>(c)].get()] = c;
 				const Eigen::Index n = static_cast<Eigen::Index>(this->NumVariables());
 
-				std::vector<Mat<mpfr_complex>> per_function;
+				std::vector<Mat<complex_mp>> per_function;
 				per_function.reserve(static_cast<size_t>(degree_matrix_.rows()));
 
 				for (Eigen::Index ii = 0; ii < degree_matrix_.rows(); ++ii)
 				{
-					std::vector<Vec<mpfr_complex>> rows;
+					std::vector<Vec<complex_mp>> rows;
 					for (Eigen::Index g = 0; g < degree_matrix_.cols(); ++g)
 					{
 						const int d = degree_matrix_(ii, g);
 						if (d == 0)
 							continue;
 
-						const Mat<mpfr_complex>& C = linear_coeffs_(ii, g);
+						const Mat<complex_mp>& C = linear_coeffs_(ii, g);
 						const VariableGroup& gvars = var_groups_[static_cast<size_t>(g)];
 						// the homogenizing variable of an affine group, if the system is
 						// homogenized; projective groups (g < num_hom_groups_) have none.
@@ -157,10 +157,10 @@ namespace bertini
 
 						for (Eigen::Index f = 0; f < d; ++f)
 						{
-							Vec<mpfr_complex> row = Vec<mpfr_complex>::Zero(n + 1);
+							Vec<complex_mp> row = Vec<complex_mp>::Zero(n + 1);
 							for (size_t k = 0; k < gvars.size(); ++k)
 								row(col_of.at(gvars[k].get())) = C(f, static_cast<Eigen::Index>(k));
-							const mpfr_complex& constant = C(f, static_cast<Eigen::Index>(gvars.size()));
+							const complex_mp& constant = C(f, static_cast<Eigen::Index>(gvars.size()));
 							if (hom_var && col_of.count(hom_var.get()))
 								row(col_of.at(hom_var.get())) = constant;
 							else
@@ -169,7 +169,7 @@ namespace bertini
 						}
 					}
 
-					Mat<mpfr_complex> M(static_cast<Eigen::Index>(rows.size()), n + 1);
+					Mat<complex_mp> M(static_cast<Eigen::Index>(rows.size()), n + 1);
 					for (size_t r = 0; r < rows.size(); ++r)
 						M.row(static_cast<Eigen::Index>(r)) = rows[r].transpose();
 					per_function.push_back(std::move(M));
@@ -488,15 +488,15 @@ namespace bertini
 			Vec<T> b = Vec<T>::Zero(static_cast<Eigen::Index>(num_grouped_variables));
 
 			// coefficients come from linear_coeffs_ (mpfr master); cast each to the working
-			// type T (a no-op widen for mpfr, a narrowing for dbl).
-			auto as_T = [](mpfr_complex const& z) -> T {
-				if constexpr (std::is_same<T, dbl>::value) return dbl(z);
+			// type T (a no-op widen for mpfr, a narrowing for complex_dbl).
+			auto as_T = [](complex_mp const& z) -> T {
+				if constexpr (std::is_same<T, complex_dbl>::value) return complex_dbl(z);
 				else return z;
 			};
 			for(int ii = 0; ii < partition.size(); ++ii)
 			{
 				std::vector<size_t> cols = variable_cols_[static_cast<size_t>(partition[ii])];
-				const Mat<mpfr_complex>& C = linear_coeffs_(ii, partition[ii]);
+				const Mat<complex_mp>& C = linear_coeffs_(ii, partition[ii]);
 				const Eigen::Index f = static_cast<Eigen::Index>(subscript[static_cast<size_t>(ii)]);
 				for(size_t jj = 0; jj < cols.size(); ++jj)
 				{
@@ -527,24 +527,24 @@ namespace bertini
 			// coefficients and the patch are stored at MaxPrecisionAllowed, which would
 			// otherwise leak into the start point and mismatch the tracker's working
 			// precision (the adaptive tracker begins at the ambient precision).
-			if constexpr (!std::is_same<T, dbl>::value)
+			if constexpr (!std::is_same<T, complex_dbl>::value)
 				for (Eigen::Index i = 0; i < start_point.size(); ++i)
 					start_point(i).precision(DefaultPrecision());
 		}
 		
 		
-		Vec<dbl> MHomogeneous::GenerateStartPoint(dbl,unsigned long long index) const
+		Vec<complex_dbl> MHomogeneous::GenerateStartPoint(complex_dbl,unsigned long long index) const
 		{
-			Vec<dbl> start_point(NumVariables());
+			Vec<complex_dbl> start_point(NumVariables());
 			GenerateStartPointT(start_point, index);
 			
 			return start_point;
 		}
 
 
-		Vec<mpfr_complex> MHomogeneous::GenerateStartPoint(mpfr_complex,unsigned long long index) const
+		Vec<complex_mp> MHomogeneous::GenerateStartPoint(complex_mp,unsigned long long index) const
 		{
-			Vec<mpfr_complex> start_point(NumVariables());
+			Vec<complex_mp> start_point(NumVariables());
 			GenerateStartPointT(start_point, index);
 
 			return start_point;	

--- a/core/src/system/start/total_degree.cpp
+++ b/core/src/system/start/total_degree.cpp
@@ -70,23 +70,23 @@ namespace bertini {
 
 
 		
-		Vec<dbl> TotalDegree::GenerateStartPoint(dbl,unsigned long long index) const
+		Vec<complex_dbl> TotalDegree::GenerateStartPoint(complex_dbl,unsigned long long index) const
 		{
-			Vec<dbl> start_point(NumVariables());
+			Vec<complex_dbl> start_point(NumVariables());
 			auto indices = IndexToSubscript(index, degrees_);
 
 			unsigned offset = 0;
 			if (IsPatched())
 			{
-				start_point(0) = dbl(1);
+				start_point(0) = complex_dbl(1);
 				offset = 1;
 			}
 
 			// authoritative pi (see issue #156 / special_number.cpp), not acos(-1)
-			auto two_i_pi = boost::math::constants::pi<double>() * dbl(0,2);
+			auto two_i_pi = boost::math::constants::pi<double>() * complex_dbl(0,2);
 
 			for (size_t ii = 0; ii< NumNaturalVariables(); ++ii)
-				start_point(static_cast<Eigen::Index>(ii+offset)) = exp( two_i_pi * static_cast<double>(indices[ii]) / static_cast<double>(degrees_[ii])  ) * pow(random_values_[ii]->Value<dbl>(), 1.0 / static_cast<double>(degrees_[ii]));
+				start_point(static_cast<Eigen::Index>(ii+offset)) = exp( two_i_pi * static_cast<double>(indices[ii]) / static_cast<double>(degrees_[ii])  ) * pow(random_values_[ii]->Value<complex_dbl>(), 1.0 / static_cast<double>(degrees_[ii]));
 
 			if (IsPatched())
 				RescalePointToFitPatchInPlace(start_point);
@@ -95,29 +95,29 @@ namespace bertini {
 		}
 
 
-		Vec<mpfr_complex> TotalDegree::GenerateStartPoint(mpfr_complex,unsigned long long index) const
+		Vec<complex_mp> TotalDegree::GenerateStartPoint(complex_mp,unsigned long long index) const
 		{
 			using bertini::ThreadPrecision;
 
-			Vec<mpfr_complex> start_point(NumVariables()); // make the value we're returning
+			Vec<complex_mp> start_point(NumVariables()); // make the value we're returning
 			auto indices = IndexToSubscript(index, degrees_); // get the position of it -- used in the angle of the coordinates of the produced point.
 
 			unsigned offset = 0;
 			if (IsPatched())
 			{
-				start_point(0) = mpfr_complex(1,0,ThreadPrecision());
+				start_point(0) = complex_mp(1,0,ThreadPrecision());
 				offset = 1;
 			}
 
 // TODO: this code should be cleaned up after issue 308 is solved -- namely, the two precision adjustment calls should be removed.  They're only necessary because prec16 / ulonglog = prec19.
 
-			auto one = mpfr_float(1);
+			auto one = real_mp(1);
 			// authoritative pi (see issue #156 / special_number.cpp), not acos(-1)
-			mpfr_complex two_i_pi = mpfr_complex(0,2) * boost::math::constants::pi<mpfr_float>();
+			complex_mp two_i_pi = complex_mp(0,2) * boost::math::constants::pi<real_mp>();
 			for (size_t ii = 0; ii< NumNaturalVariables(); ++ii)
 			{
-				mpfr_complex a = exp( (two_i_pi * indices[ii]) / degrees_[ii]);
-				mpfr_complex b = pow(random_values_[ii]->Value<mpfr_complex>(), one / degrees_[ii]);
+				complex_mp a = exp( (two_i_pi * indices[ii]) / degrees_[ii]);
+				complex_mp b = pow(random_values_[ii]->Value<complex_mp>(), one / degrees_[ii]);
 
 				Precision(a,ThreadPrecision());
 				Precision(b,ThreadPrecision());

--- a/core/src/system/start/user.cpp
+++ b/core/src/system/start/user.cpp
@@ -33,57 +33,57 @@ namespace bertini {
 	namespace start_system {
 
 		// constructor for User start system, from any other *suitable* system.
-		User::User(System const& s, SampCont<dbl> const& solns) : user_system_(s), solns_in_dbl_(true)
+		User::User(System const& s, SampCont<complex_dbl> const& solns) : user_system_(s), solns_in_dbl_(true)
 		{
-			std::get<SampCont<dbl>>(solns_) = solns;
+			std::get<SampCont<complex_dbl>>(solns_) = solns;
 		}
 
-		User::User(System const& s, SampCont<mpfr_complex> const& solns) : user_system_(s), solns_in_dbl_(false)
+		User::User(System const& s, SampCont<complex_mp> const& solns) : user_system_(s), solns_in_dbl_(false)
 		{
-			std::get<SampCont<mpfr_complex>>(solns_) = solns;
+			std::get<SampCont<complex_mp>>(solns_) = solns;
 		}
 				
 		
 		unsigned long long User::NumStartPoints() const
 		{
 			if (solns_in_dbl_)
-				return std::get<SampCont<dbl>>(solns_).size();
+				return std::get<SampCont<complex_dbl>>(solns_).size();
 			else
-				return std::get<SampCont<mpfr_complex>>(solns_).size();
+				return std::get<SampCont<complex_mp>>(solns_).size();
 		}
 
 
 		
-		Vec<dbl> User::GenerateStartPoint(dbl,unsigned long long index) const
+		Vec<complex_dbl> User::GenerateStartPoint(complex_dbl,unsigned long long index) const
 		{
 			if (solns_in_dbl_)
-				return std::get<SampCont<dbl>>(solns_)[index];
+				return std::get<SampCont<complex_dbl>>(solns_)[index];
 			else
 			{
-				const auto& r = std::get<SampCont<mpfr_complex>>(solns_)[index];
-				Vec<dbl> pt(r.size());
+				const auto& r = std::get<SampCont<complex_mp>>(solns_)[index];
+				Vec<complex_dbl> pt(r.size());
 				for (unsigned ii=0; ii<r.size(); ++ii)
-					pt(ii) = dbl(r(ii));
+					pt(ii) = complex_dbl(r(ii));
 
 				return pt;
 			}
 		}
 
 
-		Vec<mpfr_complex> User::GenerateStartPoint(mpfr_complex,unsigned long long index) const
+		Vec<complex_mp> User::GenerateStartPoint(complex_mp,unsigned long long index) const
 		{
 			if (solns_in_dbl_)
 			{
-				const auto& r = std::get<SampCont<dbl>>(solns_)[index];
-				Vec<mpfr_complex> pt(r.size());
+				const auto& r = std::get<SampCont<complex_dbl>>(solns_)[index];
+				Vec<complex_mp> pt(r.size());
 				for (unsigned ii=0; ii<r.size(); ++ii)
-					pt(ii) = static_cast<mpfr_complex>(r(ii));
+					pt(ii) = static_cast<complex_mp>(r(ii));
 
 				return pt;
 			}
 			else
 			{
-				return std::get<SampCont<mpfr_complex>>(solns_)[index];
+				return std::get<SampCont<complex_mp>>(solns_)[index];
 			}
 		}
 

--- a/core/src/system/straight_line_program.cpp
+++ b/core/src/system/straight_line_program.cpp
@@ -68,28 +68,28 @@ namespace bertini{
 	// evaluates bit-for-bit identically to the old node-backed path, at the ambient working
 	// precision (ThreadPrecision).
 	template<>
-	dbl_complex ConstantRecipe::Produce<dbl_complex>() const {
+	complex_dbl ConstantRecipe::Produce<complex_dbl>() const {
 		switch (kind) {
-			case Kind::Integer:  return dbl_complex(double(int_value), 0);
-			case Kind::Rational: return dbl_complex(double(rat_real), double(rat_imag));
-			case Kind::Complex:    return dbl_complex(float_value);
-			case Kind::Pi:       return dbl_complex(boost::math::constants::pi<double>(), 0);
-			case Kind::E:        return dbl_complex(exp(1.0), 0.0);
+			case Kind::Integer:  return complex_dbl(double(int_value), 0);
+			case Kind::Rational: return complex_dbl(double(rat_real), double(rat_imag));
+			case Kind::Complex:    return complex_dbl(float_value);
+			case Kind::Pi:       return complex_dbl(boost::math::constants::pi<double>(), 0);
+			case Kind::E:        return complex_dbl(exp(1.0), 0.0);
 		}
-		throw std::runtime_error("unrecognized ConstantRecipe kind in Produce<dbl_complex>");
+		throw std::runtime_error("unrecognized ConstantRecipe kind in Produce<complex_dbl>");
 	}
 
 	template<>
-	mpfr_complex ConstantRecipe::Produce<mpfr_complex>() const {
+	complex_mp ConstantRecipe::Produce<complex_mp>() const {
 		using boost::multiprecision::mpfr_float;
 		switch (kind) {
-			case Kind::Integer:  return mpfr_complex(int_value, 0, ThreadPrecision());
-			case Kind::Rational: return mpfr_complex(mpfr_float(rat_real, ThreadPrecision()), mpfr_float(rat_imag, ThreadPrecision()));
-			case Kind::Complex:    return mpfr_complex(float_value, ThreadPrecision());
-			case Kind::Pi:       return mpfr_complex(boost::math::constants::pi<mpfr_float>());
-			case Kind::E:        return mpfr_complex(mpfr_float(exp(mpfr_float(1))));
+			case Kind::Integer:  return complex_mp(int_value, 0, ThreadPrecision());
+			case Kind::Rational: return complex_mp(real_mp(rat_real, ThreadPrecision()), real_mp(rat_imag, ThreadPrecision()));
+			case Kind::Complex:    return complex_mp(float_value, ThreadPrecision());
+			case Kind::Pi:       return complex_mp(boost::math::constants::pi<real_mp>());
+			case Kind::E:        return complex_mp(real_mp(exp(real_mp(1))));
 		}
-		throw std::runtime_error("unrecognized ConstantRecipe kind in Produce<mpfr_complex>");
+		throw std::runtime_error("unrecognized ConstantRecipe kind in Produce<complex_mp>");
 	}
 
 
@@ -106,12 +106,12 @@ namespace bertini{
 			return;
 		}
 		else{
-			auto& mem = memory_.Get<mpfr_complex>();
+			auto& mem = memory_.Get<complex_mp>();
 
 			// Refill the constants from their exact recipes (no node evaluation), then normalize
 			// every slot to the new precision.  (Matches the historical node-backed path.)
 			for (auto const& c : program_->constant_recipes_)
-				mem[c.slot] = c.Produce<mpfr_complex>();
+				mem[c.slot] = c.Produce<complex_mp>();
 
 			for (auto& n : mem)
 				Precision(n, new_precision);
@@ -129,31 +129,31 @@ namespace bertini{
 	{
 		for (auto const& c : program_->constant_recipes_){
 			memory_.Get<NumT>()[c.slot] = c.Produce<NumT>();
-			if (std::is_same<NumT,mpfr_complex>::value)
+			if (std::is_same<NumT,complex_mp>::value)
 				Precision(memory_.Get<NumT>()[c.slot], memory_.precision_);
 		}
 	}
 
-	template void StraightLineProgram::CopyNumbersIntoMemory<dbl_complex>() const;
-	template void StraightLineProgram::CopyNumbersIntoMemory<mpfr_complex>() const;
+	template void StraightLineProgram::CopyNumbersIntoMemory<complex_dbl>() const;
+	template void StraightLineProgram::CopyNumbersIntoMemory<complex_mp>() const;
 
 
 	void StraightLineProgram::SetupMemory()
 	{
 		// Re-seed the thread-local default precision from the program's own precision before
-		// growing the mpfr_complex memory block. resize() default-constructs each new element via
+		// growing the complex_mp memory block. resize() default-constructs each new element via
 		// mpfr_init2(x, thread_default_precision()); on Boost 1.87 that value can be 0 on fresh
 		// threads, which aborts. DefaultPrecision() sets both the static and thread-local defaults
 		// so the default-constructed slots are valid.
 		DefaultPrecision(memory_.precision_);
 
 		// adjust the sizes of the memory blocks to match the number expected via compilation
-		memory_.Get<dbl_complex>().resize(program_->num_slots_);
-		memory_.Get<mpfr_complex>().resize(program_->num_slots_);
+		memory_.Get<complex_dbl>().resize(program_->num_slots_);
+		memory_.Get<complex_mp>().resize(program_->num_slots_);
 
 		// downsample to get ready for evaluation
-		CopyNumbersIntoMemory<dbl_complex>();
-		CopyNumbersIntoMemory<mpfr_complex>();
+		CopyNumbersIntoMemory<complex_dbl>();
+		CopyNumbersIntoMemory<complex_mp>();
 	}
 
 
@@ -237,10 +237,10 @@ namespace bertini{
 
 
 
-		auto& memory_dbl =  s.memory_.Get<dbl_complex>();
-		auto& memory_mpfr =  s.memory_.Get<mpfr_complex>();
+		auto& memory_dbl =  s.memory_.Get<complex_dbl>();
+		auto& memory_mpfr =  s.memory_.Get<complex_mp>();
 
-		out << "\nvariable values in dbl memory:\n";
+		out << "\nvariable values in complex_dbl memory:\n";
 		for (unsigned ii=0; ii<prog.number_of_.Variables; ++ii){
 			out << memory_dbl[prog.input_locations_.Variables + ii] << " ";
 		}
@@ -252,7 +252,7 @@ namespace bertini{
 		}
 
 		if (s.HavePathVariable()){
-			out << "\ntime value in dbl memory:\n";
+			out << "\ntime value in complex_dbl memory:\n";
 				out << memory_dbl[prog.input_locations_.Time] << " ";
 
 
@@ -284,7 +284,7 @@ namespace bertini{
 
 
 #ifndef BERTINI_DISABLE_PRECISION_CHECKS
-		if (! std::is_same<NumT,dbl_complex>::value && Precision(memory[0])!=mem.precision_){
+		if (! std::is_same<NumT,complex_dbl>::value && Precision(memory[0])!=mem.precision_){
 			throw std::runtime_error("memory and SLP are out-of-sync WRT precision");
 		}
 #endif
@@ -297,7 +297,7 @@ namespace bertini{
 		// never change; mpfr constants are valid while the working precision is unchanged), skip it
 		// and re-run only the live segment, reusing the frozen slots already in memory.
 		bool frozen_valid;
-		if constexpr (std::is_same<NumT,dbl_complex>::value)
+		if constexpr (std::is_same<NumT,complex_dbl>::value)
 			frozen_valid = mem.frozen_valid_dbl_;
 		else
 			frozen_valid = (mem.frozen_valid_mp_precision_ == mem.precision_);
@@ -396,7 +396,7 @@ namespace bertini{
 		// A full run (from instruction 0) has just refreshed the frozen prologue at this precision.
 		if (!frozen_valid)
 		{
-			if constexpr (std::is_same<NumT,dbl_complex>::value)
+			if constexpr (std::is_same<NumT,complex_dbl>::value)
 				mem.frozen_valid_dbl_ = true;
 			else
 				mem.frozen_valid_mp_precision_ = mem.precision_;
@@ -405,8 +405,8 @@ namespace bertini{
 		mem.is_evaluated_ = true;
 	}
 
-	template void SLPProgram::Eval<dbl_complex>(SLPMemory&) const;
-	template void SLPProgram::Eval<mpfr_complex>(SLPMemory&) const;
+	template void SLPProgram::Eval<complex_dbl>(SLPMemory&) const;
+	template void SLPProgram::Eval<complex_mp>(SLPMemory&) const;
 
 
 	void SLPProgram::PartitionInstructions()

--- a/core/src/system/system.cpp
+++ b/core/src/system/system.cpp
@@ -231,8 +231,8 @@ namespace bertini
 			std::visit([&](auto const& b){ b.Precision(new_precision); }, blk);
 
 		using bertini::Precision;
-		Precision(std::get<Vec<mpfr_complex> >(current_variable_values_),new_precision);
-		Precision(std::get<mpfr_complex>(current_path_value_),new_precision);
+		Precision(std::get<Vec<complex_mp> >(current_variable_values_),new_precision);
+		Precision(std::get<complex_mp>(current_path_value_),new_precision);
 
 		if (IsPatched())
 			patch_.Precision(new_precision);
@@ -847,8 +847,8 @@ namespace bertini
 		return bound;
 	}
 
-	template double System::CoefficientBound<dbl>(unsigned) const;
-	template mpfr_float System::CoefficientBound<mpfr_complex>(unsigned) const;
+	template double System::CoefficientBound<complex_dbl>(unsigned) const;
+	template real_mp System::CoefficientBound<complex_mp>(unsigned) const;
 
     int System::DegreeBound() const
     {
@@ -893,13 +893,13 @@ namespace bertini
 		// where row r of M holds the (augmented) coefficients and `vars` are the ordered variable
 		// nodes (column c <-> vars[c]); the last column is the constant / augmenting term.  Zero
 		// coefficients are skipped to keep the tree compact (and exact: a skipped term is +0).
-		Nd LinearFormNode(Mat<mpfr_complex> const& M, Eigen::Index r,
+		Nd LinearFormNode(Mat<complex_mp> const& M, Eigen::Index r,
 		                  VariableGroup const& vars, size_t num_vars)
 		{
 			Nd form = node::Complex::Make(M(r, static_cast<Eigen::Index>(num_vars))); // constant term
 			for (size_t c = 0; c < num_vars; ++c)
 			{
-				mpfr_complex const& coeff = M(r, static_cast<Eigen::Index>(c));
+				complex_mp const& coeff = M(r, static_cast<Eigen::Index>(c));
 				if (coeff.real() == 0 && coeff.imag() == 0)
 					continue;
 				form = form + node::Complex::Make(coeff) * vars[c];
@@ -985,7 +985,7 @@ namespace bertini
 						Nd gi = nullptr;
 						for (size_t j = 0; j < N; ++j)
 						{
-							mpfr_complex const& c = R(static_cast<Eigen::Index>(i), static_cast<Eigen::Index>(j));
+							complex_mp const& c = R(static_cast<Eigen::Index>(i), static_cast<Eigen::Index>(j));
 							if (c.real() == 0 && c.imag() == 0)
 								continue;
 							Nd term = Complex::Make(c) * fj[j];
@@ -1017,7 +1017,7 @@ namespace bertini
 							Nd form = nullptr;
 							for (size_t c = 0; c < n; ++c)
 							{
-								mpfr_complex const& coeff = M(r, static_cast<Eigen::Index>(c));
+								complex_mp const& coeff = M(r, static_cast<Eigen::Index>(c));
 								if (coeff.real() == 0 && coeff.imag() == 0)
 									continue;
 								Nd term = node::Complex::Make(coeff) * vars[c];
@@ -1084,7 +1084,7 @@ namespace bertini
 	} // anonymous namespace
 
 
-	System System::AssembleRandomized(std::shared_ptr<System> operand, Mat<mpfr_complex> coefficients) const
+	System System::AssembleRandomized(std::shared_ptr<System> operand, Mat<complex_mp> coefficients) const
 	{
 		const size_t G = operand->NumVariableGroups();
 		const size_t N = operand->NumNaturalFunctions();
@@ -1103,7 +1103,7 @@ namespace bertini
 		for (size_t i = 0; i < n; ++i)
 			for (size_t j = 0; j < N; ++j)
 			{
-				mpfr_complex const& c = coefficients(static_cast<Eigen::Index>(i), static_cast<Eigen::Index>(j));
+				complex_mp const& c = coefficients(static_cast<Eigen::Index>(i), static_cast<Eigen::Index>(j));
 				if (c.real() == 0 && c.imag() == 0)
 					continue;
 				for (size_t g = 0; g < G; ++g)
@@ -1132,7 +1132,7 @@ namespace bertini
 
 		auto operand = std::make_shared<System>(*this);
 
-		Mat<mpfr_complex> R(static_cast<Eigen::Index>(n), static_cast<Eigen::Index>(N));
+		Mat<complex_mp> R(static_cast<Eigen::Index>(n), static_cast<Eigen::Index>(N));
 
 		if (G == 1)
 		{
@@ -1146,7 +1146,7 @@ namespace bertini
 				{
 					if (j < n)
 						R(static_cast<Eigen::Index>(i), static_cast<Eigen::Index>(j)) =
-							(i == j) ? mpfr_complex(1) : mpfr_complex(0);
+							(i == j) ? complex_mp(1) : complex_mp(0);
 					else
 						R(static_cast<Eigen::Index>(i), static_cast<Eigen::Index>(j)) =
 							bertini::multiprecision::RandomComplex(DefaultPrecision());
@@ -1166,7 +1166,7 @@ namespace bertini
 	}
 
 
-	System System::Randomize(Mat<mpfr_complex> const& R) const
+	System System::Randomize(Mat<complex_mp> const& R) const
 	{
 		if (static_cast<size_t>(R.cols()) != NumNaturalFunctions())
 			throw std::runtime_error("Randomize: supplied matrix must have one column per natural function of the system.");
@@ -1175,7 +1175,7 @@ namespace bertini
 	}
 
 
-	Mat<mpfr_complex> System::RandomizationMatrix() const
+	Mat<complex_mp> System::RandomizationMatrix() const
 	{
 		for (auto const& b : blocks_)
 			if (auto const* rb = std::get_if<blocks::RandomizationBlock<System>>(&b))
@@ -1688,40 +1688,40 @@ namespace bertini
 
 	// Explicit instantiation definitions — paired with extern template declarations in system.hpp.
 
-	template void System::EvalInPlace<dbl>(Vec<dbl>&) const;
-	template void System::EvalInPlace<mpfr_complex>(Vec<mpfr_complex>&) const;
+	template void System::EvalInPlace<complex_dbl>(Vec<complex_dbl>&) const;
+	template void System::EvalInPlace<complex_mp>(Vec<complex_mp>&) const;
 
-	template Vec<dbl> System::Eval<dbl>() const;
-	template Vec<mpfr_complex> System::Eval<mpfr_complex>() const;
+	template Vec<complex_dbl> System::Eval<complex_dbl>() const;
+	template Vec<complex_mp> System::Eval<complex_mp>() const;
 
-	template void System::JacobianInPlace<dbl>(Mat<dbl>&) const;
-	template void System::JacobianInPlace<mpfr_complex>(Mat<mpfr_complex>&) const;
+	template void System::JacobianInPlace<complex_dbl>(Mat<complex_dbl>&) const;
+	template void System::JacobianInPlace<complex_mp>(Mat<complex_mp>&) const;
 
-	template Mat<dbl> System::Jacobian<dbl>() const;
-	template Mat<mpfr_complex> System::Jacobian<mpfr_complex>() const;
+	template Mat<complex_dbl> System::Jacobian<complex_dbl>() const;
+	template Mat<complex_mp> System::Jacobian<complex_mp>() const;
 
-	template Mat<dbl> System::Jacobian<dbl>(const Vec<dbl>&) const;
-	template Mat<mpfr_complex> System::Jacobian<mpfr_complex>(const Vec<mpfr_complex>&) const;
+	template Mat<complex_dbl> System::Jacobian<complex_dbl>(const Vec<complex_dbl>&) const;
+	template Mat<complex_mp> System::Jacobian<complex_mp>(const Vec<complex_mp>&) const;
 
-	template void System::JacobianInPlace<dbl>(Mat<dbl>&, const Vec<dbl>&) const;
-	template void System::JacobianInPlace<mpfr_complex>(Mat<mpfr_complex>&, const Vec<mpfr_complex>&) const;
+	template void System::JacobianInPlace<complex_dbl>(Mat<complex_dbl>&, const Vec<complex_dbl>&) const;
+	template void System::JacobianInPlace<complex_mp>(Mat<complex_mp>&, const Vec<complex_mp>&) const;
 
-	template void System::TimeDerivativeInPlace<dbl>(Vec<dbl>&) const;
-	template void System::TimeDerivativeInPlace<mpfr_complex>(Vec<mpfr_complex>&) const;
+	template void System::TimeDerivativeInPlace<complex_dbl>(Vec<complex_dbl>&) const;
+	template void System::TimeDerivativeInPlace<complex_mp>(Vec<complex_mp>&) const;
 
-	template Vec<dbl> System::TimeDerivative<dbl>() const;
-	template Vec<mpfr_complex> System::TimeDerivative<mpfr_complex>() const;
+	template Vec<complex_dbl> System::TimeDerivative<complex_dbl>() const;
+	template Vec<complex_mp> System::TimeDerivative<complex_mp>() const;
 
-	template void System::SetVariables<dbl>(const Vec<dbl>&) const;
-	template void System::SetVariables<mpfr_complex>(const Vec<mpfr_complex>&) const;
+	template void System::SetVariables<complex_dbl>(const Vec<complex_dbl>&) const;
+	template void System::SetVariables<complex_mp>(const Vec<complex_mp>&) const;
 
-	template void System::SetPathVariable<dbl>(dbl const&) const;
-	template void System::SetPathVariable<mpfr_complex>(mpfr_complex const&) const;
+	template void System::SetPathVariable<complex_dbl>(complex_dbl const&) const;
+	template void System::SetPathVariable<complex_mp>(complex_mp const&) const;
 
-	template void System::SetAndReset<dbl>(Vec<dbl> const&, dbl const&) const;
-	template void System::SetAndReset<mpfr_complex>(Vec<mpfr_complex> const&, mpfr_complex const&) const;
+	template void System::SetAndReset<complex_dbl>(Vec<complex_dbl> const&, complex_dbl const&) const;
+	template void System::SetAndReset<complex_mp>(Vec<complex_mp> const&, complex_mp const&) const;
 
-	template void System::SetAndReset<dbl>(Vec<dbl> const&) const;
-	template void System::SetAndReset<mpfr_complex>(Vec<mpfr_complex> const&) const;
+	template void System::SetAndReset<complex_dbl>(Vec<complex_dbl> const&) const;
+	template void System::SetAndReset<complex_mp>(Vec<complex_mp> const&) const;
 
 }

--- a/core/src/tracking/explicit_predictors.cpp
+++ b/core/src/tracking/explicit_predictors.cpp
@@ -301,62 +301,62 @@ const Eigen::Matrix<mpq_rational,10,1> ExplicitRKPredictor::cRKV67_(cRKV67Ptr_);
 		// These pair with the extern template declarations in explicit_predictors.hpp
 		// and prevent each including TU from emitting its own copy.
 
-		template SuccessCode ExplicitRKPredictor::Predict<dbl>(
-		    Vec<dbl>&, System const&, Vec<dbl> const&, dbl, dbl const&,
+		template SuccessCode ExplicitRKPredictor::Predict<complex_dbl>(
+		    Vec<complex_dbl>&, System const&, Vec<complex_dbl> const&, complex_dbl, complex_dbl const&,
 		    double&, unsigned&, unsigned, double const&);
-		template SuccessCode ExplicitRKPredictor::Predict<mpfr_complex>(
-		    Vec<mpfr_complex>&, System const&, Vec<mpfr_complex> const&, mpfr_complex, mpfr_complex const&,
+		template SuccessCode ExplicitRKPredictor::Predict<complex_mp>(
+		    Vec<complex_mp>&, System const&, Vec<complex_mp> const&, complex_mp, complex_mp const&,
 		    double&, unsigned&, unsigned, double const&);
 
-		template SuccessCode ExplicitRKPredictor::Predict<dbl>(
-		    Vec<dbl>&, double&, double&, double&,
-		    System const&, Vec<dbl> const&, dbl, dbl const&,
+		template SuccessCode ExplicitRKPredictor::Predict<complex_dbl>(
+		    Vec<complex_dbl>&, double&, double&, double&,
+		    System const&, Vec<complex_dbl> const&, complex_dbl, complex_dbl const&,
 		    double&, unsigned&, unsigned, double const&, AdaptiveMultiplePrecisionConfig const&);
-		template SuccessCode ExplicitRKPredictor::Predict<mpfr_complex>(
-		    Vec<mpfr_complex>&, double&, double&, double&,
-		    System const&, Vec<mpfr_complex> const&, mpfr_complex, mpfr_complex const&,
-		    double&, unsigned&, unsigned, double const&, AdaptiveMultiplePrecisionConfig const&);
-
-		template SuccessCode ExplicitRKPredictor::Predict<dbl>(
-		    Vec<dbl>&, double&, double&, double&, double&,
-		    System const&, Vec<dbl> const&, dbl, dbl const&,
-		    double&, unsigned&, unsigned, double const&, AdaptiveMultiplePrecisionConfig const&);
-		template SuccessCode ExplicitRKPredictor::Predict<mpfr_complex>(
-		    Vec<mpfr_complex>&, double&, double&, double&, double&,
-		    System const&, Vec<mpfr_complex> const&, mpfr_complex, mpfr_complex const&,
+		template SuccessCode ExplicitRKPredictor::Predict<complex_mp>(
+		    Vec<complex_mp>&, double&, double&, double&,
+		    System const&, Vec<complex_mp> const&, complex_mp, complex_mp const&,
 		    double&, unsigned&, unsigned, double const&, AdaptiveMultiplePrecisionConfig const&);
 
-		template SuccessCode ExplicitRKPredictor::FullStep<dbl>(
-		    Vec<dbl>&, System const&, Vec<dbl> const&, dbl const&, dbl const&);
-		template SuccessCode ExplicitRKPredictor::FullStep<mpfr_complex>(
-		    Vec<mpfr_complex>&, System const&, Vec<mpfr_complex> const&, mpfr_complex const&, mpfr_complex const&);
+		template SuccessCode ExplicitRKPredictor::Predict<complex_dbl>(
+		    Vec<complex_dbl>&, double&, double&, double&, double&,
+		    System const&, Vec<complex_dbl> const&, complex_dbl, complex_dbl const&,
+		    double&, unsigned&, unsigned, double const&, AdaptiveMultiplePrecisionConfig const&);
+		template SuccessCode ExplicitRKPredictor::Predict<complex_mp>(
+		    Vec<complex_mp>&, double&, double&, double&, double&,
+		    System const&, Vec<complex_mp> const&, complex_mp, complex_mp const&,
+		    double&, unsigned&, unsigned, double const&, AdaptiveMultiplePrecisionConfig const&);
 
-		template void ExplicitRKPredictor::SetNormsCond<dbl>(
+		template SuccessCode ExplicitRKPredictor::FullStep<complex_dbl>(
+		    Vec<complex_dbl>&, System const&, Vec<complex_dbl> const&, complex_dbl const&, complex_dbl const&);
+		template SuccessCode ExplicitRKPredictor::FullStep<complex_mp>(
+		    Vec<complex_mp>&, System const&, Vec<complex_mp> const&, complex_mp const&, complex_mp const&);
+
+		template void ExplicitRKPredictor::SetNormsCond<complex_dbl>(
 		    double&, double&, double&, unsigned, unsigned);
-		template void ExplicitRKPredictor::SetNormsCond<mpfr_complex>(
+		template void ExplicitRKPredictor::SetNormsCond<complex_mp>(
 		    double&, double&, double&, unsigned, unsigned);
 
-		template SuccessCode ExplicitRKPredictor::SetErrorEstimate<dbl>(double&, dbl const&);
-		template SuccessCode ExplicitRKPredictor::SetErrorEstimate<mpfr_complex>(double&, mpfr_complex const&);
+		template SuccessCode ExplicitRKPredictor::SetErrorEstimate<complex_dbl>(double&, complex_dbl const&);
+		template SuccessCode ExplicitRKPredictor::SetErrorEstimate<complex_mp>(double&, complex_mp const&);
 
-		template SuccessCode ExplicitRKPredictor::SetSizeProportion<dbl>(double&, dbl const&);
-		template SuccessCode ExplicitRKPredictor::SetSizeProportion<mpfr_complex>(double&, mpfr_complex const&);
+		template SuccessCode ExplicitRKPredictor::SetSizeProportion<complex_dbl>(double&, complex_dbl const&);
+		template SuccessCode ExplicitRKPredictor::SetSizeProportion<complex_mp>(double&, complex_mp const&);
 
-		template SuccessCode ExplicitRKPredictor::EvalRHS<dbl>(
-		    System const&, Vec<dbl> const&, dbl const&, Mat<dbl>&, unsigned);
-		template SuccessCode ExplicitRKPredictor::EvalRHS<mpfr_complex>(
-		    System const&, Vec<mpfr_complex> const&, mpfr_complex const&, Mat<mpfr_complex>&, unsigned);
+		template SuccessCode ExplicitRKPredictor::EvalRHS<complex_dbl>(
+		    System const&, Vec<complex_dbl> const&, complex_dbl const&, Mat<complex_dbl>&, unsigned);
+		template SuccessCode ExplicitRKPredictor::EvalRHS<complex_mp>(
+		    System const&, Vec<complex_mp> const&, complex_mp const&, Mat<complex_mp>&, unsigned);
 
 		template void ExplicitRKPredictor::FillButcherTable<double>(
 		    int, Mat<mpq_rational> const&, Mat<mpq_rational> const&,
 		    Mat<mpq_rational> const&, Mat<mpq_rational> const&);
-		template void ExplicitRKPredictor::FillButcherTable<mpfr_float>(
+		template void ExplicitRKPredictor::FillButcherTable<real_mp>(
 		    int, Mat<mpq_rational> const&, Mat<mpq_rational> const&,
 		    Mat<mpq_rational> const&, Mat<mpq_rational> const&);
 
 		template void ExplicitRKPredictor::FillButcherTable<double>(
 		    int, Mat<mpq_rational> const&, Mat<mpq_rational> const&, Mat<mpq_rational> const&);
-		template void ExplicitRKPredictor::FillButcherTable<mpfr_float>(
+		template void ExplicitRKPredictor::FillButcherTable<real_mp>(
 		    int, Mat<mpq_rational> const&, Mat<mpq_rational> const&, Mat<mpq_rational> const&);
 
 		} // re: predict

--- a/core/test/blackbox/parsing.cpp
+++ b/core/test/blackbox/parsing.cpp
@@ -35,13 +35,13 @@ BOOST_AUTO_TEST_SUITE(blackbox_test)
 BOOST_AUTO_TEST_SUITE(parsing_configs)
 
 using namespace bertini;
-using mpfr = bertini::mpfr_complex;
-using dbl = bertini::dbl;
+using mpfr = bertini::complex_mp;
+using complex_dbl = bertini::complex_dbl;
  
 BOOST_AUTO_TEST_CASE(parse1)
 {
 	
-	using AllConfsD = blackbox::config::Configs::All<dbl>::type;
+	using AllConfsD = blackbox::config::Configs::All<complex_dbl>::type;
 	using AllConfsMP = blackbox::config::Configs::All<mpfr>::type;
 
 std::string config = 
@@ -114,14 +114,14 @@ BOOST_AUTO_TEST_SUITE_END() // end parser_errors suite
 
 BOOST_AUTO_TEST_SUITE(unary_minus_precedence)
 
-using dbl = bertini::dbl;
+using complex_dbl = bertini::complex_dbl;
 
 namespace {
 	// parse "f = <expr>" over variable_group x,y,z and evaluate at the given point
-	dbl ParseEval(std::string const& expr, dbl x, dbl y, dbl z)
+	complex_dbl ParseEval(std::string const& expr, complex_dbl x, complex_dbl y, complex_dbl z)
 	{
 		bertini::System s{"variable_group x, y, z;\nfunction f;\nf = " + expr + ";"};
-		bertini::Vec<dbl> pt(3);
+		bertini::Vec<complex_dbl> pt(3);
 		pt << x, y, z;
 		return s.Eval(pt)(0);
 	}
@@ -132,39 +132,39 @@ namespace {
 // factor_, so "-y+x" is (-y)+x and "-x^2" is -(x^2).
 BOOST_AUTO_TEST_CASE(leading_minus_negates_only_its_operand)
 {
-	const dbl x(2,0), y(5,0), z(3,0);
+	const complex_dbl x(2,0), y(5,0), z(3,0);
 	// "-y+x" == x-y == -3, NOT -(y+x) == -7
 	BOOST_CHECK_SMALL(std::abs(ParseEval("-y+x", x,y,z) - ParseEval("x-y", x,y,z)), 1e-12);
-	BOOST_CHECK_SMALL(std::abs(ParseEval("-y+x", x,y,z) - dbl(-3,0)),               1e-12);
+	BOOST_CHECK_SMALL(std::abs(ParseEval("-y+x", x,y,z) - complex_dbl(-3,0)),               1e-12);
 }
 
 BOOST_AUTO_TEST_CASE(leading_minus_on_a_parenthesized_sum)
 {
-	const dbl x(2,0), y(5,0), z(3,0);
+	const complex_dbl x(2,0), y(5,0), z(3,0);
 	// the bug found via round-tripping: "-(y-z)+x" == x-(y-z) == 0, NOT -((y-z)+x)
 	BOOST_CHECK_SMALL(std::abs(ParseEval("-(y-z)+x", x,y,z) - ParseEval("x-(y-z)", x,y,z)), 1e-12);
-	BOOST_CHECK_SMALL(std::abs(ParseEval("-(y-z)+x", x,y,z) - dbl(0,0)),                    1e-12);
+	BOOST_CHECK_SMALL(std::abs(ParseEval("-(y-z)+x", x,y,z) - complex_dbl(0,0)),                    1e-12);
 }
 
 BOOST_AUTO_TEST_CASE(all_negative_sum_is_unchanged)
 {
-	const dbl x(2,0), y(5,0), z(3,0);
+	const complex_dbl x(2,0), y(5,0), z(3,0);
 	// "-y-x" == -(y+x) == -7 (here the greedy reading happened to agree)
-	BOOST_CHECK_SMALL(std::abs(ParseEval("-y-x", x,y,z) - dbl(-7,0)), 1e-12);
+	BOOST_CHECK_SMALL(std::abs(ParseEval("-y-x", x,y,z) - complex_dbl(-7,0)), 1e-12);
 }
 
 BOOST_AUTO_TEST_CASE(unary_minus_binds_looser_than_power)
 {
-	const dbl x(2,0), y(5,0), z(3,0);
+	const complex_dbl x(2,0), y(5,0), z(3,0);
 	// "-x^2" == -(x^2) == -4, NOT (-x)^2 == 4
-	BOOST_CHECK_SMALL(std::abs(ParseEval("-x^2", x,y,z) - dbl(-4,0)), 1e-12);
+	BOOST_CHECK_SMALL(std::abs(ParseEval("-x^2", x,y,z) - complex_dbl(-4,0)), 1e-12);
 }
 
 BOOST_AUTO_TEST_CASE(unary_minus_then_product)
 {
-	const dbl x(2,0), y(5,0), z(3,0);
+	const complex_dbl x(2,0), y(5,0), z(3,0);
 	// "-x*y" == -(x*y) == -10
-	BOOST_CHECK_SMALL(std::abs(ParseEval("-x*y", x,y,z) - dbl(-10,0)), 1e-12);
+	BOOST_CHECK_SMALL(std::abs(ParseEval("-x*y", x,y,z) - complex_dbl(-10,0)), 1e-12);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // unary_minus_precedence

--- a/core/test/blackbox/user_homotopy.cpp
+++ b/core/test/blackbox/user_homotopy.cpp
@@ -33,7 +33,7 @@ BOOST_AUTO_TEST_SUITE(blackbox_test)
 BOOST_AUTO_TEST_SUITE(user_hom)
 
 using namespace bertini;
-using mpfr = bertini::mpfr_complex;
+using mpfr = bertini::complex_mp;
 
 
 

--- a/core/test/classes/blend_block_test.cpp
+++ b/core/test/classes/blend_block_test.cpp
@@ -71,9 +71,9 @@ BOOST_AUTO_TEST_CASE(eval_double)
 	DefaultPrecision(30);
 	auto blend = MakeTestBlend();
 
-	bertini::Vec<dbl> x(2); x << dbl(1), dbl(1);
-	bertini::Vec<dbl> result(1);
-	blend.EvalInPlace<dbl>(result, x, dbl(0.5));
+	bertini::Vec<complex_dbl> x(2); x << complex_dbl(1), complex_dbl(1);
+	bertini::Vec<complex_dbl> result(1);
+	blend.EvalInPlace<complex_dbl>(result, x, complex_dbl(0.5));
 
 	BOOST_CHECK_CLOSE(result(0).real(), 2.0, 1e-11);
 	BOOST_CHECK_SMALL(result(0).imag(), 1e-11);
@@ -84,9 +84,9 @@ BOOST_AUTO_TEST_CASE(jacobian_double)
 	DefaultPrecision(30);
 	auto blend = MakeTestBlend();
 
-	bertini::Vec<dbl> x(2); x << dbl(1), dbl(1);
-	bertini::Mat<dbl> J(1, 2);
-	blend.JacobianInPlace<dbl>(J, x, dbl(0.5));
+	bertini::Vec<complex_dbl> x(2); x << complex_dbl(1), complex_dbl(1);
+	bertini::Mat<complex_dbl> J(1, 2);
+	blend.JacobianInPlace<complex_dbl>(J, x, complex_dbl(0.5));
 
 	BOOST_CHECK_CLOSE(J(0, 0).real(), 1.0, 1e-11);
 	BOOST_CHECK_CLOSE(J(0, 1).real(), 1.5, 1e-11);
@@ -97,9 +97,9 @@ BOOST_AUTO_TEST_CASE(time_derivative_double)
 	DefaultPrecision(30);
 	auto blend = MakeTestBlend();
 
-	bertini::Vec<dbl> x(2); x << dbl(1), dbl(1);
-	bertini::Vec<dbl> dHdt(1);
-	blend.TimeDerivInPlace<dbl>(dHdt, x, dbl(0.5));
+	bertini::Vec<complex_dbl> x(2); x << complex_dbl(1), complex_dbl(1);
+	bertini::Vec<complex_dbl> dHdt(1);
+	blend.TimeDerivInPlace<complex_dbl>(dHdt, x, complex_dbl(0.5));
 
 	BOOST_CHECK_CLOSE(dHdt(0).real(), -2.0, 1e-11);
 }
@@ -110,16 +110,16 @@ BOOST_AUTO_TEST_CASE(eval_and_time_derivative_mpfr)
 	auto blend = MakeTestBlend();
 	blend.Precision(30);
 
-	bertini::Vec<mpfr_complex> x(2); x << mpfr_complex(1), mpfr_complex(1);
-	mpfr_complex t("0.5");
+	bertini::Vec<complex_mp> x(2); x << complex_mp(1), complex_mp(1);
+	complex_mp t("0.5");
 
-	bertini::Vec<mpfr_complex> result(1);
-	blend.EvalInPlace<mpfr_complex>(result, x, t);
-	BOOST_CHECK(abs(result(0) - mpfr_complex(2)) < mpfr_float("1e-25"));
+	bertini::Vec<complex_mp> result(1);
+	blend.EvalInPlace<complex_mp>(result, x, t);
+	BOOST_CHECK(abs(result(0) - complex_mp(2)) < real_mp("1e-25"));
 
-	bertini::Vec<mpfr_complex> dHdt(1);
-	blend.TimeDerivInPlace<mpfr_complex>(dHdt, x, t);
-	BOOST_CHECK(abs(dHdt(0) - mpfr_complex(-2)) < mpfr_float("1e-25"));
+	bertini::Vec<complex_mp> dHdt(1);
+	blend.TimeDerivInPlace<complex_mp>(dHdt, x, t);
+	BOOST_CHECK(abs(dHdt(0) - complex_mp(-2)) < real_mp("1e-25"));
 }
 
 // The coefficients are evaluated through a cached coefficient System (compiled once,
@@ -130,22 +130,22 @@ BOOST_AUTO_TEST_CASE(repeated_evaluation_reuses_coefficients_consistently)
 	DefaultPrecision(30);
 	auto blend = MakeTestBlend();
 
-	bertini::Vec<dbl> x(2); x << dbl(1), dbl(1);
-	bertini::Vec<dbl> result(1);
+	bertini::Vec<complex_dbl> x(2); x << complex_dbl(1), complex_dbl(1);
+	bertini::Vec<complex_dbl> result(1);
 
 	// First call builds the cached coefficient system; subsequent calls reuse it.
-	blend.EvalInPlace<dbl>(result, x, dbl(0.5));
+	blend.EvalInPlace<complex_dbl>(result, x, complex_dbl(0.5));
 	BOOST_CHECK_CLOSE(result(0).real(), 2.0, 1e-11);
 
-	blend.EvalInPlace<dbl>(result, x, dbl(0.5));
+	blend.EvalInPlace<complex_dbl>(result, x, complex_dbl(0.5));
 	BOOST_CHECK_CLOSE(result(0).real(), 2.0, 1e-11);
 
 	// A different path value: H = (1-t)*3 + t*1 = 3 - 2t; at t=0 -> 3.
-	blend.EvalInPlace<dbl>(result, x, dbl(0.0));
+	blend.EvalInPlace<complex_dbl>(result, x, complex_dbl(0.0));
 	BOOST_CHECK_CLOSE(result(0).real(), 3.0, 1e-11);
 
 	// And at t=1 -> 1.
-	blend.EvalInPlace<dbl>(result, x, dbl(1.0));
+	blend.EvalInPlace<complex_dbl>(result, x, complex_dbl(1.0));
 	BOOST_CHECK_CLOSE(result(0).real(), 1.0, 1e-11);
 }
 

--- a/core/test/classes/boost_multiprecision_test.cpp
+++ b/core/test/classes/boost_multiprecision_test.cpp
@@ -1,7 +1,7 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/multiprecision/mpc.hpp>
 
-using mpfr_float = boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<0>, boost::multiprecision::et_on>;
+using real_mp = boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<0>, boost::multiprecision::et_on>;
 using mpz_int = boost::multiprecision::number<boost::multiprecision::backends::gmp_int, boost::multiprecision::et_on>;
 using mpq_rational = boost::multiprecision::number<boost::multiprecision::backends::gmp_rational, boost::multiprecision::et_on>;
 using mpc_complex = boost::multiprecision::number<boost::multiprecision::backends::mpc_complex_backend<0>, boost::multiprecision::et_on>;
@@ -233,7 +233,7 @@ BOOST_AUTO_TEST_CASE(precision_complex_rational_div_other_order, *utf::depends_o
 
 BOOST_AUTO_TEST_CASE(precision_complex_longlong_div_set_float_16digits)
 {
-	mpfr_float::default_precision(30);
+	real_mp::default_precision(30);
 	mpc_complex::default_precision(16);
 
 	mpc_complex b(1,0);
@@ -261,7 +261,7 @@ BOOST_AUTO_TEST_CASE(precision_complex_longlong_div_set_complex_16digits, *utf::
 
 BOOST_AUTO_TEST_CASE(precision_complex_longlong_div_set_both_16digits, *utf::depends_on("boost_multiprecision/precision_complex_longlong_div_set_complex_16digits"))
 {
-	mpfr_float::default_precision(16);
+	real_mp::default_precision(16);
 	mpc_complex::default_precision(16);
 
 	mpc_complex b(1,0);
@@ -274,7 +274,7 @@ BOOST_AUTO_TEST_CASE(precision_complex_longlong_div_set_both_16digits, *utf::dep
 
 BOOST_AUTO_TEST_CASE(precision_complex_longlong_div_set_float20_complex16, *utf::depends_on("boost_multiprecision/precision_complex_longlong_div_set_both_16digits"))
 {
-	mpfr_float::default_precision(20);
+	real_mp::default_precision(20);
 	mpc_complex::default_precision(16);
 
 	mpc_complex b(1,0);
@@ -290,7 +290,7 @@ BOOST_AUTO_TEST_CASE(precision_complex_longlong_div_set_float20_complex16, *utf:
 
 BOOST_AUTO_TEST_CASE(precision_complex_longlong_div_set_float16_complex20, *utf::depends_on("boost_multiprecision/precision_complex_longlong_div_set_float20_complex16"))
 {
-	mpfr_float::default_precision(16);
+	real_mp::default_precision(16);
 	mpc_complex::default_precision(20);
 
 	mpc_complex b(1,0);
@@ -305,7 +305,7 @@ BOOST_AUTO_TEST_CASE(precision_complex_longlong_div_set_float16_complex20, *utf:
 
 BOOST_AUTO_TEST_CASE(precision_complex_longlong_div_set_float20_complex20)
 {
-	mpfr_float::default_precision(20);
+	real_mp::default_precision(20);
 	mpc_complex::default_precision(20);
 
 	mpc_complex b(1,0);
@@ -356,17 +356,17 @@ BOOST_AUTO_TEST_CASE(precision_complex_longlong_div_set_float20_complex20)
 struct scoped_mpfr_precision_options_all_threads
 {
    boost::multiprecision::variable_precision_options saved_options;
-   scoped_mpfr_precision_options_all_threads(boost::multiprecision::variable_precision_options opts) : saved_options(mpfr_float::default_variable_precision_options())
+   scoped_mpfr_precision_options_all_threads(boost::multiprecision::variable_precision_options opts) : saved_options(real_mp::default_variable_precision_options())
    {
-      mpfr_float::default_variable_precision_options(opts);
+      real_mp::default_variable_precision_options(opts);
    }
    ~scoped_mpfr_precision_options_all_threads()
    {
-      mpfr_float::default_variable_precision_options(saved_options);
+      real_mp::default_variable_precision_options(saved_options);
    }
    void reset(boost::multiprecision::variable_precision_options opts)
    {
-      mpfr_float::default_variable_precision_options(opts);
+      real_mp::default_variable_precision_options(opts);
    }
 };
 
@@ -377,17 +377,17 @@ struct scoped_mpfr_precision_options_all_threads
 struct scoped_mpfr_precision_options_this_thread
 {
    boost::multiprecision::variable_precision_options saved_options;
-   scoped_mpfr_precision_options_this_thread(boost::multiprecision::variable_precision_options opts) : saved_options(mpfr_float::thread_default_variable_precision_options())
+   scoped_mpfr_precision_options_this_thread(boost::multiprecision::variable_precision_options opts) : saved_options(real_mp::thread_default_variable_precision_options())
    {
-      mpfr_float::thread_default_variable_precision_options(opts);
+      real_mp::thread_default_variable_precision_options(opts);
    }
    ~scoped_mpfr_precision_options_this_thread()
    {
-      mpfr_float::thread_default_variable_precision_options(saved_options);
+      real_mp::thread_default_variable_precision_options(saved_options);
    }
    void reset(boost::multiprecision::variable_precision_options opts)
    {
-      mpfr_float::thread_default_variable_precision_options(opts);
+      real_mp::thread_default_variable_precision_options(opts);
    }
 };
 
@@ -411,7 +411,7 @@ BOOST_AUTO_TEST_CASE(precision_opts_all_threads_affect_current_thread)
 
 	scoped_mpfr_precision_options_all_threads scoped_opts_all(boost::multiprecision::variable_precision_options::preserve_source_precision);
 
-	bool options_match = mpfr_float::default_variable_precision_options() == mpfr_float::thread_default_variable_precision_options();
+	bool options_match = real_mp::default_variable_precision_options() == real_mp::thread_default_variable_precision_options();
 	BOOST_CHECK(options_match && "there's a bug in Boost.Multiprecision in 1.82 and below: default_variable_precision_options() doesn't affect the current thread.  see https://github.com/boostorg/multiprecision/issues/551");
 }
 
@@ -429,22 +429,22 @@ BOOST_AUTO_TEST_CASE(arithmetic_precision_fresh_variable_all_threads_preserve_ta
 
 
 
-	mpfr_float::default_precision(50);
-	mpfr_float x("0.01234567890123456789012345678901234567890123456789");
+	real_mp::default_precision(50);
+	real_mp x("0.01234567890123456789012345678901234567890123456789");
 	BOOST_CHECK_EQUAL(x.precision(), 50);
 
 
-	mpfr_float::default_precision(60);
-	mpfr_float y("0.12345678901234567890123456789012345678901234567890123");
+	real_mp::default_precision(60);
+	real_mp y("0.12345678901234567890123456789012345678901234567890123");
 	BOOST_CHECK_EQUAL(y.precision(), 60);
 
 
-	mpfr_float w(0);
+	real_mp w(0);
 
-	mpfr_float::default_precision(30);
+	real_mp::default_precision(30);
 	scoped_mpfr_precision_options_all_threads scoped_opts(boost::multiprecision::variable_precision_options::preserve_target_precision);
 	
-	mpfr_float z = x*y;
+	real_mp z = x*y;
 
 	BOOST_CHECK_EQUAL(x.precision(), 50);
 	BOOST_CHECK_EQUAL(y.precision(), 60);
@@ -465,21 +465,21 @@ BOOST_AUTO_TEST_CASE(arithmetic_precision_fresh_variable_all_threads_preserve_so
 
 
 
-	mpfr_float::default_precision(50);
-	mpfr_float x("0.01234567890123456789012345678901234567890123456789");
+	real_mp::default_precision(50);
+	real_mp x("0.01234567890123456789012345678901234567890123456789");
 	BOOST_CHECK_EQUAL(x.precision(), 50);
 
 
-	mpfr_float::default_precision(60);
-	mpfr_float y("0.12345678901234567890123456789012345678901234567890123");
+	real_mp::default_precision(60);
+	real_mp y("0.12345678901234567890123456789012345678901234567890123");
 	BOOST_CHECK_EQUAL(y.precision(), 60);
 
 
 
-	mpfr_float::default_precision(30);
+	real_mp::default_precision(30);
 	scoped_mpfr_precision_options_all_threads scoped_opts(boost::multiprecision::variable_precision_options::preserve_source_precision);
 	
-	mpfr_float z = x*y;
+	real_mp z = x*y;
 
 	BOOST_CHECK_EQUAL(x.precision(), 50);
 	BOOST_CHECK_EQUAL(y.precision(), 60);
@@ -497,21 +497,21 @@ BOOST_AUTO_TEST_CASE(arithmetic_precision_fresh_variable_all_threads_preserve_co
 
 
 
-	mpfr_float::default_precision(50);
-	mpfr_float x("0.01234567890123456789012345678901234567890123456789");
+	real_mp::default_precision(50);
+	real_mp x("0.01234567890123456789012345678901234567890123456789");
 	BOOST_CHECK_EQUAL(x.precision(), 50);
 
 
-	mpfr_float::default_precision(60);
-	mpfr_float y("0.12345678901234567890123456789012345678901234567890123");
+	real_mp::default_precision(60);
+	real_mp y("0.12345678901234567890123456789012345678901234567890123");
 	BOOST_CHECK_EQUAL(y.precision(), 60);
 
 
 
-	mpfr_float::default_precision(30);
+	real_mp::default_precision(30);
 	scoped_mpfr_precision_options_all_threads scoped_opts(boost::multiprecision::variable_precision_options::preserve_component_precision);
 	
-	mpfr_float z = x*y;
+	real_mp z = x*y;
 
 	BOOST_CHECK_EQUAL(x.precision(), 50);
 	BOOST_CHECK_EQUAL(y.precision(), 60);
@@ -527,21 +527,21 @@ BOOST_AUTO_TEST_CASE(arithmetic_precision_fresh_variable_all_threads_preserve_re
 
 
 
-	mpfr_float::default_precision(50);
-	mpfr_float x("0.01234567890123456789012345678901234567890123456789");
+	real_mp::default_precision(50);
+	real_mp x("0.01234567890123456789012345678901234567890123456789");
 	BOOST_CHECK_EQUAL(x.precision(), 50);
 
 
-	mpfr_float::default_precision(60);
-	mpfr_float y("0.12345678901234567890123456789012345678901234567890123");
+	real_mp::default_precision(60);
+	real_mp y("0.12345678901234567890123456789012345678901234567890123");
 	BOOST_CHECK_EQUAL(y.precision(), 60);
 
 
 
-	mpfr_float::default_precision(30);
+	real_mp::default_precision(30);
 	scoped_mpfr_precision_options_all_threads scoped_opts(boost::multiprecision::variable_precision_options::preserve_related_precision);
 	
-	mpfr_float z = x*y;
+	real_mp z = x*y;
 
 	BOOST_CHECK_EQUAL(x.precision(), 50);
 	BOOST_CHECK_EQUAL(y.precision(), 60);
@@ -557,21 +557,21 @@ BOOST_AUTO_TEST_CASE(arithmetic_precision_fresh_variable_all_threads_preserve_al
 
 
 
-	mpfr_float::default_precision(50);
-	mpfr_float x("0.01234567890123456789012345678901234567890123456789");
+	real_mp::default_precision(50);
+	real_mp x("0.01234567890123456789012345678901234567890123456789");
 	BOOST_CHECK_EQUAL(x.precision(), 50);
 
 
-	mpfr_float::default_precision(60);
-	mpfr_float y("0.12345678901234567890123456789012345678901234567890123");
+	real_mp::default_precision(60);
+	real_mp y("0.12345678901234567890123456789012345678901234567890123");
 	BOOST_CHECK_EQUAL(y.precision(), 60);
 
 
 
-	mpfr_float::default_precision(30);
+	real_mp::default_precision(30);
 	scoped_mpfr_precision_options_all_threads scoped_opts(boost::multiprecision::variable_precision_options::preserve_all_precision);
 	
-	mpfr_float z = x*y;
+	real_mp z = x*y;
 
 	BOOST_CHECK_EQUAL(x.precision(), 50);
 	BOOST_CHECK_EQUAL(y.precision(), 60);
@@ -612,26 +612,26 @@ BOOST_AUTO_TEST_CASE(arithmetic_precision_existing_variable_all_threads_preserve
 
 
 
-	mpfr_float::thread_default_precision(50);
-	mpfr_float x("0.01234567890123456789012345678901234567890123456789");
+	real_mp::thread_default_precision(50);
+	real_mp x("0.01234567890123456789012345678901234567890123456789");
 	BOOST_CHECK_EQUAL(x.precision(), 50);
 
 
-	mpfr_float::thread_default_precision(60);
-	mpfr_float y("0.12345678901234567890123456789012345678901234567890123456789");
+	real_mp::thread_default_precision(60);
+	real_mp y("0.12345678901234567890123456789012345678901234567890123456789");
 	BOOST_CHECK_EQUAL(y.precision(), 60);
 
 
 	// make a variable at precision 70
-	mpfr_float::thread_default_precision(70);
-	mpfr_float z("0");
+	real_mp::thread_default_precision(70);
+	real_mp z("0");
 
 	BOOST_CHECK_EQUAL(x.precision(), 50);
 	BOOST_CHECK_EQUAL(y.precision(), 60);
 	BOOST_CHECK_EQUAL(z.precision(), 70);
 
 
-	mpfr_float::thread_default_precision(30);
+	real_mp::thread_default_precision(30);
 	// then try to write into this existing variable with various policies
 
 
@@ -655,19 +655,19 @@ BOOST_AUTO_TEST_CASE(arithmetic_precision_existing_variable_all_threads_preserve
 
 
 
-	mpfr_float::thread_default_precision(50);
-	mpfr_float x("0.01234567890123456789012345678901234567890123456789");
+	real_mp::thread_default_precision(50);
+	real_mp x("0.01234567890123456789012345678901234567890123456789");
 	BOOST_CHECK_EQUAL(x.precision(), 50);
 
 
-	mpfr_float::thread_default_precision(60);
-	mpfr_float y("0.12345678901234567890123456789012345678901234567890123456789");
+	real_mp::thread_default_precision(60);
+	real_mp y("0.12345678901234567890123456789012345678901234567890123456789");
 	BOOST_CHECK_EQUAL(y.precision(), 60);
 
 
 	// make a variable at precision 70
-	mpfr_float::thread_default_precision(70);
-	mpfr_float z("0");
+	real_mp::thread_default_precision(70);
+	real_mp z("0");
 
 
 	BOOST_CHECK_EQUAL(x.precision(), 50);
@@ -676,7 +676,7 @@ BOOST_AUTO_TEST_CASE(arithmetic_precision_existing_variable_all_threads_preserve
 
 
 
-	mpfr_float::thread_default_precision(30);
+	real_mp::thread_default_precision(30);
 	// then try to write into this existing variable with various policies
 
 
@@ -700,26 +700,26 @@ BOOST_AUTO_TEST_CASE(arithmetic_precision_existing_variable_all_threads_preserve
 
 
 
-	mpfr_float::thread_default_precision(50);
-	mpfr_float x("0.01234567890123456789012345678901234567890123456789");
+	real_mp::thread_default_precision(50);
+	real_mp x("0.01234567890123456789012345678901234567890123456789");
 	BOOST_CHECK_EQUAL(x.precision(), 50);
 
 
-	mpfr_float::thread_default_precision(60);
-	mpfr_float y("0.12345678901234567890123456789012345678901234567890123456789");
+	real_mp::thread_default_precision(60);
+	real_mp y("0.12345678901234567890123456789012345678901234567890123456789");
 	BOOST_CHECK_EQUAL(y.precision(), 60);
 
 
 	// make a variable at precision 70
-	mpfr_float::thread_default_precision(70);
-	mpfr_float z("0");
+	real_mp::thread_default_precision(70);
+	real_mp z("0");
 
 	BOOST_CHECK_EQUAL(x.precision(), 50);
 	BOOST_CHECK_EQUAL(y.precision(), 60);
 	BOOST_CHECK_EQUAL(z.precision(), 70);
 
 
-	mpfr_float::thread_default_precision(30);
+	real_mp::thread_default_precision(30);
 	// then try to write into this existing variable with various policies
 
 
@@ -745,30 +745,30 @@ BOOST_AUTO_TEST_CASE(arithmetic_precision_existing_variable_all_threads_preserve
 
 
 
-	mpfr_float::thread_default_precision(50);
-	mpfr_float x("0.01234567890123456789012345678901234567890123456789");
+	real_mp::thread_default_precision(50);
+	real_mp x("0.01234567890123456789012345678901234567890123456789");
 	BOOST_CHECK_EQUAL(x.precision(), 50);
 
 
-	mpfr_float::thread_default_precision(60);
-	mpfr_float y("0.12345678901234567890123456789012345678901234567890123456789");
+	real_mp::thread_default_precision(60);
+	real_mp y("0.12345678901234567890123456789012345678901234567890123456789");
 	BOOST_CHECK_EQUAL(y.precision(), 60);
 
 
 	// make a variable at precision 70
-	mpfr_float::thread_default_precision(70);
-	mpfr_float z("0");
+	real_mp::thread_default_precision(70);
+	real_mp z("0");
 
 	BOOST_CHECK_EQUAL(x.precision(), 50);
 	BOOST_CHECK_EQUAL(y.precision(), 60);
 	BOOST_CHECK_EQUAL(z.precision(), 70);
 
 
-	mpfr_float::thread_default_precision(30);
+	real_mp::thread_default_precision(30);
 	// then try to write into this existing variable with various policies
 
 
-	// All expressions are evaluated at the precision of the highest precision variable within the expression, and that precision is preserved upon assignment. If the expression contains component types then these are also considered when calculating the precision of the expression. In addition to component types, all related types are considered when evaluating the precision of the expression. Related types are considered to be instantiations of the same template, but with different parameters. So for example mpfr_float_100 would be a related type to mpfr_float, and all expressions containing an mpfr_float_100 variable would have at least 100 decimal digits of precision when evaluated as an mpfr_float expression. Moves, are true moves not copies.  
+	// All expressions are evaluated at the precision of the highest precision variable within the expression, and that precision is preserved upon assignment. If the expression contains component types then these are also considered when calculating the precision of the expression. In addition to component types, all related types are considered when evaluating the precision of the expression. Related types are considered to be instantiations of the same template, but with different parameters. So for example mpfr_float_100 would be a related type to real_mp, and all expressions containing an mpfr_float_100 variable would have at least 100 decimal digits of precision when evaluated as an real_mp expression. Moves, are true moves not copies.  
 
 	scoped_mpfr_precision_options_all_threads   scoped_opts(boost::multiprecision::variable_precision_options::preserve_related_precision);
 
@@ -787,26 +787,26 @@ BOOST_AUTO_TEST_CASE(arithmetic_precision_existing_variable_all_threads_preserve
 
 
 
-	mpfr_float::thread_default_precision(50);
-	mpfr_float x("0.01234567890123456789012345678901234567890123456789");
+	real_mp::thread_default_precision(50);
+	real_mp x("0.01234567890123456789012345678901234567890123456789");
 	BOOST_CHECK_EQUAL(x.precision(), 50);
 
 
-	mpfr_float::thread_default_precision(60);
-	mpfr_float y("0.12345678901234567890123456789012345678901234567890123456789");
+	real_mp::thread_default_precision(60);
+	real_mp y("0.12345678901234567890123456789012345678901234567890123456789");
 	BOOST_CHECK_EQUAL(y.precision(), 60);
 
 
 	// make a variable at precision 70
-	mpfr_float::thread_default_precision(70);
-	mpfr_float z("0");
+	real_mp::thread_default_precision(70);
+	real_mp z("0");
 
 	BOOST_CHECK_EQUAL(x.precision(), 50);
 	BOOST_CHECK_EQUAL(y.precision(), 60);
 	BOOST_CHECK_EQUAL(z.precision(), 70);
 
 
-	mpfr_float::thread_default_precision(30);
+	real_mp::thread_default_precision(30);
 	// then try to write into this existing variable with various policies
 
 
@@ -892,21 +892,21 @@ BOOST_AUTO_TEST_CASE(arithmetic_precision_fresh_variable_this_thread_preserve_ta
 
 
 
-	mpfr_float::default_precision(50);
-	mpfr_float x("0.01234567890123456789012345678901234567890123456789");
+	real_mp::default_precision(50);
+	real_mp x("0.01234567890123456789012345678901234567890123456789");
 	BOOST_CHECK_EQUAL(x.precision(), 50);
 
 
-	mpfr_float::default_precision(60);
-	mpfr_float y("0.12345678901234567890123456789012345678901234567890123");
+	real_mp::default_precision(60);
+	real_mp y("0.12345678901234567890123456789012345678901234567890123");
 	BOOST_CHECK_EQUAL(y.precision(), 60);
 
 
 
-	mpfr_float::default_precision(30);
+	real_mp::default_precision(30);
 	scoped_mpfr_precision_options_this_thread scoped_opts(boost::multiprecision::variable_precision_options::preserve_target_precision);
 	
-	mpfr_float z = x*y;
+	real_mp z = x*y;
 
 	BOOST_CHECK_EQUAL(x.precision(), 50);
 	BOOST_CHECK_EQUAL(y.precision(), 60);
@@ -923,21 +923,21 @@ BOOST_AUTO_TEST_CASE(arithmetic_precision_fresh_variable_this_thread_preserve_so
 
 
 
-	mpfr_float::default_precision(50);
-	mpfr_float x("0.01234567890123456789012345678901234567890123456789");
+	real_mp::default_precision(50);
+	real_mp x("0.01234567890123456789012345678901234567890123456789");
 	BOOST_CHECK_EQUAL(x.precision(), 50);
 
 
-	mpfr_float::default_precision(60);
-	mpfr_float y("0.12345678901234567890123456789012345678901234567890123");
+	real_mp::default_precision(60);
+	real_mp y("0.12345678901234567890123456789012345678901234567890123");
 	BOOST_CHECK_EQUAL(y.precision(), 60);
 
 
 
-	mpfr_float::default_precision(30);
+	real_mp::default_precision(30);
 	scoped_mpfr_precision_options_this_thread scoped_opts(boost::multiprecision::variable_precision_options::preserve_source_precision);
 	
-	mpfr_float z = x*y;
+	real_mp z = x*y;
 
 	BOOST_CHECK_EQUAL(x.precision(), 50);
 	BOOST_CHECK_EQUAL(y.precision(), 60);
@@ -955,21 +955,21 @@ BOOST_AUTO_TEST_CASE(arithmetic_precision_fresh_variable_this_thread_preserve_co
 
 
 
-	mpfr_float::default_precision(50);
-	mpfr_float x("0.01234567890123456789012345678901234567890123456789");
+	real_mp::default_precision(50);
+	real_mp x("0.01234567890123456789012345678901234567890123456789");
 	BOOST_CHECK_EQUAL(x.precision(), 50);
 
 
-	mpfr_float::default_precision(60);
-	mpfr_float y("0.12345678901234567890123456789012345678901234567890123");
+	real_mp::default_precision(60);
+	real_mp y("0.12345678901234567890123456789012345678901234567890123");
 	BOOST_CHECK_EQUAL(y.precision(), 60);
 
 
 
-	mpfr_float::default_precision(30);
+	real_mp::default_precision(30);
 	scoped_mpfr_precision_options_this_thread scoped_opts(boost::multiprecision::variable_precision_options::preserve_component_precision);
 	
-	mpfr_float z = x*y;
+	real_mp z = x*y;
 
 	BOOST_CHECK_EQUAL(x.precision(), 50);
 	BOOST_CHECK_EQUAL(y.precision(), 60);
@@ -985,21 +985,21 @@ BOOST_AUTO_TEST_CASE(arithmetic_precision_fresh_variable_this_thread_preserve_re
 
 
 
-	mpfr_float::default_precision(50);
-	mpfr_float x("0.01234567890123456789012345678901234567890123456789");
+	real_mp::default_precision(50);
+	real_mp x("0.01234567890123456789012345678901234567890123456789");
 	BOOST_CHECK_EQUAL(x.precision(), 50);
 
 
-	mpfr_float::default_precision(60);
-	mpfr_float y("0.12345678901234567890123456789012345678901234567890123");
+	real_mp::default_precision(60);
+	real_mp y("0.12345678901234567890123456789012345678901234567890123");
 	BOOST_CHECK_EQUAL(y.precision(), 60);
 
 
 
-	mpfr_float::default_precision(30);
+	real_mp::default_precision(30);
 	scoped_mpfr_precision_options_this_thread scoped_opts(boost::multiprecision::variable_precision_options::preserve_related_precision);
 	
-	mpfr_float z = x*y;
+	real_mp z = x*y;
 
 	BOOST_CHECK_EQUAL(x.precision(), 50);
 	BOOST_CHECK_EQUAL(y.precision(), 60);
@@ -1015,21 +1015,21 @@ BOOST_AUTO_TEST_CASE(arithmetic_precision_fresh_variable_this_thread_preserve_al
 
 
 
-	mpfr_float::default_precision(50);
-	mpfr_float x("0.01234567890123456789012345678901234567890123456789");
+	real_mp::default_precision(50);
+	real_mp x("0.01234567890123456789012345678901234567890123456789");
 	BOOST_CHECK_EQUAL(x.precision(), 50);
 
 
-	mpfr_float::default_precision(60);
-	mpfr_float y("0.12345678901234567890123456789012345678901234567890123");
+	real_mp::default_precision(60);
+	real_mp y("0.12345678901234567890123456789012345678901234567890123");
 	BOOST_CHECK_EQUAL(y.precision(), 60);
 
 
 
-	mpfr_float::default_precision(30);
+	real_mp::default_precision(30);
 	scoped_mpfr_precision_options_this_thread scoped_opts(boost::multiprecision::variable_precision_options::preserve_all_precision);
 	
-	mpfr_float z = x*y;
+	real_mp z = x*y;
 
 	BOOST_CHECK_EQUAL(x.precision(), 50);
 	BOOST_CHECK_EQUAL(y.precision(), 60);
@@ -1062,26 +1062,26 @@ BOOST_AUTO_TEST_CASE(arithmetic_precision_existing_variable_this_thread_preserve
 
 
 
-	mpfr_float::thread_default_precision(50);
-	mpfr_float x("0.01234567890123456789012345678901234567890123456789");
+	real_mp::thread_default_precision(50);
+	real_mp x("0.01234567890123456789012345678901234567890123456789");
 	BOOST_CHECK_EQUAL(x.precision(), 50);
 
 
-	mpfr_float::thread_default_precision(60);
-	mpfr_float y("0.12345678901234567890123456789012345678901234567890123456789");
+	real_mp::thread_default_precision(60);
+	real_mp y("0.12345678901234567890123456789012345678901234567890123456789");
 	BOOST_CHECK_EQUAL(y.precision(), 60);
 
 
 	// make a variable at precision 70
-	mpfr_float::thread_default_precision(70);
-	mpfr_float z("0");
+	real_mp::thread_default_precision(70);
+	real_mp z("0");
 
 	BOOST_CHECK_EQUAL(x.precision(), 50);
 	BOOST_CHECK_EQUAL(y.precision(), 60);
 	BOOST_CHECK_EQUAL(z.precision(), 70);
 
 
-	mpfr_float::thread_default_precision(30);
+	real_mp::thread_default_precision(30);
 	// then try to write into this existing variable with various policies
 
 
@@ -1106,19 +1106,19 @@ BOOST_AUTO_TEST_CASE(arithmetic_precision_existing_variable_this_thread_preserve
 
 
 
-	mpfr_float::thread_default_precision(50);
-	mpfr_float x("0.01234567890123456789012345678901234567890123456789");
+	real_mp::thread_default_precision(50);
+	real_mp x("0.01234567890123456789012345678901234567890123456789");
 	BOOST_CHECK_EQUAL(x.precision(), 50);
 
 
-	mpfr_float::thread_default_precision(60);
-	mpfr_float y("0.12345678901234567890123456789012345678901234567890123456789");
+	real_mp::thread_default_precision(60);
+	real_mp y("0.12345678901234567890123456789012345678901234567890123456789");
 	BOOST_CHECK_EQUAL(y.precision(), 60);
 
 
 	// make a variable at precision 70
-	mpfr_float::thread_default_precision(70);
-	mpfr_float z("0");
+	real_mp::thread_default_precision(70);
+	real_mp z("0");
 
 
 	BOOST_CHECK_EQUAL(x.precision(), 50);
@@ -1127,7 +1127,7 @@ BOOST_AUTO_TEST_CASE(arithmetic_precision_existing_variable_this_thread_preserve
 
 
 
-	mpfr_float::thread_default_precision(30);
+	real_mp::thread_default_precision(30);
 	// then try to write into this existing variable with various policies
 
 
@@ -1151,26 +1151,26 @@ BOOST_AUTO_TEST_CASE(arithmetic_precision_existing_variable_this_thread_preserve
 
 
 
-	mpfr_float::thread_default_precision(50);
-	mpfr_float x("0.01234567890123456789012345678901234567890123456789");
+	real_mp::thread_default_precision(50);
+	real_mp x("0.01234567890123456789012345678901234567890123456789");
 	BOOST_CHECK_EQUAL(x.precision(), 50);
 
 
-	mpfr_float::thread_default_precision(60);
-	mpfr_float y("0.12345678901234567890123456789012345678901234567890123456789");
+	real_mp::thread_default_precision(60);
+	real_mp y("0.12345678901234567890123456789012345678901234567890123456789");
 	BOOST_CHECK_EQUAL(y.precision(), 60);
 
 
 	// make a variable at precision 70
-	mpfr_float::thread_default_precision(70);
-	mpfr_float z("0");
+	real_mp::thread_default_precision(70);
+	real_mp z("0");
 
 	BOOST_CHECK_EQUAL(x.precision(), 50);
 	BOOST_CHECK_EQUAL(y.precision(), 60);
 	BOOST_CHECK_EQUAL(z.precision(), 70);
 
 
-	mpfr_float::thread_default_precision(30);
+	real_mp::thread_default_precision(30);
 	// then try to write into this existing variable with various policies
 
 
@@ -1196,30 +1196,30 @@ BOOST_AUTO_TEST_CASE(arithmetic_precision_existing_variable_this_thread_preserve
 
 
 
-	mpfr_float::thread_default_precision(50);
-	mpfr_float x("0.01234567890123456789012345678901234567890123456789");
+	real_mp::thread_default_precision(50);
+	real_mp x("0.01234567890123456789012345678901234567890123456789");
 	BOOST_CHECK_EQUAL(x.precision(), 50);
 
 
-	mpfr_float::thread_default_precision(60);
-	mpfr_float y("0.12345678901234567890123456789012345678901234567890123456789");
+	real_mp::thread_default_precision(60);
+	real_mp y("0.12345678901234567890123456789012345678901234567890123456789");
 	BOOST_CHECK_EQUAL(y.precision(), 60);
 
 
 	// make a variable at precision 70
-	mpfr_float::thread_default_precision(70);
-	mpfr_float z("0");
+	real_mp::thread_default_precision(70);
+	real_mp z("0");
 
 	BOOST_CHECK_EQUAL(x.precision(), 50);
 	BOOST_CHECK_EQUAL(y.precision(), 60);
 	BOOST_CHECK_EQUAL(z.precision(), 70);
 
 
-	mpfr_float::thread_default_precision(30);
+	real_mp::thread_default_precision(30);
 	// then try to write into this existing variable with various policies
 
 
-	// All expressions are evaluated at the precision of the highest precision variable within the expression, and that precision is preserved upon assignment. If the expression contains component types then these are also considered when calculating the precision of the expression. In addition to component types, all related types are considered when evaluating the precision of the expression. Related types are considered to be instantiations of the same template, but with different parameters. So for example mpfr_float_100 would be a related type to mpfr_float, and all expressions containing an mpfr_float_100 variable would have at least 100 decimal digits of precision when evaluated as an mpfr_float expression. Moves, are true moves not copies.  
+	// All expressions are evaluated at the precision of the highest precision variable within the expression, and that precision is preserved upon assignment. If the expression contains component types then these are also considered when calculating the precision of the expression. In addition to component types, all related types are considered when evaluating the precision of the expression. Related types are considered to be instantiations of the same template, but with different parameters. So for example mpfr_float_100 would be a related type to real_mp, and all expressions containing an mpfr_float_100 variable would have at least 100 decimal digits of precision when evaluated as an real_mp expression. Moves, are true moves not copies.  
 
 	scoped_mpfr_precision_options_this_thread   scoped_opts(boost::multiprecision::variable_precision_options::preserve_related_precision);
 
@@ -1238,26 +1238,26 @@ BOOST_AUTO_TEST_CASE(arithmetic_precision_existing_variable_this_thread_preserve
 
 
 
-	mpfr_float::thread_default_precision(50);
-	mpfr_float x("0.01234567890123456789012345678901234567890123456789");
+	real_mp::thread_default_precision(50);
+	real_mp x("0.01234567890123456789012345678901234567890123456789");
 	BOOST_CHECK_EQUAL(x.precision(), 50);
 
 
-	mpfr_float::thread_default_precision(60);
-	mpfr_float y("0.12345678901234567890123456789012345678901234567890123456789");
+	real_mp::thread_default_precision(60);
+	real_mp y("0.12345678901234567890123456789012345678901234567890123456789");
 	BOOST_CHECK_EQUAL(y.precision(), 60);
 
 
 	// make a variable at precision 70
-	mpfr_float::thread_default_precision(70);
-	mpfr_float z("0");
+	real_mp::thread_default_precision(70);
+	real_mp z("0");
 
 	BOOST_CHECK_EQUAL(x.precision(), 50);
 	BOOST_CHECK_EQUAL(y.precision(), 60);
 	BOOST_CHECK_EQUAL(z.precision(), 70);
 
 
-	mpfr_float::thread_default_precision(30);
+	real_mp::thread_default_precision(30);
 	// then try to write into this existing variable with various policies
 
 

--- a/core/test/classes/class_test.cpp
+++ b/core/test/classes/class_test.cpp
@@ -45,14 +45,14 @@
 
 #include "externs.hpp"
 
-using dbl = bertini::dbl;
-using mpfr = bertini::mpfr_complex;
+using complex_dbl = bertini::complex_dbl;
+using mpfr = bertini::complex_mp;
 
 const double relaxed_threshold_clearance_d = 1e-14;
 const double threshold_clearance_d = 1e-14;
 
 unsigned const CLASS_TEST_MPFR_DEFAULT_DIGITS = 50;
-bertini::mpfr_float threshold_clearance_mp("1e-27");
+bertini::real_mp threshold_clearance_mp("1e-27");
 
 const std::string xstr_real = "3.1";
 const std::string xstr_imag = "4.1";
@@ -70,12 +70,12 @@ const std::string pstr_imag = "-1.7";
 
 
 
-const dbl xnum_dbl(std::stod(xstr_real), std::stod(xstr_imag));
-const dbl ynum_dbl(std::stod(ystr_real), std::stod(ystr_imag));
-const dbl znum_dbl(std::stod(zstr_real), std::stod(zstr_imag));
-const dbl anum_dbl(std::stod(astr_real), std::stod(astr_imag));
-const dbl bnum_dbl(std::stod(bstr_real), std::stod(bstr_imag));
-const dbl pnum_dbl(std::stod(pstr_real), std::stod(pstr_imag));
+const complex_dbl xnum_dbl(std::stod(xstr_real), std::stod(xstr_imag));
+const complex_dbl ynum_dbl(std::stod(ystr_real), std::stod(ystr_imag));
+const complex_dbl znum_dbl(std::stod(zstr_real), std::stod(zstr_imag));
+const complex_dbl anum_dbl(std::stod(astr_real), std::stod(astr_imag));
+const complex_dbl bnum_dbl(std::stod(bstr_real), std::stod(bstr_imag));
+const complex_dbl pnum_dbl(std::stod(pstr_real), std::stod(pstr_imag));
 
 mpfr xnum_mpfr;
 mpfr ynum_mpfr;
@@ -105,7 +105,7 @@ struct ClassTestInit{
 		bnum_mpfr = mpfr(bstr_real, bstr_imag);
 		pnum_mpfr = mpfr(pstr_real, pstr_imag);
 
-		threshold_clearance_mp = bertini::mpfr_float("1e-27");
+		threshold_clearance_mp = bertini::real_mp("1e-27");
 	}
 };
 

--- a/core/test/classes/complex_test.cpp
+++ b/core/test/classes/complex_test.cpp
@@ -38,18 +38,18 @@
 BOOST_AUTO_TEST_SUITE(complex_multiprecision_class)
 
 using bertini::Precision;
-using mpfr_float = bertini::mpfr_float;
+using real_mp = bertini::real_mp;
 using bertini::DefaultPrecision;
 
 BOOST_AUTO_TEST_CASE(complex_create_default_constructor)
 {
-	bertini::mpfr_complex z;
+	bertini::complex_mp z;
 }
 
 
 BOOST_AUTO_TEST_CASE(complex_create_two_input_constructor)
 {
-	bertini::mpfr_complex z("0.1","1.2");
+	bertini::complex_mp z("0.1","1.2");
 }
 
 
@@ -57,12 +57,12 @@ BOOST_AUTO_TEST_CASE(complex_addition)
 {
 	bertini::DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
 
-	bertini::mpfr_complex z("0.1","1.2");
-	bertini::mpfr_complex v("0.2","1.3");
+	bertini::complex_mp z("0.1","1.2");
+	bertini::complex_mp v("0.2","1.3");
 	
-	bertini::mpfr_complex r = z+v;
-	BOOST_CHECK(abs(r.real()-bertini::mpfr_float("0.3")) < threshold_clearance_mp);
-	BOOST_CHECK(abs(r.imag()-bertini::mpfr_float("2.5")) < threshold_clearance_mp);
+	bertini::complex_mp r = z+v;
+	BOOST_CHECK(abs(r.real()-bertini::real_mp("0.3")) < threshold_clearance_mp);
+	BOOST_CHECK(abs(r.imag()-bertini::real_mp("2.5")) < threshold_clearance_mp);
 }
 
 
@@ -70,12 +70,12 @@ BOOST_AUTO_TEST_CASE(complex_subtraction)
 {
 	bertini::DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
 
-	bertini::mpfr_complex z("0.1","1.2");
-	bertini::mpfr_complex v("0.2","1.3");
+	bertini::complex_mp z("0.1","1.2");
+	bertini::complex_mp v("0.2","1.3");
 	
-	bertini::mpfr_complex r = z-v;
-	BOOST_CHECK(abs(r.real()-bertini::mpfr_float("-0.1")) < threshold_clearance_mp);
-	BOOST_CHECK(abs(r.imag()-bertini::mpfr_float("-0.1")) < threshold_clearance_mp);
+	bertini::complex_mp r = z-v;
+	BOOST_CHECK(abs(r.real()-bertini::real_mp("-0.1")) < threshold_clearance_mp);
+	BOOST_CHECK(abs(r.imag()-bertini::real_mp("-0.1")) < threshold_clearance_mp);
 }
 
 
@@ -83,23 +83,23 @@ BOOST_AUTO_TEST_CASE(complex_negation)
 {
 	bertini::DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
 
-	bertini::mpfr_complex z("0.1","1.2");
+	bertini::complex_mp z("0.1","1.2");
 
-	bertini::mpfr_complex r = -z;
+	bertini::complex_mp r = -z;
 
-	BOOST_CHECK_EQUAL(r.real(),-bertini::mpfr_float("0.1"));
-	BOOST_CHECK_EQUAL(r.imag(),-bertini::mpfr_float("1.2"));
+	BOOST_CHECK_EQUAL(r.real(),-bertini::real_mp("0.1"));
+	BOOST_CHECK_EQUAL(r.imag(),-bertini::real_mp("1.2"));
 }
 
 BOOST_AUTO_TEST_CASE(complex_multiplication)
 {
 	bertini::DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
-	bertini::mpfr_complex z("0.1000","1.2000");
-	bertini::mpfr_complex v("0.2000","1.3000");
-	bertini::mpfr_complex r = z*v;
+	bertini::complex_mp z("0.1000","1.2000");
+	bertini::complex_mp v("0.2000","1.3000");
+	bertini::complex_mp r = z*v;
 	
-	BOOST_CHECK(abs(r.real()-bertini::mpfr_float("-1.54")) < threshold_clearance_mp);
-	BOOST_CHECK(abs(r.imag()-bertini::mpfr_float("0.37"))< threshold_clearance_mp);
+	BOOST_CHECK(abs(r.real()-bertini::real_mp("-1.54")) < threshold_clearance_mp);
+	BOOST_CHECK(abs(r.imag()-bertini::real_mp("0.37"))< threshold_clearance_mp);
 	
 }
 
@@ -107,12 +107,12 @@ BOOST_AUTO_TEST_CASE(complex_multiplication)
 BOOST_AUTO_TEST_CASE(complex_division)
 {
 	bertini::DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
-	bertini::mpfr_complex z("1.5","2.25");
-	bertini::mpfr_complex v("-3.1","5.1");
-	bertini::mpfr_complex r = z/v;
+	bertini::complex_mp z("1.5","2.25");
+	bertini::complex_mp v("-3.1","5.1");
+	bertini::complex_mp r = z/v;
 	
-	BOOST_CHECK(abs(r.real()-bertini::mpfr_float("0.191605839416058394160583941605839416058394160583941605839416")) < threshold_clearance_mp);
-	BOOST_CHECK(abs(r.imag()-bertini::mpfr_float("-0.410583941605839416058394160583941605839416058394160583941606"))< threshold_clearance_mp);
+	BOOST_CHECK(abs(r.real()-bertini::real_mp("0.191605839416058394160583941605839416058394160583941605839416")) < threshold_clearance_mp);
+	BOOST_CHECK(abs(r.imag()-bertini::real_mp("-0.410583941605839416058394160583941605839416058394160583941606"))< threshold_clearance_mp);
 	
 }
 
@@ -122,15 +122,15 @@ BOOST_AUTO_TEST_CASE(complex_division)
 
 // BOOST_AUTO_TEST_CASE(complex_inverse)
 // {
-// 	using mpfr_float = bertini::mpfr_float;
+// 	using real_mp = bertini::real_mp;
 // 	DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
 	
-// 	bertini::mpfr_complex z("1.5", "2.25");
-// 	bertini::mpfr_complex w = inverse(z);
+// 	bertini::complex_mp z("1.5", "2.25");
+// 	bertini::complex_mp w = inverse(z);
 	
-// 	BOOST_CHECK( abs(real(w) - mpfr_float("0.205128205128205128205128205128205128205128205128205128205128")) < threshold_clearance_mp);
+// 	BOOST_CHECK( abs(real(w) - real_mp("0.205128205128205128205128205128205128205128205128205128205128")) < threshold_clearance_mp);
 // 	// this value computed with matlab's vpa.
-// 	BOOST_CHECK( abs(imag(w) - mpfr_float("-0.307692307692307692307692307692307692307692307692307692307692")) < threshold_clearance_mp);
+// 	BOOST_CHECK( abs(imag(w) - real_mp("-0.307692307692307692307692307692307692307692307692307692307692")) < threshold_clearance_mp);
 // 	// this value computed with matlab's vpa.
 	
 // }
@@ -141,15 +141,15 @@ BOOST_AUTO_TEST_CASE(complex_division)
 
 BOOST_AUTO_TEST_CASE(complex_sqrt)
 {
-	using mpfr_float = bertini::mpfr_float;
+	using real_mp = bertini::real_mp;
 	DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
 	
-	bertini::mpfr_complex z("1.5", "2.25");
-	bertini::mpfr_complex w = sqrt(z);
+	bertini::complex_mp z("1.5", "2.25");
+	bertini::complex_mp w = sqrt(z);
 	
-	BOOST_CHECK(abs(real(w)- mpfr_float("1.44985576120488481677238036203436657121811982450524518214799")) < threshold_clearance_mp);
+	BOOST_CHECK(abs(real(w)- real_mp("1.44985576120488481677238036203436657121811982450524518214799")) < threshold_clearance_mp);
 	// this value computed with matlab's vpa.
-	BOOST_CHECK(abs(imag(w)- mpfr_float("0.775939255547105301187773883610045740361564192945364951422177")) < threshold_clearance_mp);
+	BOOST_CHECK(abs(imag(w)- real_mp("0.775939255547105301187773883610045740361564192945364951422177")) < threshold_clearance_mp);
 	// this value computed with matlab's vpa.
 	
 }
@@ -159,15 +159,15 @@ BOOST_AUTO_TEST_CASE(complex_sqrt)
 
 BOOST_AUTO_TEST_CASE(complex_log)
 {
-	using mpfr_float = bertini::mpfr_float;
+	using real_mp = bertini::real_mp;
 	DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
 	
-	bertini::mpfr_complex z("1.5", "2.25");
-	bertini::mpfr_complex w = log(z);
+	bertini::complex_mp z("1.5", "2.25");
+	bertini::complex_mp w = log(z);
 	
-	BOOST_CHECK(abs(real(w)- mpfr_float("0.994792606278987440587524714788831870899124261482342501702857")) < threshold_clearance_mp);
+	BOOST_CHECK(abs(real(w)- real_mp("0.994792606278987440587524714788831870899124261482342501702857")) < threshold_clearance_mp);
 	// this value computed with matlab's vpa.
-	BOOST_CHECK(abs(imag(w)- mpfr_float("0.982793723247329067985710611014666014496877453631628556761425")) < threshold_clearance_mp);
+	BOOST_CHECK(abs(imag(w)- real_mp("0.982793723247329067985710611014666014496877453631628556761425")) < threshold_clearance_mp);
 	// this value computed with matlab's vpa.
 	
 }
@@ -175,17 +175,17 @@ BOOST_AUTO_TEST_CASE(complex_log)
 
 BOOST_AUTO_TEST_CASE(complex_pow_expressionofreal)
 {
-	using mpfr_float = bertini::mpfr_float;
+	using real_mp = bertini::real_mp;
 	DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
 	
-	bertini::mpfr_complex z("1.5", "2.25");
-	mpfr_float v("-3.1");
-	bertini::mpfr_complex w = pow(z,2*v);
+	bertini::complex_mp z("1.5", "2.25");
+	real_mp v("-3.1");
+	bertini::complex_mp w = pow(z,2*v);
 		
 	//	0.0020583559161721337087583598028377697763165142184117220013738 + 0.000395572868694696378274143631981503385520868787960481823572936
-	BOOST_CHECK(abs(real(w)- mpfr_float("0.0020583559161721337087583598028377697763165142184117220013738")) < threshold_clearance_mp);
+	BOOST_CHECK(abs(real(w)- real_mp("0.0020583559161721337087583598028377697763165142184117220013738")) < threshold_clearance_mp);
 	// this value computed with matlab's vpa.
-	BOOST_CHECK(abs(imag(w)- mpfr_float("0.000395572868694696378274143631981503385520868787960481823572936")) < threshold_clearance_mp);
+	BOOST_CHECK(abs(imag(w)- real_mp("0.000395572868694696378274143631981503385520868787960481823572936")) < threshold_clearance_mp);
 	// this value computed with matlab's vpa.
 }
 
@@ -193,15 +193,15 @@ BOOST_AUTO_TEST_CASE(complex_pow_expressionofreal)
 
 BOOST_AUTO_TEST_CASE(complex_exponential)
 {
-	using mpfr_float = bertini::mpfr_float;
+	using real_mp = bertini::real_mp;
 	DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
 	
-	bertini::mpfr_complex z("1.5", "2.25"), v("-3.1", "5.1");
-	bertini::mpfr_complex w = pow(z,v);
+	bertini::complex_mp z("1.5", "2.25"), v("-3.1", "5.1");
+	bertini::complex_mp w = pow(z,v);
 	
-	BOOST_CHECK(abs(real(w)- mpfr_float("-0.000134184252069350633500916903057767602709221538143686248955454")) < threshold_clearance_mp);
+	BOOST_CHECK(abs(real(w)- real_mp("-0.000134184252069350633500916903057767602709221538143686248955454")) < threshold_clearance_mp);
 	// this value computed with matlab's vpa.
-	BOOST_CHECK(abs(imag(w)- mpfr_float("0.000273589335652288672638569400353054443664478211013806804752627")) < threshold_clearance_mp);
+	BOOST_CHECK(abs(imag(w)- real_mp("0.000273589335652288672638569400353054443664478211013806804752627")) < threshold_clearance_mp);
 	// this value computed with matlab's vpa.
 	
 }
@@ -213,31 +213,31 @@ BOOST_AUTO_TEST_CASE(complex_exponential)
 
 BOOST_AUTO_TEST_CASE(complex_sin)
 {
-	using mpfr_float = bertini::mpfr_float;
+	using real_mp = bertini::real_mp;
 	DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
 	
-	bertini::mpfr_complex z("1.5", "2.25");
-	bertini::mpfr_complex w = sin(z);
+	bertini::complex_mp z("1.5", "2.25");
+	bertini::complex_mp w = sin(z);
 	
-	BOOST_CHECK(abs(real(w)- mpfr_float("4.78455206454183468376293313858001326644589827567133864164966")) < threshold_clearance_mp);
+	BOOST_CHECK(abs(real(w)- real_mp("4.78455206454183468376293313858001326644589827567133864164966")) < threshold_clearance_mp);
 	// this value computed with matlab's vpa.
-	BOOST_CHECK(abs(imag(w)- mpfr_float("0.331840118511466433278036564370915664859189055829310017561679")) < threshold_clearance_mp);
+	BOOST_CHECK(abs(imag(w)- real_mp("0.331840118511466433278036564370915664859189055829310017561679")) < threshold_clearance_mp);
 	// this value computed with matlab's vpa.
 	
 }
 
 BOOST_AUTO_TEST_CASE(complex_cos)
 {
-	using mpfr_float = bertini::mpfr_float;
+	using real_mp = bertini::real_mp;
 	DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
 	
-	bertini::mpfr_complex z("1.5", "2.25");
-	bertini::mpfr_complex w = cos(z);
+	bertini::complex_mp z("1.5", "2.25");
+	bertini::complex_mp w = cos(z);
 	
 	
-	BOOST_CHECK(abs(real(w)- mpfr_float("0.339295764714918536764798162132262895147653901636178423640742")) < threshold_clearance_mp);
+	BOOST_CHECK(abs(real(w)- real_mp("0.339295764714918536764798162132262895147653901636178423640742")) < threshold_clearance_mp);
 	// this value computed with matlab's vpa.
-	BOOST_CHECK(abs(imag(w)- mpfr_float("-4.67941686644942009239504224985289863706184473303907201576996")) < threshold_clearance_mp);
+	BOOST_CHECK(abs(imag(w)- real_mp("-4.67941686644942009239504224985289863706184473303907201576996")) < threshold_clearance_mp);
 	// this value computed with matlab's vpa.
 	
 }
@@ -245,15 +245,15 @@ BOOST_AUTO_TEST_CASE(complex_cos)
 
 BOOST_AUTO_TEST_CASE(complex_tan)
 {
-	using mpfr_float = bertini::mpfr_float;
+	using real_mp = bertini::real_mp;
 	DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
 	
-	bertini::mpfr_complex z("1.5", "2.25");
-	bertini::mpfr_complex w = tan(z);
+	bertini::complex_mp z("1.5", "2.25");
+	bertini::complex_mp w = tan(z);
 	
-	BOOST_CHECK(abs(real(w)- mpfr_float("0.0032055151478664658165188420647201618843131312777936688172756")) < threshold_clearance_mp);
+	BOOST_CHECK(abs(real(w)- real_mp("0.0032055151478664658165188420647201618843131312777936688172756")) < threshold_clearance_mp);
 	// this value computed with matlab's vpa.
-	BOOST_CHECK(abs(imag(w)- mpfr_float("1.02223515949711949776179466571527189987176458555122839197245")) < threshold_clearance_mp);
+	BOOST_CHECK(abs(imag(w)- real_mp("1.02223515949711949776179466571527189987176458555122839197245")) < threshold_clearance_mp);
 	// this value computed with matlab's vpa.
 	
 }
@@ -272,31 +272,31 @@ BOOST_AUTO_TEST_CASE(complex_tan)
 
 BOOST_AUTO_TEST_CASE(complex_sinh)
 {
-	using mpfr_float = bertini::mpfr_float;
+	using real_mp = bertini::real_mp;
 	DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
 	
-	bertini::mpfr_complex z("1.5", "2.25");
-	bertini::mpfr_complex w = sinh(z);
+	bertini::complex_mp z("1.5", "2.25");
+	bertini::complex_mp w = sinh(z);
 	
-	BOOST_CHECK(abs(real(w)- mpfr_float("-1.33755718909601135383265663229426431626814744207128061926332")) < threshold_clearance_mp);
+	BOOST_CHECK(abs(real(w)- real_mp("-1.33755718909601135383265663229426431626814744207128061926332")) < threshold_clearance_mp);
 	// this value computed with matlab's vpa.
-	BOOST_CHECK(abs(imag(w)- mpfr_float("1.83034686972219823005238120890074929109631502976918245359956")) < threshold_clearance_mp);
+	BOOST_CHECK(abs(imag(w)- real_mp("1.83034686972219823005238120890074929109631502976918245359956")) < threshold_clearance_mp);
 	// this value computed with matlab's vpa.
 	
 }
 
 BOOST_AUTO_TEST_CASE(complex_cosh)
 {
-	using mpfr_float = bertini::mpfr_float;
+	using real_mp = bertini::real_mp;
 	DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
 	
-	bertini::mpfr_complex z("1.5", "2.25");
-	bertini::mpfr_complex w = cosh(z);
+	bertini::complex_mp z("1.5", "2.25");
+	bertini::complex_mp w = cosh(z);
 	
 	
-	BOOST_CHECK(abs(real(w)- mpfr_float("-1.47772167013515546574129058780587714414840064875386904640065")) < threshold_clearance_mp);
+	BOOST_CHECK(abs(real(w)- real_mp("-1.47772167013515546574129058780587714414840064875386904640065")) < threshold_clearance_mp);
 	// this value computed with matlab's vpa.
-	BOOST_CHECK(abs(imag(w)- mpfr_float("1.65673527269339558987730878420158930664270667966911313867276")) < threshold_clearance_mp);
+	BOOST_CHECK(abs(imag(w)- real_mp("1.65673527269339558987730878420158930664270667966911313867276")) < threshold_clearance_mp);
 	// this value computed with matlab's vpa.
 	
 }
@@ -304,15 +304,15 @@ BOOST_AUTO_TEST_CASE(complex_cosh)
 
 BOOST_AUTO_TEST_CASE(complex_tanh)
 {
-	using mpfr_float = bertini::mpfr_float;
+	using real_mp = bertini::real_mp;
 	DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
 	
-	bertini::mpfr_complex z("1.5", "2.25");
-	bertini::mpfr_complex w = tanh(z);
+	bertini::complex_mp z("1.5", "2.25");
+	bertini::complex_mp w = tanh(z);
 	
-	BOOST_CHECK(abs(real(w)- mpfr_float("1.01633467755934300564918114729269683730547835877531900704421")) < threshold_clearance_mp);
+	BOOST_CHECK(abs(real(w)- real_mp("1.01633467755934300564918114729269683730547835877531900704421")) < threshold_clearance_mp);
 	// this value computed with matlab's vpa.
-	BOOST_CHECK(abs(imag(w)- mpfr_float("-0.0991725055603753242720729815306256466293467541150851175179255")) < threshold_clearance_mp);
+	BOOST_CHECK(abs(imag(w)- real_mp("-0.0991725055603753242720729815306256466293467541150851175179255")) < threshold_clearance_mp);
 	// this value computed with matlab's vpa.
 	
 }
@@ -329,30 +329,30 @@ BOOST_AUTO_TEST_CASE(complex_tanh)
 
 BOOST_AUTO_TEST_CASE(complex_asin)
 {
-	using mpfr_float = bertini::mpfr_float;
+	using real_mp = bertini::real_mp;
 	DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
 	
-	bertini::mpfr_complex z("1.5", "2.25");
-	bertini::mpfr_complex w = asin(z);
+	bertini::complex_mp z("1.5", "2.25");
+	bertini::complex_mp w = asin(z);
 	
-	BOOST_CHECK(abs(real(w)- mpfr_float("0.557728098701882481783572689617979376112207607697432876677129")) < threshold_clearance_mp);
+	BOOST_CHECK(abs(real(w)- real_mp("0.557728098701882481783572689617979376112207607697432876677129")) < threshold_clearance_mp);
 	// this value computed with matlab's vpa.
-	BOOST_CHECK(abs(imag(w)- mpfr_float("1.70220126917599043453132270948063371483983368727808240752544")) < threshold_clearance_mp);
+	BOOST_CHECK(abs(imag(w)- real_mp("1.70220126917599043453132270948063371483983368727808240752544")) < threshold_clearance_mp);
 	// this value computed with matlab's vpa.
 	
 }
 
 BOOST_AUTO_TEST_CASE(complex_acos)
 {
-	using mpfr_float = bertini::mpfr_float;
+	using real_mp = bertini::real_mp;
 	DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
 	
-	bertini::mpfr_complex z("1.5", "2.25");
-	bertini::mpfr_complex w = acos(z);
+	bertini::complex_mp z("1.5", "2.25");
+	bertini::complex_mp w = acos(z);
 	
-	BOOST_CHECK(abs(real(w)- mpfr_float("1.01306822809301413744774900202177206598637709199012003381034")) < threshold_clearance_mp);
+	BOOST_CHECK(abs(real(w)- real_mp("1.01306822809301413744774900202177206598637709199012003381034")) < threshold_clearance_mp);
 	// this value computed with matlab's vpa.
-	BOOST_CHECK(abs(imag(w)- mpfr_float("-1.70220126917599043453132270948063371483983368727808240752544")) < threshold_clearance_mp);
+	BOOST_CHECK(abs(imag(w)- real_mp("-1.70220126917599043453132270948063371483983368727808240752544")) < threshold_clearance_mp);
 	// this value computed with matlab's vpa.
 	
 }
@@ -360,15 +360,15 @@ BOOST_AUTO_TEST_CASE(complex_acos)
 
 BOOST_AUTO_TEST_CASE(complex_atan)
 {
-	using mpfr_float = bertini::mpfr_float;
+	using real_mp = bertini::real_mp;
 	DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
 	
-	bertini::mpfr_complex z("1.5", "2.25");
-	bertini::mpfr_complex w = atan(z);
+	bertini::complex_mp z("1.5", "2.25");
+	bertini::complex_mp w = atan(z);
 
-	BOOST_CHECK(abs(real(w)- mpfr_float("1.34897118928106882765457017435994248505893277188774702053495")) < threshold_clearance_mp);
+	BOOST_CHECK(abs(real(w)- real_mp("1.34897118928106882765457017435994248505893277188774702053495")) < threshold_clearance_mp);
 	// this value computed with matlab's vpa.
-	BOOST_CHECK(abs(imag(w)- mpfr_float("0.303034028741274232429033400709495120396582520146639573148632")) < threshold_clearance_mp);
+	BOOST_CHECK(abs(imag(w)- real_mp("0.303034028741274232429033400709495120396582520146639573148632")) < threshold_clearance_mp);
 	// this value computed with matlab's vpa.
 	
 }
@@ -381,30 +381,30 @@ BOOST_AUTO_TEST_CASE(complex_atan)
 
 BOOST_AUTO_TEST_CASE(complex_asinh)
 {
-	using mpfr_float = bertini::mpfr_float;
+	using real_mp = bertini::real_mp;
 	DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
 	
-	bertini::mpfr_complex z("1.5", "2.25");
-	bertini::mpfr_complex w = asinh(z);
+	bertini::complex_mp z("1.5", "2.25");
+	bertini::complex_mp w = asinh(z);
 	
-	BOOST_CHECK(abs(real(w)- mpfr_float("1.67614738083746762411099043767860402156031800041110901006856")) < threshold_clearance_mp);
+	BOOST_CHECK(abs(real(w)- real_mp("1.67614738083746762411099043767860402156031800041110901006856")) < threshold_clearance_mp);
 	// this value computed with matlab's vpa.
-	BOOST_CHECK(abs(imag(w)- mpfr_float("0.950053155715849776576329694197937868331910565261475162022272")) < threshold_clearance_mp);
+	BOOST_CHECK(abs(imag(w)- real_mp("0.950053155715849776576329694197937868331910565261475162022272")) < threshold_clearance_mp);
 	// this value computed with matlab's vpa.
 	
 }
 
 BOOST_AUTO_TEST_CASE(complex_acosh)
 {
-	using mpfr_float = bertini::mpfr_float;
+	using real_mp = bertini::real_mp;
 	DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
 	
-	bertini::mpfr_complex z("1.5", "2.25");
-	bertini::mpfr_complex w = acosh(z);
+	bertini::complex_mp z("1.5", "2.25");
+	bertini::complex_mp w = acosh(z);
 	
-	BOOST_CHECK(abs(real(w)- mpfr_float("1.70220126917599043453132270948063371483983368727808240752544")) < threshold_clearance_mp);
+	BOOST_CHECK(abs(real(w)- real_mp("1.70220126917599043453132270948063371483983368727808240752544")) < threshold_clearance_mp);
 	// this value computed with matlab's vpa.
-	BOOST_CHECK(abs(imag(w)- mpfr_float("1.01306822809301413744774900202177206598637709199012003381034")) < threshold_clearance_mp);
+	BOOST_CHECK(abs(imag(w)- real_mp("1.01306822809301413744774900202177206598637709199012003381034")) < threshold_clearance_mp);
 	// this value computed with matlab's vpa.
 	
 }
@@ -412,15 +412,15 @@ BOOST_AUTO_TEST_CASE(complex_acosh)
 
 BOOST_AUTO_TEST_CASE(complex_atanh)
 {
-	using mpfr_float = bertini::mpfr_float;
+	using real_mp = bertini::real_mp;
 	DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
 	
-	bertini::mpfr_complex z("1.5", "2.25");
-	bertini::mpfr_complex w = atanh(z);
+	bertini::complex_mp z("1.5", "2.25");
+	bertini::complex_mp w = atanh(z);
 	
-	BOOST_CHECK(abs(real(w)- mpfr_float("0.188961443693877322997198271883423688031632018662054076093211")) < threshold_clearance_mp);
+	BOOST_CHECK(abs(real(w)- real_mp("0.188961443693877322997198271883423688031632018662054076093211")) < threshold_clearance_mp);
 	// this value computed with matlab's vpa.
-	BOOST_CHECK(abs(imag(w)- mpfr_float("1.26114018722767258645714375731198514259936666747537259674077")) < threshold_clearance_mp);
+	BOOST_CHECK(abs(imag(w)- real_mp("1.26114018722767258645714375731198514259936666747537259674077")) < threshold_clearance_mp);
 	// this value computed with matlab's vpa.
 	
 }
@@ -434,18 +434,18 @@ BOOST_AUTO_TEST_CASE(complex_atanh)
 
 BOOST_AUTO_TEST_CASE(complex_absolute_value)
 {
-	using mpfr_float = bertini::mpfr_float;
+	using real_mp = bertini::real_mp;
 	DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
 	
-	BOOST_CHECK_EQUAL(abs(bertini::mpfr_complex("1.0","1.0")), sqrt(mpfr_float("2.0")));
+	BOOST_CHECK_EQUAL(abs(bertini::complex_mp("1.0","1.0")), sqrt(real_mp("2.0")));
 	
 }
 
 BOOST_AUTO_TEST_CASE(complex_abs_of_i_is_one)
 {
-	bertini::mpfr_complex i("0.0","1.0");
-	bertini::mpfr_float one = abs(i);
-	BOOST_CHECK_EQUAL(one,bertini::mpfr_float("1.0"));
+	bertini::complex_mp i("0.0","1.0");
+	bertini::real_mp one = abs(i);
+	BOOST_CHECK_EQUAL(one,bertini::real_mp("1.0"));
 }
 
 
@@ -453,12 +453,12 @@ BOOST_AUTO_TEST_CASE(complex_abs_of_i_is_one)
 
 BOOST_AUTO_TEST_CASE(complex_eleventh_power)
 {
-	using mpfr_float = bertini::mpfr_float;
-	bertini::mpfr_complex z("2.0","0.5"), w;
+	using real_mp = bertini::real_mp;
+	bertini::complex_mp z("2.0","0.5"), w;
 	
 	w = pow(z,11);
-	BOOST_CHECK_EQUAL(real(w), mpfr_float("-1319867") / mpfr_float("512") );
-	BOOST_CHECK_EQUAL(imag(w),  mpfr_float("2529647") / mpfr_float("2048"));
+	BOOST_CHECK_EQUAL(real(w), real_mp("-1319867") / real_mp("512") );
+	BOOST_CHECK_EQUAL(imag(w),  real_mp("2529647") / real_mp("2048"));
 	
 	
 }
@@ -468,14 +468,14 @@ BOOST_AUTO_TEST_CASE(complex_eleventh_power)
 
 BOOST_AUTO_TEST_CASE(complex_conjugation)
 {
-	using mpfr_float = bertini::mpfr_float;
+	using real_mp = bertini::real_mp;
 	DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
 	
-	bertini::mpfr_complex z("2.0", sqrt(mpfr_float("2.0")));
-	bertini::mpfr_complex w = conj(z);
+	bertini::complex_mp z("2.0", sqrt(real_mp("2.0")));
+	bertini::complex_mp w = conj(z);
 	
-	BOOST_CHECK_EQUAL(real(w),mpfr_float("2.0"));
-	BOOST_CHECK_EQUAL(imag(w),-sqrt(mpfr_float("2.0")));
+	BOOST_CHECK_EQUAL(real(w),real_mp("2.0"));
+	BOOST_CHECK_EQUAL(imag(w),-sqrt(real_mp("2.0")));
 }
 
 
@@ -485,12 +485,12 @@ BOOST_AUTO_TEST_CASE(complex_conjugation)
 
 BOOST_AUTO_TEST_CASE(complex_argument)
 {
-	using mpfr_float = bertini::mpfr_float;
+	using real_mp = bertini::real_mp;
 	DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
 	
-	bertini::mpfr_complex z("1.0","1.0");
+	bertini::complex_mp z("1.0","1.0");
 	
-	BOOST_CHECK_EQUAL(arg(z), acos(mpfr_float("-1.0"))/mpfr_float("4.0"));
+	BOOST_CHECK_EQUAL(arg(z), acos(real_mp("-1.0"))/real_mp("4.0"));
 }
 
 
@@ -501,7 +501,7 @@ BOOST_AUTO_TEST_CASE(complex_make_random_50)
 {
 	DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);  
 	
-	bertini::mpfr_complex z = bertini::multiprecision::rand();
+	bertini::complex_mp z = bertini::multiprecision::rand();
 
 }
 
@@ -510,28 +510,28 @@ BOOST_AUTO_TEST_CASE(complex_make_random_50)
 BOOST_AUTO_TEST_CASE(complex_make_random_100)
 {
 	DefaultPrecision(100);  
-	bertini::mpfr_complex z = bertini::multiprecision::rand();
+	bertini::complex_mp z = bertini::multiprecision::rand();
 }
 
 
 #ifndef B2_FORBID_MIXED_ARITHMETIC
 BOOST_AUTO_TEST_CASE(interoperability_with_rational)
 {
-	mpfr_complex z;
+	complex_mp z;
 	bertini::mpq_rational r;
 
-	mpfr_complex w = z*r;
+	complex_mp w = z*r;
 }
 #endif
 
 
 BOOST_AUTO_TEST_CASE(complex_serialization)
 {
-	using mpfr_float = bertini::mpfr_float;
+	using real_mp = bertini::real_mp;
 	DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
 	
 	
-	bertini::mpfr_complex z("1.23456", acos(mpfr_float("-1")));
+	bertini::complex_mp z("1.23456", acos(real_mp("-1")));
 	
 	{
 		std::ofstream fout("serialization_test_complex");
@@ -542,8 +542,8 @@ BOOST_AUTO_TEST_CASE(complex_serialization)
 		oa << z;
 	}
 	
-	//	bertini::mpfr_complex w;
-	bertini::mpfr_complex w;
+	//	bertini::complex_mp w;
+	bertini::complex_mp w;
 	{
 		std::ifstream fin("serialization_test_complex");
 		
@@ -568,13 +568,13 @@ BOOST_AUTO_TEST_CASE(complex_precision_predictable_add)
 
 
 	DefaultPrecision(30);
-	bertini::mpfr_complex a(1,2);
+	bertini::complex_mp a(1,2);
 
 	DefaultPrecision(50);
-	bertini::mpfr_complex b(3,4);
+	bertini::complex_mp b(3,4);
 
 	DefaultPrecision(70);
-	bertini::mpfr_complex c(5,6);
+	bertini::complex_mp c(5,6);
 
 	a = b+c;
 	BOOST_CHECK_EQUAL(Precision(a),std::max(Precision(b),Precision(c)));
@@ -591,15 +591,15 @@ BOOST_AUTO_TEST_CASE(complex_precision_predictable_sub)
 
 
 	DefaultPrecision(30);
-	bertini::mpfr_complex a(1,2);
+	bertini::complex_mp a(1,2);
 	BOOST_CHECK_EQUAL(Precision(a),30);
 
 	DefaultPrecision(50);
-	bertini::mpfr_complex b(3,4);
+	bertini::complex_mp b(3,4);
 	BOOST_CHECK_EQUAL(Precision(b),50);
 
 	DefaultPrecision(70);
-	bertini::mpfr_complex c(5,6);
+	bertini::complex_mp c(5,6);
 	BOOST_CHECK_EQUAL(Precision(c),70);
 
 	a = b-c;
@@ -616,15 +616,15 @@ BOOST_AUTO_TEST_CASE(complex_precision_predictable_mul)
 	bertini::scoped_mpfr_precision_options_this_thread precision_options(boost::multiprecision::variable_precision_options::preserve_source_precision);
 
 	DefaultPrecision(30);
-	bertini::mpfr_complex a(1,2);
+	bertini::complex_mp a(1,2);
 	BOOST_CHECK_EQUAL(Precision(a),30);
 
 	DefaultPrecision(50);
-	bertini::mpfr_complex b(3,4);
+	bertini::complex_mp b(3,4);
 	BOOST_CHECK_EQUAL(Precision(b),50);
 
 	DefaultPrecision(70);
-	bertini::mpfr_complex c(5,6);
+	bertini::complex_mp c(5,6);
 	BOOST_CHECK_EQUAL(Precision(c),70);
 
 	a = b*c;
@@ -642,15 +642,15 @@ BOOST_AUTO_TEST_CASE(complex_precision_predictable_div)
 	bertini::scoped_mpfr_precision_options_this_thread precision_options(boost::multiprecision::variable_precision_options::preserve_source_precision);
 
 	DefaultPrecision(30);
-	bertini::mpfr_complex a(1,2);
+	bertini::complex_mp a(1,2);
 	BOOST_CHECK_EQUAL(Precision(a),30);
 
 	DefaultPrecision(50);
-	bertini::mpfr_complex b(3,4);
+	bertini::complex_mp b(3,4);
 	BOOST_CHECK_EQUAL(Precision(b),50);
 
 	DefaultPrecision(70);
-	bertini::mpfr_complex c(5,6);
+	bertini::complex_mp c(5,6);
 	BOOST_CHECK_EQUAL(Precision(c),70);
 
 	a = b/c;
@@ -667,15 +667,15 @@ BOOST_AUTO_TEST_CASE(complex_precision_predictable_pow)
 	bertini::scoped_mpfr_precision_options_this_thread precision_options(boost::multiprecision::variable_precision_options::preserve_source_precision);
 
 	DefaultPrecision(30);
-	bertini::mpfr_complex a(1,2);
+	bertini::complex_mp a(1,2);
 	BOOST_CHECK_EQUAL(Precision(a),30);
 
 	DefaultPrecision(50);
-	bertini::mpfr_complex b(3,4);
+	bertini::complex_mp b(3,4);
 	BOOST_CHECK_EQUAL(Precision(b),50);
 
 	DefaultPrecision(70);
-	bertini::mpfr_complex c(5,6);
+	bertini::complex_mp c(5,6);
 	BOOST_CHECK_EQUAL(Precision(c),70);
 
 	a = pow(b,c);
@@ -691,15 +691,15 @@ BOOST_AUTO_TEST_CASE(complex_precision_predictable_trig)
 	bertini::scoped_mpfr_precision_options_this_thread precision_options(boost::multiprecision::variable_precision_options::preserve_source_precision);
 
 	DefaultPrecision(30);
-	bertini::mpfr_complex a(1,2);
+	bertini::complex_mp a(1,2);
 	BOOST_CHECK_EQUAL(Precision(a),30);
 
 	DefaultPrecision(50);
-	bertini::mpfr_complex b(3,4);
+	bertini::complex_mp b(3,4);
 	BOOST_CHECK_EQUAL(Precision(b),50);
 
 	DefaultPrecision(70);
-	bertini::mpfr_complex c(5,6);
+	bertini::complex_mp c(5,6);
 	BOOST_CHECK_EQUAL(Precision(c),DefaultPrecision());
 
 	a = tan(b);
@@ -716,15 +716,15 @@ BOOST_AUTO_TEST_CASE(complex_precision_predictable_arg)
 	bertini::scoped_mpfr_precision_options_this_thread precision_options(boost::multiprecision::variable_precision_options::preserve_source_precision);
 
 	DefaultPrecision(30);
-	bertini::mpfr_complex a(1,2);
+	bertini::complex_mp a(1,2);
 	BOOST_CHECK_EQUAL(Precision(a),30);
 
 	DefaultPrecision(50);
-	bertini::mpfr_complex b(3,4);
+	bertini::complex_mp b(3,4);
 	BOOST_CHECK_EQUAL(Precision(b),50);
 
 	DefaultPrecision(70);
-	bertini::mpfr_complex c(5,6);
+	bertini::complex_mp c(5,6);
 	BOOST_CHECK_EQUAL(Precision(c),70);
 
 	a = arg(b);
@@ -742,28 +742,28 @@ BOOST_AUTO_TEST_CASE(complex_precision_predictable2)
 {
 	bertini::scoped_mpfr_precision_options_this_thread precision_options(boost::multiprecision::variable_precision_options::preserve_source_precision);
 
-	mpfr_complex::default_precision(50);
-	mpfr_float::default_precision(50);
-	mpfr_complex a;
+	complex_mp::default_precision(50);
+	real_mp::default_precision(50);
+	complex_mp a;
 	BOOST_CHECK_EQUAL(a.real().precision(),50);
-	mpfr_complex::default_precision(40);
-	mpfr_float::default_precision(40);
+	complex_mp::default_precision(40);
+	real_mp::default_precision(40);
 	BOOST_CHECK_EQUAL(a.real().precision(),50);
 
-	mpfr_complex::default_precision(50);
-	mpfr_float::default_precision(50);
-	mpfr_complex b;
+	complex_mp::default_precision(50);
+	real_mp::default_precision(50);
+	complex_mp b;
 	BOOST_CHECK_EQUAL(b.real().precision(),50);
-	mpfr_float::default_precision(40);
+	real_mp::default_precision(40);
 	BOOST_CHECK_EQUAL(b.real().precision(),50);
 
 
 
-	mpfr_complex::default_precision(50);
-	mpfr_float::default_precision(50);
-	mpfr_complex c;
+	complex_mp::default_precision(50);
+	real_mp::default_precision(50);
+	complex_mp c;
 	BOOST_CHECK_EQUAL(c.real().precision(),50);
-	mpfr_complex::default_precision(40);
+	complex_mp::default_precision(40);
 	BOOST_CHECK_EQUAL(c.real().precision(),50);
 }
 
@@ -773,12 +773,12 @@ BOOST_AUTO_TEST_CASE(complex_precision_predictable3)
 	bertini::scoped_mpfr_precision_options_this_thread precision_options(bertini::DefaultPrecisionPolicy());
 
 	DefaultPrecision(50);
-	mpfr_complex a;
+	complex_mp a;
 
 	DefaultPrecision(40);
-	mpfr_complex b(a);
+	complex_mp b(a);
 
-	mpfr_complex c = a;
+	complex_mp c = a;
 
 	BOOST_CHECK_EQUAL(c.precision(), 50);
 	BOOST_CHECK_EQUAL(b.precision(), 50);
@@ -790,10 +790,10 @@ BOOST_AUTO_TEST_CASE(complex_precision_move)
 	bertini::scoped_mpfr_precision_options_this_thread precision_options(bertini::DefaultPrecisionPolicy());
 
 	DefaultPrecision(50);
-	mpfr_complex a;
+	complex_mp a;
 
 	DefaultPrecision(100);
-	mpfr_complex b;
+	complex_mp b;
 
 	DefaultPrecision(50);
 	a = std::move(b);
@@ -806,10 +806,10 @@ BOOST_AUTO_TEST_CASE(complex_precision_move2)
 	bertini::scoped_mpfr_precision_options_this_thread precision_options(bertini::DefaultPrecisionPolicy());
 
 	DefaultPrecision(50);
-	mpfr_complex a;
+	complex_mp a;
 
 	DefaultPrecision(100);
-	mpfr_complex b;
+	complex_mp b;
 
 	a = std::move(b);
 	BOOST_CHECK_EQUAL(a.precision(),100);
@@ -820,9 +820,9 @@ BOOST_AUTO_TEST_CASE(real_precision_increase)
 	bertini::scoped_mpfr_precision_options_this_thread precision_options(bertini::DefaultPrecisionPolicy());
 
 	DefaultPrecision(50);
-	mpfr_float a(2);
+	real_mp a(2);
 	a.precision(100);
-	BOOST_CHECK(abs(mpfr_float(2)-a) < 1e-50);
+	BOOST_CHECK(abs(real_mp(2)-a) < 1e-50);
 }
 
 BOOST_AUTO_TEST_CASE(complex_precision_increase)
@@ -830,9 +830,9 @@ BOOST_AUTO_TEST_CASE(complex_precision_increase)
 	bertini::scoped_mpfr_precision_options_this_thread precision_options(bertini::DefaultPrecisionPolicy());
 
 	DefaultPrecision(50);
-	mpfr_complex a(2,3);
+	complex_mp a(2,3);
 	a.precision(100);
-	BOOST_CHECK(abs(mpfr_complex(2,3)-a) < 1e-50);
+	BOOST_CHECK(abs(complex_mp(2,3)-a) < 1e-50);
 }
 
 BOOST_AUTO_TEST_CASE(construct_from_nondefault_reals)
@@ -840,13 +840,13 @@ BOOST_AUTO_TEST_CASE(construct_from_nondefault_reals)
 	bertini::scoped_mpfr_precision_options_this_thread precision_options(bertini::DefaultPrecisionPolicy());
 
 	DefaultPrecision(100);
-	mpfr_float a(1);
-	mpfr_float b(2);
+	real_mp a(1);
+	real_mp b(2);
 
 
 	DefaultPrecision(50);
 
-	mpfr_complex z(a,b);
+	complex_mp z(a,b);
 
 	BOOST_CHECK_EQUAL(a.precision(), 100);
 	BOOST_CHECK_EQUAL(b.precision(), 100);
@@ -859,11 +859,11 @@ BOOST_AUTO_TEST_CASE(complex_get_from_stream_parens_with_comma)
 	std::stringstream ss;
 	ss << "(0.1234,-4.12397)";
 	
-	bertini::mpfr_complex z;
+	bertini::complex_mp z;
 	ss >> z;
 	
-	BOOST_CHECK_EQUAL(z.real(),bertini::mpfr_float("0.1234"));
-	BOOST_CHECK_EQUAL(z.imag(),bertini::mpfr_float("-4.12397"));
+	BOOST_CHECK_EQUAL(z.real(),bertini::real_mp("0.1234"));
+	BOOST_CHECK_EQUAL(z.imag(),bertini::real_mp("-4.12397"));
 }
 
 
@@ -872,11 +872,11 @@ BOOST_AUTO_TEST_CASE(complex_get_from_stream_parens_no_comma)
 	std::stringstream ss;
 	ss << "(-3.651263418976498712e-2)";
 	
-	bertini::mpfr_complex z;
+	bertini::complex_mp z;
 	ss >> z;
 	
-	BOOST_CHECK_EQUAL(z.real(),bertini::mpfr_float("-3.651263418976498712e-2"));
-	BOOST_CHECK_EQUAL(z.imag(),bertini::mpfr_float("0"));
+	BOOST_CHECK_EQUAL(z.real(),bertini::real_mp("-3.651263418976498712e-2"));
+	BOOST_CHECK_EQUAL(z.imag(),bertini::real_mp("0"));
 }
 
 
@@ -885,11 +885,11 @@ BOOST_AUTO_TEST_CASE(complex_get_from_stream_no_parens)
 	std::stringstream ss;
 	ss << "-3.651263418976498712e-2";
 	
-	bertini::mpfr_complex z;
+	bertini::complex_mp z;
 	ss >> z;
 	
-	BOOST_CHECK_EQUAL(z.real(),bertini::mpfr_float("-3.651263418976498712e-2"));
-	BOOST_CHECK_EQUAL(z.imag(),bertini::mpfr_float("0"));
+	BOOST_CHECK_EQUAL(z.real(),bertini::real_mp("-3.651263418976498712e-2"));
+	BOOST_CHECK_EQUAL(z.imag(),bertini::real_mp("0"));
 }
 
 
@@ -899,10 +899,10 @@ BOOST_AUTO_TEST_CASE(float_get_from_stream_parens_with_comma)
 	std::stringstream ss;
 	ss << "0.1234";
 	
-	bertini::mpfr_float z;
+	bertini::real_mp z;
 	ss >> z;
 	
-	BOOST_CHECK_EQUAL(z,bertini::mpfr_float("0.1234"));
+	BOOST_CHECK_EQUAL(z,bertini::real_mp("0.1234"));
 }
 
 
@@ -913,14 +913,14 @@ BOOST_AUTO_TEST_CASE(float_get_from_stream_parens_with_comma)
 BOOST_AUTO_TEST_CASE(precision_of_mpfr_is_16)
 {
 	DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
-	bertini::mpfr_complex a("1.23124");
+	bertini::complex_mp a("1.23124");
 	BOOST_CHECK_EQUAL(bertini::Precision(a), CLASS_TEST_MPFR_DEFAULT_DIGITS);
 }
 
 BOOST_AUTO_TEST_CASE(precision_of_mpfr_complex_is_16)
 {
 	DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
-	bertini::mpfr_complex a("1.23124","-0.6789124678912394");
+	bertini::complex_mp a("1.23124","-0.6789124678912394");
 	BOOST_CHECK_EQUAL(bertini::Precision(a), CLASS_TEST_MPFR_DEFAULT_DIGITS);
 }
 
@@ -936,7 +936,7 @@ BOOST_AUTO_TEST_CASE(precision_random_real_default)
 BOOST_AUTO_TEST_CASE(precision_random_real_highest)
 {	using namespace bertini;
 	DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
-	bertini::mpfr_complex a;
+	bertini::complex_mp a;
 	bertini::multiprecision::RandomRealAssign (a,1000);
 	BOOST_CHECK_EQUAL(bertini::Precision(a), 1000);
 	BOOST_CHECK_EQUAL(CLASS_TEST_MPFR_DEFAULT_DIGITS, DefaultPrecision());
@@ -953,7 +953,7 @@ BOOST_AUTO_TEST_CASE(precision_random_unit_default)
 BOOST_AUTO_TEST_CASE(precision_random_unit_highest)
 {	using namespace bertini;
 	DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
-	bertini::mpfr_complex a;
+	bertini::complex_mp a;
 	bertini::multiprecision::RandomUnitAssign(a,1000);
 	BOOST_CHECK_EQUAL(bertini::Precision(a), 1000);
 	BOOST_CHECK_EQUAL(CLASS_TEST_MPFR_DEFAULT_DIGITS, DefaultPrecision());
@@ -970,7 +970,7 @@ BOOST_AUTO_TEST_CASE(precision_random_default)
 BOOST_AUTO_TEST_CASE(precision_random_highest)
 {	using namespace bertini;
 	DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
-	bertini::mpfr_complex a;
+	bertini::complex_mp a;
 	bertini::multiprecision::rand_assign(a,1000);
 	BOOST_CHECK_EQUAL(Precision(a), 1000);
 	BOOST_CHECK_EQUAL(CLASS_TEST_MPFR_DEFAULT_DIGITS, DefaultPrecision());
@@ -981,9 +981,9 @@ BOOST_AUTO_TEST_CASE(precision_random_highest)
 BOOST_AUTO_TEST_CASE(precision_through_swap)
 {	using namespace bertini;
 	DefaultPrecision(50);
-	mpfr_complex a;
+	complex_mp a;
 	DefaultPrecision(40);
-	mpfr_complex b;
+	complex_mp b;
 
 	swap(a,b);
 	BOOST_CHECK_EQUAL(a.precision(), 40);
@@ -993,9 +993,9 @@ BOOST_AUTO_TEST_CASE(precision_through_swap)
 BOOST_AUTO_TEST_CASE(precision_through_swap2)
 {	using namespace bertini;
 	DefaultPrecision(50);
-	mpfr_complex a;
+	complex_mp a;
 	DefaultPrecision(40);
-	mpfr_complex b;
+	complex_mp b;
 
 	a.swap(b);
 	BOOST_CHECK_EQUAL(a.precision(), 40);
@@ -1006,7 +1006,7 @@ BOOST_AUTO_TEST_CASE(precision_through_swap2)
 BOOST_AUTO_TEST_CASE(precision_equality)
 {	using namespace bertini;
 	DefaultPrecision(1000);
-	mpfr_complex a("1.324719827394086120398419082734980126734089612309871092830981236748901273498071240986123094861246981263481263489016238947147129807419028748901273409127349087124612576129076541203975704195690418570914657910465091256016501650916509165097164509164509761409561097561097650791650971465097165097162059761209561029756019265019726509126509172650971625097162450971309756104975610274650917825018740981274098127409182375701465172340923847120836540491320467127043127893281461230951097260126309812374091265091824981231236409851274",
+	complex_mp a("1.324719827394086120398419082734980126734089612309871092830981236748901273498071240986123094861246981263481263489016238947147129807419028748901273409127349087124612576129076541203975704195690418570914657910465091256016501650916509165097164509164509761409561097561097650791650971465097165097162059761209561029756019265019726509126509172650971625097162450971309756104975610274650917825018740981274098127409182375701465172340923847120836540491320467127043127893281461230951097260126309812374091265091824981231236409851274",
 		"-0.80743891267394610982659071452346156102764312401571972642394120395608291471029347812645125986123123904123471209381289471230512983491286102875870192091283712396550981723409812740981263471230498715096104897123094710923879065981740928740981271801391209238470129560941870129387409812883437894183883841283700483832883218128438938184289148239164079329657861209381892037483468937489237419236509823723705612893489712412306531274812364980127304981648712483248732");
 
 	BOOST_CHECK_EQUAL(a,a);
@@ -1015,7 +1015,7 @@ BOOST_AUTO_TEST_CASE(precision_equality)
 BOOST_AUTO_TEST_CASE(precision_equality_default_differs)
 {	using namespace bertini;
 	DefaultPrecision(1000);
-	mpfr_complex a("1.324719827394086120398419082734980126734089612309871092830981236748901273498071240986123094861246981263481263489016238947147129807419028748901273409127349087124612576129076541203975704195690418570914657910465091256016501650916509165097164509164509761409561097561097650791650971465097165097162059761209561029756019265019726509126509172650971625097162450971309756104975610274650917825018740981274098127409182375701465172340923847120836540491320467127043127893281461230951097260126309812374091265091824981231236409851274",
+	complex_mp a("1.324719827394086120398419082734980126734089612309871092830981236748901273498071240986123094861246981263481263489016238947147129807419028748901273409127349087124612576129076541203975704195690418570914657910465091256016501650916509165097164509164509761409561097561097650791650971465097165097162059761209561029756019265019726509126509172650971625097162450971309756104975610274650917825018740981274098127409182375701465172340923847120836540491320467127043127893281461230951097260126309812374091265091824981231236409851274",
 		"-0.80743891267394610982659071452346156102764312401571972642394120395608291471029347812645125986123123904123471209381289471230512983491286102875870192091283712396550981723409812740981263471230498715096104897123094710923879065981740928740981271801391209238470129560941870129387409812883437894183883841283700483832883218128438938184289148239164079329657861209381892037483468937489237419236509823723705612893489712412306531274812364980127304981648712483248732");
 	DefaultPrecision(40);
 
@@ -1034,10 +1034,10 @@ BOOST_AUTO_TEST_CASE(default_precision_aligns_thread_local_with_static)
 {
 	using namespace bertini;
 	DefaultPrecision(57);
-	BOOST_CHECK_EQUAL(mpfr_float::default_precision(),         57u);
-	BOOST_CHECK_EQUAL(mpfr_complex::default_precision(),       57u);
-	BOOST_CHECK_EQUAL(mpfr_float::thread_default_precision(),  57u);
-	BOOST_CHECK_EQUAL(mpfr_complex::thread_default_precision(),57u);
+	BOOST_CHECK_EQUAL(real_mp::default_precision(),         57u);
+	BOOST_CHECK_EQUAL(complex_mp::default_precision(),       57u);
+	BOOST_CHECK_EQUAL(real_mp::thread_default_precision(),  57u);
+	BOOST_CHECK_EQUAL(complex_mp::thread_default_precision(),57u);
 
 	// restore so subsequent tests aren't surprised
 	DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
@@ -1048,7 +1048,7 @@ BOOST_AUTO_TEST_CASE(default_constructed_mpfr_float_inherits_default_precision)
 {
 	using namespace bertini;
 	DefaultPrecision(63);
-	mpfr_float f;                            // no explicit precision
+	real_mp f;                            // no explicit precision
 	BOOST_CHECK_EQUAL(f.precision(), 63u);   // must not be 0
 
 	DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
@@ -1059,7 +1059,7 @@ BOOST_AUTO_TEST_CASE(default_constructed_mpfr_complex_inherits_default_precision
 {
 	using namespace bertini;
 	DefaultPrecision(71);
-	mpfr_complex z;                          // no explicit precision
+	complex_mp z;                          // no explicit precision
 	BOOST_CHECK_EQUAL(z.precision(), 71u);   // must not be 0
 
 	DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
@@ -1070,18 +1070,18 @@ BOOST_AUTO_TEST_CASE(default_precision_recovers_thread_local_from_zero)
 {
 	using namespace bertini;
 	// Simulate a freshly-spawned thread on Boost 1.87: thread_default is 0.
-	mpfr_float::thread_default_precision(0);
-	mpfr_complex::thread_default_precision(0);
+	real_mp::thread_default_precision(0);
+	complex_mp::thread_default_precision(0);
 
 	// The fix: DefaultPrecision must repair both, not just the static side.
 	// Without this, the next default-constructed mpfr temporary aborts inside
 	// mpfr_init2 (this is what surfaced on macos-15-intel via boost::python).
 	DefaultPrecision(50);
-	BOOST_CHECK_EQUAL(mpfr_float::thread_default_precision(),  50u);
-	BOOST_CHECK_EQUAL(mpfr_complex::thread_default_precision(),50u);
+	BOOST_CHECK_EQUAL(real_mp::thread_default_precision(),  50u);
+	BOOST_CHECK_EQUAL(complex_mp::thread_default_precision(),50u);
 
-	mpfr_float  f;
-	mpfr_complex z;
+	real_mp  f;
+	complex_mp z;
 	BOOST_CHECK_EQUAL(f.precision(), 50u);
 	BOOST_CHECK_EQUAL(z.precision(), 50u);
 
@@ -1102,18 +1102,18 @@ BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE(complex_eigen_compatibility)
 
 
-using mpfr_float = bertini::mpfr_float;
+using real_mp = bertini::real_mp;
 using bertini::DefaultPrecision;
 
 BOOST_AUTO_TEST_CASE(mpfr_complex_eigen_norm_of_vector)
 {
 	DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
 
-	Eigen::Matrix<bertini::mpfr_complex, Eigen::Dynamic, Eigen::Dynamic> A(1,3);
-	A << bertini::mpfr_complex("1.0","1.0"), bertini::mpfr_complex("1.0","1.0"), bertini::mpfr_complex("1.0","1.0");
-	bertini::mpfr_float n = A.norm();
+	Eigen::Matrix<bertini::complex_mp, Eigen::Dynamic, Eigen::Dynamic> A(1,3);
+	A << bertini::complex_mp("1.0","1.0"), bertini::complex_mp("1.0","1.0"), bertini::complex_mp("1.0","1.0");
+	bertini::real_mp n = A.norm();
 
-	BOOST_CHECK(abs(n/sqrt(bertini::mpfr_float("6"))-mpfr_float("1"))<threshold_clearance_mp);
+	BOOST_CHECK(abs(n/sqrt(bertini::real_mp("6"))-real_mp("1"))<threshold_clearance_mp);
 }
 
 
@@ -1121,8 +1121,8 @@ BOOST_AUTO_TEST_CASE(mpfr_complex_eigen_negative_of_vector)
 {
 	DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
 
-	Eigen::Matrix<bertini::mpfr_complex, Eigen::Dynamic, Eigen::Dynamic> A(1,3);
-	A << bertini::mpfr_complex("1.0","1.0"), bertini::mpfr_complex("1.0","1.0"), bertini::mpfr_complex("1.0","1.0");
+	Eigen::Matrix<bertini::complex_mp, Eigen::Dynamic, Eigen::Dynamic> A(1,3);
+	A << bertini::complex_mp("1.0","1.0"), bertini::complex_mp("1.0","1.0"), bertini::complex_mp("1.0","1.0");
 	auto B = -A;
 
 	BOOST_CHECK_EQUAL(B(0), -A(0));
@@ -1136,7 +1136,7 @@ BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_AUTO_TEST_SUITE(miscellaneous_complex_tests_out_of_place)
 
-using mpfr_float = bertini::mpfr_float;
+using real_mp = bertini::real_mp;
 using bertini::DefaultPrecision;
 
 BOOST_AUTO_TEST_CASE(mpfr_float_serialization)
@@ -1145,7 +1145,7 @@ BOOST_AUTO_TEST_CASE(mpfr_float_serialization)
 	DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
 	
 	
-	mpfr_float q = acos( mpfr_float("-1.0") );
+	real_mp q = acos( real_mp("-1.0") );
 	
 	
 	{
@@ -1157,7 +1157,7 @@ BOOST_AUTO_TEST_CASE(mpfr_float_serialization)
 		oa << q;
 	}
 	
-	mpfr_float w;
+	real_mp w;
 	{
 		std::ifstream fin("serialization_test_mpfr");
 		
@@ -1173,11 +1173,11 @@ BOOST_AUTO_TEST_CASE(mpfr_float_serialization)
 
 BOOST_AUTO_TEST_CASE(mpfr_float_serialization2)
 {
-	using mpfr_float = bertini::mpfr_float;
+	using real_mp = bertini::real_mp;
 	DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
 	
 	
-	mpfr_float q = acos( mpfr_float("-1.0") );
+	real_mp q = acos( real_mp("-1.0") );
 	
 	
 	{
@@ -1191,7 +1191,7 @@ BOOST_AUTO_TEST_CASE(mpfr_float_serialization2)
 	
 	DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS*2);
 
-	mpfr_float w;
+	real_mp w;
 	{
 		std::ifstream fin("serialization_test_mpfr");
 		

--- a/core/test/classes/degrees_test.cpp
+++ b/core/test/classes/degrees_test.cpp
@@ -59,13 +59,13 @@ using bertini::DefaultPrecision;
 namespace {
 
 // augmented coefficient matrix (rows x (num_vars+1)), last column the constant term.
-Mat<mpfr_complex> AugMat(std::vector<std::vector<int>> const& rows)
+Mat<complex_mp> AugMat(std::vector<std::vector<int>> const& rows)
 {
-	Mat<mpfr_complex> M(static_cast<Eigen::Index>(rows.size()),
+	Mat<complex_mp> M(static_cast<Eigen::Index>(rows.size()),
 	                    static_cast<Eigen::Index>(rows.front().size()));
 	for (Eigen::Index i = 0; i < M.rows(); ++i)
 		for (Eigen::Index j = 0; j < M.cols(); ++j)
-			M(i, j) = mpfr_complex(rows[static_cast<size_t>(i)][static_cast<size_t>(j)]);
+			M(i, j) = complex_mp(rows[static_cast<size_t>(i)][static_cast<size_t>(j)]);
 	return M;
 }
 
@@ -186,9 +186,9 @@ BOOST_AUTO_TEST_CASE(products_of_linears_degree_is_factor_count)
 {
 	DefaultPrecision(30);
 	// f0 = product of 2 linear factors (degree 2); f1 = product of 3 (degree 3).
-	Mat<mpfr_complex> f0 = AugMat({{2, 3, 1}, {1, -1, 4}});
-	Mat<mpfr_complex> f1 = AugMat({{1, 0, 1}, {0, 1, -2}, {1, 1, 0}});
-	ProductsOfLinearsBlock block(2, std::vector<Mat<mpfr_complex>>{f0, f1});
+	Mat<complex_mp> f0 = AugMat({{2, 3, 1}, {1, -1, 4}});
+	Mat<complex_mp> f1 = AugMat({{1, 0, 1}, {0, 1, -2}, {1, 1, 0}});
+	ProductsOfLinearsBlock block(2, std::vector<Mat<complex_mp>>{f0, f1});
 
 	std::vector<int> expected{2, 3};
 	BOOST_CHECK(block.Degrees() == expected);
@@ -199,7 +199,7 @@ BOOST_AUTO_TEST_CASE(products_of_linears_degree_is_factor_count)
 	System sys;
 	Var x = Variable::Make("x"), y = Variable::Make("y");
 	sys.AddVariableGroup(VariableGroup{x, y});
-	sys.AddBlock(ProductsOfLinearsBlock(2, std::vector<Mat<mpfr_complex>>{f0, f1}));
+	sys.AddBlock(ProductsOfLinearsBlock(2, std::vector<Mat<complex_mp>>{f0, f1}));
 	BOOST_CHECK(sys.Degrees() == expected);
 	BOOST_CHECK_EQUAL(sys.DegreeBound(), 3);
 }

--- a/core/test/classes/eigen_test.cpp
+++ b/core/test/classes/eigen_test.cpp
@@ -43,12 +43,12 @@
 
 BOOST_AUTO_TEST_SUITE(num_traits_checking)
 
-using mpfr_float = bertini::mpfr_float;
+using real_mp = bertini::real_mp;
 
-// this test assures that the Eigen::NumTraits defined in eigen_extensions.hpp is correctly found during template instantiation, and that the Real type it defines is actually mpfr_float.  If it were not, then we would be unable to make an expression of ::Real type in variable q, because it would be an expression, not a populatable number of type mpfr_float.
+// this test assures that the Eigen::NumTraits defined in eigen_extensions.hpp is correctly found during template instantiation, and that the Real type it defines is actually real_mp.  If it were not, then we would be unable to make an expression of ::Real type in variable q, because it would be an expression, not a populatable number of type real_mp.
 BOOST_AUTO_TEST_CASE(expressions_of_mpfr_floats)
 {
-	using NumT = bertini::mpfr_float;
+	using NumT = bertini::real_mp;
 
 	NumT a {1}, b{2}, c{3};
 
@@ -58,7 +58,7 @@ BOOST_AUTO_TEST_CASE(expressions_of_mpfr_floats)
 
 BOOST_AUTO_TEST_CASE(size_object_sensible_vec)
 {
-	bertini::Vec<bertini::dbl> v(3);
+	bertini::Vec<bertini::complex_dbl> v(3);
 	BOOST_CHECK_EQUAL(v.rows(),3);
 	BOOST_CHECK_EQUAL(v.cols(),1);
 
@@ -68,7 +68,7 @@ BOOST_AUTO_TEST_CASE(size_object_sensible_vec)
 
 BOOST_AUTO_TEST_CASE(size_object_sensible_mat)
 {
-	bertini::Mat<bertini::dbl> v(3,4);
+	bertini::Mat<bertini::complex_dbl> v(3,4);
 	BOOST_CHECK_EQUAL(v.rows(),3);
 	BOOST_CHECK_EQUAL(v.cols(),4);
 
@@ -80,7 +80,7 @@ BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_AUTO_TEST_SUITE(kahan_matrix_solving_LU)
 
-using mpfr_float = bertini::mpfr_float;
+using real_mp = bertini::real_mp;
 using bertini::KahanMatrix;
 
 	BOOST_AUTO_TEST_CASE(solve_100x100_kahan_matrix_double) {
@@ -108,13 +108,13 @@ using bertini::KahanMatrix;
 		
 		srand(2);  rand();
 		
-		Eigen::Matrix<bertini::mpfr_float, Eigen::Dynamic, Eigen::Dynamic> A =
-			KahanMatrix(size, bertini::mpfr_float(0.285)), B(size,size), C;
+		Eigen::Matrix<bertini::real_mp, Eigen::Dynamic, Eigen::Dynamic> A =
+			KahanMatrix(size, bertini::real_mp(0.285)), B(size,size), C;
 		
 		
 		for (unsigned int ii=0; ii<size; ii++)
 			for (unsigned int jj=0; jj<size; jj++)
-				jj!=ii? B(ii,jj) = -bertini::mpfr_float(1)/(ii+1) + bertini::mpfr_float(rand()) /  bertini::mpfr_float(RAND_MAX) : B(ii,jj) = 0;
+				jj!=ii? B(ii,jj) = -bertini::real_mp(1)/(ii+1) + bertini::real_mp(rand()) /  bertini::real_mp(RAND_MAX) : B(ii,jj) = 0;
 
 		C = A.lu().solve(B);
 	}
@@ -127,7 +127,7 @@ using bertini::KahanMatrix;
 		unsigned int size = 10;
 		srand(2);  rand();
 		
-		using mpfr = bertini::mpfr_float;
+		using mpfr = bertini::real_mp;
 		using mpfr_matrix = Eigen::Matrix<mpfr, Eigen::Dynamic, Eigen::Dynamic>;
 
 		bertini::DefaultPrecision(100);
@@ -173,12 +173,12 @@ using bertini::KahanMatrix;
 		
 		srand(2);  rand();
 		
-		Eigen::Matrix<bertini::mpfr_complex, Eigen::Dynamic, Eigen::Dynamic> A =
-		KahanMatrix(size, bertini::mpfr_complex("0.285","0.0")), B(size,size), C;
+		Eigen::Matrix<bertini::complex_mp, Eigen::Dynamic, Eigen::Dynamic> A =
+		KahanMatrix(size, bertini::complex_mp("0.285","0.0")), B(size,size), C;
 		
 		for (unsigned int ii=0; ii<size; ii++)
 			for (unsigned int jj=0; jj<size; jj++)
-				jj!=ii? B(ii,jj) = bertini::mpfr_complex( bertini::mpfr_complex(-1)/bertini::mpfr_complex(ii+1) + bertini::mpfr_complex(rand()) / bertini::mpfr_complex(RAND_MAX)) : B(ii,jj) = bertini::mpfr_complex(0);
+				jj!=ii? B(ii,jj) = bertini::complex_mp( bertini::complex_mp(-1)/bertini::complex_mp(ii+1) + bertini::complex_mp(rand()) / bertini::complex_mp(RAND_MAX)) : B(ii,jj) = bertini::complex_mp(0);
 		
 		C = A.lu().solve(B);
 	}
@@ -189,10 +189,10 @@ using bertini::KahanMatrix;
 		
 //		BOOST_AUTO_TEST_CASE(mpfr_float_num_traits){
 //			
-//			std::cout << Eigen::NumTraits<bertini::mpfr_float>::highest() << std::endl;
-//			std::cout << Eigen::NumTraits<bertini::mpfr_float>::lowest() << std::endl;
-//			std::cout << Eigen::NumTraits<bertini::mpfr_float>::dummy_precision() << std::endl;
-//			std::cout << Eigen::NumTraits<bertini::mpfr_float>::epsilon() << std::endl;
+//			std::cout << Eigen::NumTraits<bertini::real_mp>::highest() << std::endl;
+//			std::cout << Eigen::NumTraits<bertini::real_mp>::lowest() << std::endl;
+//			std::cout << Eigen::NumTraits<bertini::real_mp>::dummy_precision() << std::endl;
+//			std::cout << Eigen::NumTraits<bertini::real_mp>::epsilon() << std::endl;
 //			
 //		}
 	
@@ -259,39 +259,39 @@ using bertini::KahanMatrix;
 
 		bertini::DefaultPrecision(30);
 
-		bertini::mpfr_float p = pow(mpfr_float(10),-mpfr_float(30));
+		bertini::real_mp p = pow(real_mp(10),-real_mp(30));
 
-		BOOST_CHECK( bertini::IsSmallValue(bertini::mpfr_complex(p,mpfr_float(0))));
-		BOOST_CHECK( bertini::IsSmallValue(bertini::mpfr_complex(-p,mpfr_float(0))));
-		BOOST_CHECK(!bertini::IsSmallValue(bertini::mpfr_complex(1e-15,0.0)));
-		BOOST_CHECK(!bertini::IsSmallValue(bertini::mpfr_complex(1e-14,0.0)));
-		BOOST_CHECK(!bertini::IsSmallValue(bertini::mpfr_complex(1e-10,0.0)));
-		BOOST_CHECK(!bertini::IsSmallValue(bertini::mpfr_complex(1e2,0.0)));
+		BOOST_CHECK( bertini::IsSmallValue(bertini::complex_mp(p,real_mp(0))));
+		BOOST_CHECK( bertini::IsSmallValue(bertini::complex_mp(-p,real_mp(0))));
+		BOOST_CHECK(!bertini::IsSmallValue(bertini::complex_mp(1e-15,0.0)));
+		BOOST_CHECK(!bertini::IsSmallValue(bertini::complex_mp(1e-14,0.0)));
+		BOOST_CHECK(!bertini::IsSmallValue(bertini::complex_mp(1e-10,0.0)));
+		BOOST_CHECK(!bertini::IsSmallValue(bertini::complex_mp(1e2,0.0)));
 
-		BOOST_CHECK(!bertini::IsSmallValue(bertini::mpfr_complex(-1e-15,0.0)));
-		BOOST_CHECK(!bertini::IsSmallValue(bertini::mpfr_complex(-1e-14,0.0)));
-		BOOST_CHECK(!bertini::IsSmallValue(bertini::mpfr_complex(-1e-10,0.0)));
-		BOOST_CHECK(!bertini::IsSmallValue(bertini::mpfr_complex(-1e2,0.0)));
+		BOOST_CHECK(!bertini::IsSmallValue(bertini::complex_mp(-1e-15,0.0)));
+		BOOST_CHECK(!bertini::IsSmallValue(bertini::complex_mp(-1e-14,0.0)));
+		BOOST_CHECK(!bertini::IsSmallValue(bertini::complex_mp(-1e-10,0.0)));
+		BOOST_CHECK(!bertini::IsSmallValue(bertini::complex_mp(-1e2,0.0)));
 	}
 
 	BOOST_AUTO_TEST_CASE(large_change_multiprecision)
 	{
 		bertini::DefaultPrecision(30);
 
-		bertini::mpfr_float p = pow(mpfr_float(10),-mpfr_float(30));
+		bertini::real_mp p = pow(real_mp(10),-real_mp(30));
 
-		BOOST_CHECK( bertini::IsLargeChange(mpfr_float(1.0),p));
+		BOOST_CHECK( bertini::IsLargeChange(real_mp(1.0),p));
 
-		BOOST_CHECK( bertini::IsLargeChange(mpfr_float(1e16),mpfr_float(p*mpfr_float(1e16))));
+		BOOST_CHECK( bertini::IsLargeChange(real_mp(1e16),real_mp(p*real_mp(1e16))));
 
-		BOOST_CHECK( bertini::IsLargeChange(mpfr_float(-1e16),mpfr_float(p*mpfr_float(1e16))));
-		BOOST_CHECK( bertini::IsLargeChange(mpfr_float(1e16),mpfr_float(-p*mpfr_float(1e16))));
+		BOOST_CHECK( bertini::IsLargeChange(real_mp(-1e16),real_mp(p*real_mp(1e16))));
+		BOOST_CHECK( bertini::IsLargeChange(real_mp(1e16),real_mp(-p*real_mp(1e16))));
 
-		BOOST_CHECK(!bertini::IsLargeChange(mpfr_float(1.0),mpfr_float(1e-12)));
-		BOOST_CHECK(!bertini::IsLargeChange(mpfr_float(-1.0),mpfr_float(1e-12)));
-		BOOST_CHECK(!bertini::IsLargeChange(mpfr_float(1e5),mpfr_float(1e-7)));
-		BOOST_CHECK(!bertini::IsLargeChange(mpfr_float(1e3),mpfr_float(1e-4)));
-		BOOST_CHECK(!bertini::IsLargeChange(mpfr_float(1e-15),mpfr_float(1e-18)));
+		BOOST_CHECK(!bertini::IsLargeChange(real_mp(1.0),real_mp(1e-12)));
+		BOOST_CHECK(!bertini::IsLargeChange(real_mp(-1.0),real_mp(1e-12)));
+		BOOST_CHECK(!bertini::IsLargeChange(real_mp(1e5),real_mp(1e-7)));
+		BOOST_CHECK(!bertini::IsLargeChange(real_mp(1e3),real_mp(1e-4)));
+		BOOST_CHECK(!bertini::IsLargeChange(real_mp(1e-15),real_mp(1e-18)));
 	}
 
 	BOOST_AUTO_TEST_CASE(eigen_LU_partial_pivot_3x3)
@@ -319,7 +319,7 @@ using bertini::KahanMatrix;
 	{
 		bertini::DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
 
-		using data_type = bertini::mpfr_complex;
+		using data_type = bertini::complex_mp;
 		
 		Eigen::Matrix<data_type, 3, 1> v(data_type(2),data_type(4),data_type(3));
 		Eigen::Matrix<data_type, 3, 1> w(data_type(1),data_type(2),data_type(-1));
@@ -336,7 +336,7 @@ using bertini::KahanMatrix;
 	{
 		bertini::DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
 
-		using data_type = bertini::mpfr_complex;
+		using data_type = bertini::complex_mp;
 		
 		Eigen::Matrix<data_type, Eigen::Dynamic, Eigen::Dynamic> A(2,2);
 		A << data_type(2), data_type(1), data_type(1), data_type(2);
@@ -354,7 +354,7 @@ using bertini::KahanMatrix;
 	{
 		bertini::DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
 
-		using data_type = bertini::mpfr_complex;
+		using data_type = bertini::complex_mp;
 		
 		Eigen::Matrix<data_type, Eigen::Dynamic, Eigen::Dynamic> A(2,2);
 		A << data_type(2), data_type(1), data_type(1), data_type(2);
@@ -370,7 +370,7 @@ using bertini::KahanMatrix;
 	{
 		bertini::DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
 
-		using data_type = bertini::mpfr_complex;
+		using data_type = bertini::complex_mp;
 		
 		data_type q(1);
 		int a(1);
@@ -391,7 +391,7 @@ using bertini::KahanMatrix;
 	{
 		bertini::DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
 
-		using data_type = bertini::mpfr_complex;
+		using data_type = bertini::complex_mp;
 		
 		data_type q(1);
 		long a(1);
@@ -411,7 +411,7 @@ using bertini::KahanMatrix;
 	{
 		bertini::DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
 
-		using data_type = bertini::mpfr_complex;
+		using data_type = bertini::complex_mp;
 		
 		data_type q(1);
 		bertini::mpz_int a(1);
@@ -435,7 +435,7 @@ using bertini::KahanMatrix;
 	BOOST_AUTO_TEST_CASE(self_multiplication_dbl_int)
 	{
 		
-		using data_type = bertini::dbl;
+		using data_type = bertini::complex_dbl;
 		
 		Eigen::Matrix<data_type, Eigen::Dynamic, Eigen::Dynamic> A(2,2);
 		A << data_type(2), data_type(1), data_type(1), data_type(2);
@@ -450,7 +450,7 @@ using bertini::KahanMatrix;
 	{
 		bertini::DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
 
-		using data_type = bertini::mpfr_complex;
+		using data_type = bertini::complex_mp;
 		
 		Eigen::Matrix<data_type, Eigen::Dynamic, Eigen::Dynamic> A(2,2);
 		A << data_type(2), data_type(1), data_type(1), data_type(2);
@@ -465,7 +465,7 @@ using bertini::KahanMatrix;
 	{
 		bertini::DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
 
-		using data_type = bertini::mpfr_complex;
+		using data_type = bertini::complex_mp;
 		
 		data_type q(1);
 		int a(1);
@@ -483,7 +483,7 @@ using bertini::KahanMatrix;
 	{
 		bertini::DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
 
-		using data_type = bertini::mpfr_complex;
+		using data_type = bertini::complex_mp;
 		
 		data_type q(1);
 		long a(1);
@@ -498,7 +498,7 @@ using bertini::KahanMatrix;
 	{
 		bertini::DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
 
-		using data_type = bertini::mpfr_complex;
+		using data_type = bertini::complex_mp;
 		
 		data_type q(1);
 		bertini::mpz_int a(1);
@@ -514,7 +514,7 @@ using bertini::KahanMatrix;
 		bertini::DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
 
 		using bertini::Precision;
-		using data_type = bertini::mpfr_float;
+		using data_type = bertini::real_mp;
 		
 		Eigen::Matrix<data_type, Eigen::Dynamic, Eigen::Dynamic> A(2,2);
 		A << data_type(2), data_type(1), data_type(1), data_type(2);
@@ -528,7 +528,7 @@ using bertini::KahanMatrix;
 		bertini::DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
 
 		using bertini::Precision;
-		using data_type = bertini::mpfr_complex;
+		using data_type = bertini::complex_mp;
 		
 		Eigen::Matrix<data_type, Eigen::Dynamic, Eigen::Dynamic> A(2,2);
 		A << data_type(2), data_type(1), data_type(1), data_type(2);
@@ -544,7 +544,7 @@ using bertini::KahanMatrix;
 		bertini::DefaultPrecision(50);
 
 		using bertini::Precision;
-		using data_type = bertini::mpfr_complex;
+		using data_type = bertini::complex_mp;
 		
 		Eigen::Matrix<data_type, Eigen::Dynamic, Eigen::Dynamic> A(2,2);
 		A << data_type(2), data_type(1), data_type(1), data_type(2);
@@ -568,7 +568,7 @@ using bertini::KahanMatrix;
 		bertini::DefaultPrecision(50);
 
 		using bertini::Precision;
-		using data_type = bertini::mpfr_complex;
+		using data_type = bertini::complex_mp;
 		
 		Eigen::Matrix<data_type, Eigen::Dynamic, 1> A(4);
 		A << data_type(2), data_type(1), data_type(1), data_type(2);

--- a/core/test/classes/eval_expression_test.cpp
+++ b/core/test/classes/eval_expression_test.cpp
@@ -10,8 +10,8 @@ using bertini::EvalExpression;
 using bertini::node::Variable;
 using bertini::node::Integer;
 using Nd = std::shared_ptr<bertini::node::Node>;
-using dbl = bertini::dbl;
-using mpfr_complex = bertini::mpfr_complex;
+using complex_dbl = bertini::complex_dbl;
+using complex_mp = bertini::complex_mp;
 
 BOOST_AUTO_TEST_SUITE(eval_expression_without_a_system)
 
@@ -24,10 +24,10 @@ BOOST_AUTO_TEST_CASE(evaluates_a_bare_polynomial_in_double)
 
 	Nd f = x*x + y; // 2^2 + 5 == 9
 
-	std::map<std::string,dbl> values{ {"x", dbl(2,0)}, {"y", dbl(5,0)} };
-	auto result = EvalExpression<dbl>(f, values);
+	std::map<std::string,complex_dbl> values{ {"x", complex_dbl(2,0)}, {"y", complex_dbl(5,0)} };
+	auto result = EvalExpression<complex_dbl>(f, values);
 
-	BOOST_CHECK_SMALL(std::abs(result - dbl(9,0)), 1e-14);
+	BOOST_CHECK_SMALL(std::abs(result - complex_dbl(9,0)), 1e-14);
 }
 
 // Variables are matched to values by name regardless of the order they appear in the map
@@ -39,10 +39,10 @@ BOOST_AUTO_TEST_CASE(binds_values_by_name_not_position)
 
 	Nd f = a - b; // a=7, b=3 -> 4, even though 'b' is listed first in the map
 
-	std::map<std::string,dbl> values{ {"b", dbl(3,0)}, {"a", dbl(7,0)} };
-	auto result = EvalExpression<dbl>(f, values);
+	std::map<std::string,complex_dbl> values{ {"b", complex_dbl(3,0)}, {"a", complex_dbl(7,0)} };
+	auto result = EvalExpression<complex_dbl>(f, values);
 
-	BOOST_CHECK_SMALL(std::abs(result - dbl(4,0)), 1e-14);
+	BOOST_CHECK_SMALL(std::abs(result - complex_dbl(4,0)), 1e-14);
 }
 
 // A constant expression has no variables; an empty value map is the correct input.
@@ -50,10 +50,10 @@ BOOST_AUTO_TEST_CASE(evaluates_a_constant_with_no_variables)
 {
 	Nd f = Integer::Make(3) * Integer::Make(4); // 12
 
-	std::map<std::string,dbl> values; // empty
-	auto result = EvalExpression<dbl>(f, values);
+	std::map<std::string,complex_dbl> values; // empty
+	auto result = EvalExpression<complex_dbl>(f, values);
 
-	BOOST_CHECK_SMALL(std::abs(result - dbl(12,0)), 1e-14);
+	BOOST_CHECK_SMALL(std::abs(result - complex_dbl(12,0)), 1e-14);
 }
 
 // A constant expression evaluates in multiple precision too (the empty-point path).
@@ -63,10 +63,10 @@ BOOST_AUTO_TEST_CASE(evaluates_a_constant_in_multiple_precision)
 
 	Nd f = Integer::Make(3) * Integer::Make(4); // 12
 
-	std::map<std::string,mpfr_complex> values; // empty
-	auto result = EvalExpression<mpfr_complex>(f, values);
+	std::map<std::string,complex_mp> values; // empty
+	auto result = EvalExpression<complex_mp>(f, values);
 
-	BOOST_CHECK(abs(result - mpfr_complex(12)) < 1e-40);
+	BOOST_CHECK(abs(result - complex_mp(12)) < 1e-40);
 }
 
 // Every variable of the expression must be given a value; a missing one is an error.
@@ -77,8 +77,8 @@ BOOST_AUTO_TEST_CASE(missing_variable_value_is_an_error)
 
 	Nd f = x + y;
 
-	std::map<std::string,dbl> values{ {"x", dbl(1,0)} }; // y omitted
-	BOOST_CHECK_THROW(EvalExpression<dbl>(f, values), std::runtime_error);
+	std::map<std::string,complex_dbl> values{ {"x", complex_dbl(1,0)} }; // y omitted
+	BOOST_CHECK_THROW(EvalExpression<complex_dbl>(f, values), std::runtime_error);
 }
 
 // Supplying a value for a name not in the expression is an error (typo guard).
@@ -88,8 +88,8 @@ BOOST_AUTO_TEST_CASE(value_for_unknown_variable_is_an_error)
 
 	Nd f = x*x;
 
-	std::map<std::string,dbl> values{ {"x", dbl(2,0)}, {"z", dbl(9,0)} }; // z not present
-	BOOST_CHECK_THROW(EvalExpression<dbl>(f, values), std::runtime_error);
+	std::map<std::string,complex_dbl> values{ {"x", complex_dbl(2,0)}, {"z", complex_dbl(9,0)} }; // z not present
+	BOOST_CHECK_THROW(EvalExpression<complex_dbl>(f, values), std::runtime_error);
 }
 
 // The same expression evaluates correctly in multiple precision.
@@ -102,11 +102,11 @@ BOOST_AUTO_TEST_CASE(evaluates_in_multiple_precision)
 
 	Nd f = x*x + y; // 3^2 + 4 == 13
 
-	std::map<std::string,mpfr_complex> values{
-		{"x", mpfr_complex(3)}, {"y", mpfr_complex(4)} };
-	auto result = EvalExpression<mpfr_complex>(f, values);
+	std::map<std::string,complex_mp> values{
+		{"x", complex_mp(3)}, {"y", complex_mp(4)} };
+	auto result = EvalExpression<complex_mp>(f, values);
 
-	BOOST_CHECK(abs(result - mpfr_complex(13)) < 1e-40);
+	BOOST_CHECK(abs(result - complex_mp(13)) < 1e-40);
 }
 
 // The compiled evaluator is memoized on the (immutable, hash-consed) expression node: the first
@@ -119,16 +119,16 @@ BOOST_AUTO_TEST_CASE(memoizes_the_compiled_program_on_the_node)
 
 	BOOST_CHECK(f->EvalProgram() == nullptr);            // nothing compiled yet
 
-	std::map<std::string,dbl> values{ {"x", dbl(3,0)} };
-	auto r1 = EvalExpression<dbl>(f, values);            // x=3 -> 10
-	BOOST_CHECK_SMALL(std::abs(r1 - dbl(10,0)), 1e-14);
+	std::map<std::string,complex_dbl> values{ {"x", complex_dbl(3,0)} };
+	auto r1 = EvalExpression<complex_dbl>(f, values);            // x=3 -> 10
+	BOOST_CHECK_SMALL(std::abs(r1 - complex_dbl(10,0)), 1e-14);
 
 	auto cached = f->EvalProgram();
 	BOOST_CHECK(cached != nullptr);                      // first eval compiled + cached the program
 
-	values["x"] = dbl(5,0);
-	auto r2 = EvalExpression<dbl>(f, values);            // x=5 -> 26, still correct
-	BOOST_CHECK_SMALL(std::abs(r2 - dbl(26,0)), 1e-14);
+	values["x"] = complex_dbl(5,0);
+	auto r2 = EvalExpression<complex_dbl>(f, values);            // x=5 -> 26, still correct
+	BOOST_CHECK_SMALL(std::abs(r2 - complex_dbl(26,0)), 1e-14);
 	BOOST_CHECK(f->EvalProgram() == cached);             // and reused the very same cached program
 }
 
@@ -141,26 +141,26 @@ BOOST_AUTO_TEST_CASE(every_operator_compiles_and_evaluates_through_the_slp)
 	auto x = Variable::Make("x");
 	auto y = Variable::Make("y");
 	const double tol = 1e-12;
-	auto E1 = [&](Nd f, double xv){ return EvalExpression<dbl>(f, {{"x", dbl(xv,0)}}); };
-	auto E2 = [&](Nd f, double xv, double yv){ return EvalExpression<dbl>(f, {{"x", dbl(xv,0)}, {"y", dbl(yv,0)}}); };
+	auto E1 = [&](Nd f, double xv){ return EvalExpression<complex_dbl>(f, {{"x", complex_dbl(xv,0)}}); };
+	auto E2 = [&](Nd f, double xv, double yv){ return EvalExpression<complex_dbl>(f, {{"x", complex_dbl(xv,0)}, {"y", complex_dbl(yv,0)}}); };
 
-	BOOST_CHECK_SMALL(std::abs(E2(x + y + Integer::Make(3), 2, 5) - dbl(10)), tol); // Sum
-	BOOST_CHECK_SMALL(std::abs(E2(x - y - Integer::Make(1), 5, 2) - dbl(2)),  tol); // Subtract
-	BOOST_CHECK_SMALL(std::abs(E2(x * y * Integer::Make(2), 3, 4) - dbl(24)), tol); // Multiply
-	BOOST_CHECK_SMALL(std::abs(E2(x / y, 6, 2) - dbl(3)), tol);                     // Divide
-	BOOST_CHECK_SMALL(std::abs(E1(-x, 3) - dbl(-3)), tol);                          // Negate
-	BOOST_CHECK_SMALL(std::abs(E1(pow(x, 3), 2) - dbl(8)), tol);                    // IntPower
-	BOOST_CHECK_SMALL(std::abs(E2(pow(x, y), 2, 3) - dbl(8)), tol);                 // Power (variable exponent)
-	BOOST_CHECK_SMALL(std::abs(E1(sqrt(x), 4) - dbl(2)), tol);                      // Sqrt
-	BOOST_CHECK_SMALL(std::abs(E1(exp(x), 0) - dbl(1)), tol);                       // Exp
-	BOOST_CHECK_SMALL(std::abs(E1(log(x), 1) - dbl(0)), tol);                       // Log
-	BOOST_CHECK_SMALL(std::abs(E1(sin(x), 0) - dbl(0)), tol);                       // Sin
-	BOOST_CHECK_SMALL(std::abs(E1(cos(x), 0) - dbl(1)), tol);                       // Cos
-	BOOST_CHECK_SMALL(std::abs(E1(tan(x), 0) - dbl(0)), tol);                       // Tan
-	BOOST_CHECK_SMALL(std::abs(E1(asin(x), 0) - dbl(0)), tol);                      // Asin
-	BOOST_CHECK_SMALL(std::abs(E1(acos(x), 1) - dbl(0)), tol);                      // Acos
-	BOOST_CHECK_SMALL(std::abs(E1(atan(x), 0) - dbl(0)), tol);                      // Atan
-	BOOST_CHECK_SMALL(std::abs(E1(Pi() * x, 1) - dbl(3.141592653589793, 0)), 1e-12); // Pi
+	BOOST_CHECK_SMALL(std::abs(E2(x + y + Integer::Make(3), 2, 5) - complex_dbl(10)), tol); // Sum
+	BOOST_CHECK_SMALL(std::abs(E2(x - y - Integer::Make(1), 5, 2) - complex_dbl(2)),  tol); // Subtract
+	BOOST_CHECK_SMALL(std::abs(E2(x * y * Integer::Make(2), 3, 4) - complex_dbl(24)), tol); // Multiply
+	BOOST_CHECK_SMALL(std::abs(E2(x / y, 6, 2) - complex_dbl(3)), tol);                     // Divide
+	BOOST_CHECK_SMALL(std::abs(E1(-x, 3) - complex_dbl(-3)), tol);                          // Negate
+	BOOST_CHECK_SMALL(std::abs(E1(pow(x, 3), 2) - complex_dbl(8)), tol);                    // IntPower
+	BOOST_CHECK_SMALL(std::abs(E2(pow(x, y), 2, 3) - complex_dbl(8)), tol);                 // Power (variable exponent)
+	BOOST_CHECK_SMALL(std::abs(E1(sqrt(x), 4) - complex_dbl(2)), tol);                      // Sqrt
+	BOOST_CHECK_SMALL(std::abs(E1(exp(x), 0) - complex_dbl(1)), tol);                       // Exp
+	BOOST_CHECK_SMALL(std::abs(E1(log(x), 1) - complex_dbl(0)), tol);                       // Log
+	BOOST_CHECK_SMALL(std::abs(E1(sin(x), 0) - complex_dbl(0)), tol);                       // Sin
+	BOOST_CHECK_SMALL(std::abs(E1(cos(x), 0) - complex_dbl(1)), tol);                       // Cos
+	BOOST_CHECK_SMALL(std::abs(E1(tan(x), 0) - complex_dbl(0)), tol);                       // Tan
+	BOOST_CHECK_SMALL(std::abs(E1(asin(x), 0) - complex_dbl(0)), tol);                      // Asin
+	BOOST_CHECK_SMALL(std::abs(E1(acos(x), 1) - complex_dbl(0)), tol);                      // Acos
+	BOOST_CHECK_SMALL(std::abs(E1(atan(x), 0) - complex_dbl(0)), tol);                      // Atan
+	BOOST_CHECK_SMALL(std::abs(E1(Pi() * x, 1) - complex_dbl(3.141592653589793, 0)), 1e-12); // Pi
 }
 
 // Derivatives produced by Differentiate compile and evaluate correctly through the SLP -- the
@@ -171,19 +171,19 @@ BOOST_AUTO_TEST_CASE(derivatives_compile_and_evaluate_through_the_slp)
 	auto x = Variable::Make("x");
 	auto y = Variable::Make("y");
 	const double tol = 1e-12;
-	auto evald = [](Nd d, std::map<std::string,dbl> known){
-		std::map<std::string,dbl> m;
+	auto evald = [](Nd d, std::map<std::string,complex_dbl> known){
+		std::map<std::string,complex_dbl> m;
 		for (auto const& v : bertini::node::GatherVariables(d)) m[v->name()] = known.at(v->name());
-		return EvalExpression<dbl>(d, m);
+		return EvalExpression<complex_dbl>(d, m);
 	};
-	std::map<std::string,dbl> pt{ {"x", dbl(2,0)}, {"y", dbl(5,0)} };
+	std::map<std::string,complex_dbl> pt{ {"x", complex_dbl(2,0)}, {"y", complex_dbl(5,0)} };
 
-	BOOST_CHECK_SMALL(std::abs(evald((x*x)->Differentiate(x), pt)   - dbl(4)),   tol); // d/dx x^2 = 2x, x=2 -> 4
-	BOOST_CHECK_SMALL(std::abs(evald((x*y)->Differentiate(x), pt)   - dbl(5)),   tol); // d/dx x*y = y, y=5 -> 5
-	BOOST_CHECK_SMALL(std::abs(evald(pow(x,3)->Differentiate(x), pt)- dbl(12)),  tol); // d/dx x^3 = 3x^2, x=2 -> 12
-	BOOST_CHECK_SMALL(std::abs(evald(sin(x)->Differentiate(x), pt)  - dbl(std::cos(2.0))), tol); // d/dx sin = cos
-	BOOST_CHECK_SMALL(std::abs(evald(exp(x)->Differentiate(x), pt)  - dbl(std::exp(2.0))), tol); // d/dx exp = exp
-	BOOST_CHECK_SMALL(std::abs(evald((x/y)->Differentiate(x), pt)   - dbl(0.2)), tol); // d/dx x/y = 1/y, y=5 -> 0.2
+	BOOST_CHECK_SMALL(std::abs(evald((x*x)->Differentiate(x), pt)   - complex_dbl(4)),   tol); // d/dx x^2 = 2x, x=2 -> 4
+	BOOST_CHECK_SMALL(std::abs(evald((x*y)->Differentiate(x), pt)   - complex_dbl(5)),   tol); // d/dx x*y = y, y=5 -> 5
+	BOOST_CHECK_SMALL(std::abs(evald(pow(x,3)->Differentiate(x), pt)- complex_dbl(12)),  tol); // d/dx x^3 = 3x^2, x=2 -> 12
+	BOOST_CHECK_SMALL(std::abs(evald(sin(x)->Differentiate(x), pt)  - complex_dbl(std::cos(2.0))), tol); // d/dx sin = cos
+	BOOST_CHECK_SMALL(std::abs(evald(exp(x)->Differentiate(x), pt)  - complex_dbl(std::exp(2.0))), tol); // d/dx exp = exp
+	BOOST_CHECK_SMALL(std::abs(evald((x/y)->Differentiate(x), pt)   - complex_dbl(0.2)), tol); // d/dx x/y = 1/y, y=5 -> 0.2
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/core/test/classes/externs.hpp
+++ b/core/test/classes/externs.hpp
@@ -1,6 +1,6 @@
 extern const double relaxed_threshold_clearance_d;
 extern const double threshold_clearance_d;
-extern bertini::mpfr_float threshold_clearance_mp;
+extern bertini::real_mp threshold_clearance_mp;
 extern const unsigned CLASS_TEST_MPFR_DEFAULT_DIGITS;
 
 extern const std::string xstr_real;
@@ -16,16 +16,16 @@ extern const std::string pstr_imag;
 extern const std::string zstr_real;
 extern const std::string zstr_imag;
 
-extern const bertini::dbl xnum_dbl;
-extern const bertini::dbl ynum_dbl;
-extern const bertini::dbl znum_dbl;
-extern const bertini::dbl anum_dbl;
-extern const bertini::dbl bnum_dbl;
-extern const bertini::dbl pnum_dbl;
+extern const bertini::complex_dbl xnum_dbl;
+extern const bertini::complex_dbl ynum_dbl;
+extern const bertini::complex_dbl znum_dbl;
+extern const bertini::complex_dbl anum_dbl;
+extern const bertini::complex_dbl bnum_dbl;
+extern const bertini::complex_dbl pnum_dbl;
 
-extern bertini::mpfr_complex xnum_mpfr;
-extern bertini::mpfr_complex ynum_mpfr;
-extern bertini::mpfr_complex znum_mpfr;
-extern bertini::mpfr_complex anum_mpfr;
-extern bertini::mpfr_complex bnum_mpfr;
-extern bertini::mpfr_complex pnum_mpfr;
+extern bertini::complex_mp xnum_mpfr;
+extern bertini::complex_mp ynum_mpfr;
+extern bertini::complex_mp znum_mpfr;
+extern bertini::complex_mp anum_mpfr;
+extern bertini::complex_mp bnum_mpfr;
+extern bertini::complex_mp pnum_mpfr;

--- a/core/test/classes/function_tree_transform.cpp
+++ b/core/test/classes/function_tree_transform.cpp
@@ -52,7 +52,7 @@ using Rational = bertini::node::Rational;
 using SumOperator = bertini::node::SumOperator;
 using MultOperator = bertini::node::MultOperator;
 
-using dbl = bertini::dbl;
+using complex_dbl = bertini::complex_dbl;
 
 auto MakeZero(){return Nd(Integer::Make(0));}
 auto MakeOne(){return Nd(Integer::Make(1));}
@@ -86,22 +86,22 @@ BOOST_AUTO_TEST_SUITE(simplified)
 BOOST_AUTO_TEST_CASE(leaf_zero_is_unchanged)
 {
 	auto zero = MakeZero();
-	BOOST_CHECK_EQUAL(EvalAt<dbl>(zero->Simplified()), 0.);
+	BOOST_CHECK_EQUAL(EvalAt<complex_dbl>(zero->Simplified()), 0.);
 }
 
 BOOST_AUTO_TEST_CASE(zeros_drop_from_sum_signs_preserved)
 {
 	auto zero = MakeZero();
 	auto n = 2 + zero - 1 + zero - 2;
-	BOOST_CHECK_EQUAL(EvalAt<dbl>(bertini::Simplify(n)), -1.);
+	BOOST_CHECK_EQUAL(EvalAt<complex_dbl>(bertini::Simplify(n)), -1.);
 }
 
 BOOST_AUTO_TEST_CASE(sums_of_zeros_are_zero)
 {
 	auto zero = MakeZero();
-	BOOST_CHECK_EQUAL(EvalAt<dbl>(bertini::Simplify(zero+zero)), 0.);
-	BOOST_CHECK_EQUAL(EvalAt<dbl>(bertini::Simplify(zero+0)), 0.);
-	BOOST_CHECK_EQUAL(EvalAt<dbl>(bertini::Simplify(0+zero)), 0.);
+	BOOST_CHECK_EQUAL(EvalAt<complex_dbl>(bertini::Simplify(zero+zero)), 0.);
+	BOOST_CHECK_EQUAL(EvalAt<complex_dbl>(bertini::Simplify(zero+0)), 0.);
+	BOOST_CHECK_EQUAL(EvalAt<complex_dbl>(bertini::Simplify(0+zero)), 0.);
 }
 
 // ---- like factors combine into powers, like terms into coefficients ----
@@ -122,7 +122,7 @@ BOOST_AUTO_TEST_CASE(divided_like_factors_lower_the_exponent)
 {
 	auto x = Variable::Make("x");
 	BOOST_CHECK_EQUAL(SimplifiedForm(x*x/x), "x");                 // x^2 / x -> x
-	BOOST_CHECK_EQUAL(EvalAt<dbl>(bertini::Simplify(x/x)), 1.);    // x / x -> 1
+	BOOST_CHECK_EQUAL(EvalAt<complex_dbl>(bertini::Simplify(x/x)), 1.);    // x / x -> 1
 }
 
 BOOST_AUTO_TEST_CASE(like_terms_combine_into_coefficients)
@@ -138,7 +138,7 @@ BOOST_AUTO_TEST_CASE(like_terms_combine_into_coefficients)
 BOOST_AUTO_TEST_CASE(opposite_like_terms_cancel)
 {
 	auto x = Variable::Make("x");
-	BOOST_CHECK_EQUAL(EvalAt<dbl>(bertini::Simplify(x - x)), 0.);
+	BOOST_CHECK_EQUAL(EvalAt<complex_dbl>(bertini::Simplify(x - x)), 0.);
 	BOOST_CHECK_EQUAL(SimplifiedForm(Integer::Make(3)*x - x), "2*x");
 }
 
@@ -147,16 +147,16 @@ BOOST_AUTO_TEST_CASE(combining_preserves_value)
 	auto x = Variable::Make("x");
 	Nd f = x*x*x + x*x*x;                 // 2*x^3 = 16 at x=2
 	auto s = bertini::Simplify(f);
-	BOOST_CHECK_EQUAL(EvalAt<dbl>(s, {{"x", dbl(2.0, 0.0)}}), dbl(16.0, 0.0));
+	BOOST_CHECK_EQUAL(EvalAt<complex_dbl>(s, {{"x", complex_dbl(2.0, 0.0)}}), complex_dbl(16.0, 0.0));
 }
 
 BOOST_AUTO_TEST_CASE(zero_terms_drop_keeping_value)
 {
 	auto x = Variable::Make("x");
 	auto zero = MakeZero();
-	std::map<std::string,dbl> pt{ {"x", dbl(2.0)} };
-	BOOST_CHECK_EQUAL(EvalAt<dbl>(bertini::Simplify(pow(x,2) + zero*2), pt), 4.);
-	BOOST_CHECK_EQUAL(EvalAt<dbl>(bertini::Simplify(pow(x,2) + x*zero*2*(x*x*x)), pt), 4.);
+	std::map<std::string,complex_dbl> pt{ {"x", complex_dbl(2.0)} };
+	BOOST_CHECK_EQUAL(EvalAt<complex_dbl>(bertini::Simplify(pow(x,2) + zero*2), pt), 4.);
+	BOOST_CHECK_EQUAL(EvalAt<complex_dbl>(bertini::Simplify(pow(x,2) + x*zero*2*(x*x*x)), pt), 4.);
 }
 
 BOOST_AUTO_TEST_CASE(zero_term_drops_in_deeper_sum)
@@ -164,32 +164,32 @@ BOOST_AUTO_TEST_CASE(zero_term_drops_in_deeper_sum)
 	auto x = Variable::Make("x");
 	auto zero = MakeZero();
 	auto n = (x + sqrt(x) + zero) + x*2*(x*x*x);
-	BOOST_CHECK_EQUAL(EvalAt<dbl>(bertini::Simplify(n), {{"x", dbl(2.0)}}),
+	BOOST_CHECK_EQUAL(EvalAt<complex_dbl>(bertini::Simplify(n), {{"x", complex_dbl(2.0)}}),
 		35.414213562373095048801688724209698078569671875377);
 }
 
 BOOST_AUTO_TEST_CASE(literal_zero_collapses_product)
 {
 	auto zero = MakeZero();
-	BOOST_CHECK_EQUAL(EvalAt<dbl>(bertini::Simplify(1*zero)), 0.);
-	BOOST_CHECK_EQUAL(EvalAt<dbl>(bertini::Simplify(zero*zero)), 0.);
+	BOOST_CHECK_EQUAL(EvalAt<complex_dbl>(bertini::Simplify(1*zero)), 0.);
+	BOOST_CHECK_EQUAL(EvalAt<complex_dbl>(bertini::Simplify(zero*zero)), 0.);
 }
 
 // ---- literal ones drop from products ----
 BOOST_AUTO_TEST_CASE(leaf_one_is_unchanged)
 {
 	auto one = MakeOne();
-	BOOST_CHECK_EQUAL(EvalAt<dbl>(one->Simplified()), 1.);
+	BOOST_CHECK_EQUAL(EvalAt<complex_dbl>(one->Simplified()), 1.);
 }
 
 BOOST_AUTO_TEST_CASE(ones_drop_from_product)
 {
 	auto x = Variable::Make("x");
 	auto one = MakeOne();
-	std::map<std::string,dbl> pt{ {"x", dbl(2.)} };
-	BOOST_CHECK_EQUAL(EvalAt<dbl>(bertini::Simplify(one*one)), 1.);
-	BOOST_CHECK_EQUAL(EvalAt<dbl>(bertini::Simplify(x*one), pt), 2.);
-	BOOST_CHECK_EQUAL(EvalAt<dbl>(bertini::Simplify(one*x), pt), 2.);
+	std::map<std::string,complex_dbl> pt{ {"x", complex_dbl(2.)} };
+	BOOST_CHECK_EQUAL(EvalAt<complex_dbl>(bertini::Simplify(one*one)), 1.);
+	BOOST_CHECK_EQUAL(EvalAt<complex_dbl>(bertini::Simplify(x*one), pt), 2.);
+	BOOST_CHECK_EQUAL(EvalAt<complex_dbl>(bertini::Simplify(one*x), pt), 2.);
 }
 
 BOOST_AUTO_TEST_CASE(ones_fold_through_division_chains)
@@ -197,10 +197,10 @@ BOOST_AUTO_TEST_CASE(ones_fold_through_division_chains)
 	auto x = Variable::Make("x");
 	auto one = Integer::Make(1);
 	auto two = Integer::Make(2);
-	std::map<std::string,dbl> pt{ {"x", dbl(2.)} };
-	BOOST_CHECK_EQUAL(EvalAt<dbl>(bertini::Simplify((two*one/two)*x), pt), 2.);
-	BOOST_CHECK_EQUAL(EvalAt<dbl>(bertini::Simplify(one*one/one*one/one*one*x), pt), 2.);
-	BOOST_CHECK_EQUAL(EvalAt<dbl>(bertini::Simplify((one*one*2) * (one*x*one)), pt), 4.);
+	std::map<std::string,complex_dbl> pt{ {"x", complex_dbl(2.)} };
+	BOOST_CHECK_EQUAL(EvalAt<complex_dbl>(bertini::Simplify((two*one/two)*x), pt), 2.);
+	BOOST_CHECK_EQUAL(EvalAt<complex_dbl>(bertini::Simplify(one*one/one*one/one*one*x), pt), 2.);
+	BOOST_CHECK_EQUAL(EvalAt<complex_dbl>(bertini::Simplify((one*one*2) * (one*x*one)), pt), 4.);
 }
 
 // ---- nested singletons unwrap to the variable itself ----
@@ -211,7 +211,7 @@ BOOST_AUTO_TEST_CASE(nested_singleton_mults_unwrap_to_the_variable)
 	for (int i = 0; i < 4; ++i) n = MultOperator::Make(n);
 	auto s = bertini::Simplify(n);
 	BOOST_CHECK(std::dynamic_pointer_cast<bertini::node::Variable>(s));  // unwrapped
-	BOOST_CHECK_EQUAL(EvalAt<dbl>(s, {{"x", dbl(5.)}}), 5.);
+	BOOST_CHECK_EQUAL(EvalAt<complex_dbl>(s, {{"x", complex_dbl(5.)}}), 5.);
 }
 
 // ---- the load-bearing contract: Simplified() does NOT mutate its input ----
@@ -225,7 +225,7 @@ BOOST_AUTO_TEST_CASE(simplify_does_not_mutate_input)
 	auto s = bertini::Simplify(n);
 	BOOST_CHECK_EQUAL(n->NumOperands(), before);   // input untouched
 	BOOST_CHECK(s != n);                            // a fresh tree was returned
-	BOOST_CHECK_EQUAL(EvalAt<dbl>(s, {{"x", dbl(3.)}}), 6.);   // value preserved (x + x)
+	BOOST_CHECK_EQUAL(EvalAt<complex_dbl>(s, {{"x", complex_dbl(3.)}}), 6.);   // value preserved (x + x)
 }
 
 BOOST_AUTO_TEST_SUITE_END() // simplified
@@ -275,12 +275,12 @@ BOOST_AUTO_TEST_CASE(flattens_completely)
 
 	auto r = p+q+0*s + 0*1 + sqrt(0*x);
 
-dbl a(4.1203847861962345182734, -5.1234768951256847623781614314);
-dbl b(-8.98798649152356714919234, 0.49879892634876018735619234);
+complex_dbl a(4.1203847861962345182734, -5.1234768951256847623781614314);
+complex_dbl b(-8.98798649152356714919234, 0.49879892634876018735619234);
 
 	auto rs = bertini::Simplify(r);  // functional: r is untouched, rs is simplified
 
-	auto result = EvalAt<dbl>(rs, {{"x", a}, {"y", b}});
+	auto result = EvalAt<complex_dbl>(rs, {{"x", a}, {"y", b}});
 	BOOST_CHECK_EQUAL(result, a+a);
 }
 
@@ -293,11 +293,11 @@ BOOST_AUTO_TEST_CASE(complicated)
 
 	auto ns = bertini::Simplify(n);
 
-	dbl a(1.7, -0.3);
-	dbl b(-0.9, 2.1);
-	std::map<std::string,dbl> pt{ {"x", a}, {"y", b} };
+	complex_dbl a(1.7, -0.3);
+	complex_dbl b(-0.9, 2.1);
+	std::map<std::string,complex_dbl> pt{ {"x", a}, {"y", b} };
 
-	BOOST_CHECK_SMALL(abs(EvalAt<dbl>(ns, pt) - a*b), threshold_clearance_d);
+	BOOST_CHECK_SMALL(abs(EvalAt<complex_dbl>(ns, pt) - a*b), threshold_clearance_d);
 }
 
 
@@ -312,11 +312,11 @@ BOOST_AUTO_TEST_CASE(complicated2)
 
 	auto dfdxs = bertini::Simplify(dfdx);
 
-	dbl xval(1.3, -0.7);
-	dbl tval(0.4, 0.2);
-	std::map<std::string,dbl> pt{ {"x", xval}, {"t", tval} };
+	complex_dbl xval(1.3, -0.7);
+	complex_dbl tval(0.4, 0.2);
+	std::map<std::string,complex_dbl> pt{ {"x", xval}, {"t", tval} };
 
-	BOOST_CHECK_SMALL(abs(EvalAt<dbl>(dfdxs, pt) - 2.*(xval+tval-1.)), 1e-15);
+	BOOST_CHECK_SMALL(abs(EvalAt<complex_dbl>(dfdxs, pt) - 2.*(xval+tval-1.)), 1e-15);
 }
 
 
@@ -332,16 +332,16 @@ BOOST_AUTO_TEST_CASE(complicated3)
 
 	auto f = ((zero*pow((y-(HOM_VAR_0*one)),2))+((2*(y-(HOM_VAR_0*one))*(one-((zero*one)+(zero*HOM_VAR_0))))*(one-t)));
 
-	std::map<std::string,dbl> pt{ {"x", dbl(1.1,-0.2)}, {"y", dbl(0.7,1.3)},
-		{"HOM_VAR_0", dbl(-0.5,0.9)}, {"t", dbl(0.3,0.6)} };
+	std::map<std::string,complex_dbl> pt{ {"x", complex_dbl(1.1,-0.2)}, {"y", complex_dbl(0.7,1.3)},
+		{"HOM_VAR_0", complex_dbl(-0.5,0.9)}, {"t", complex_dbl(0.3,0.6)} };
 
-	auto init_val = EvalAt<dbl>(f, pt);
+	auto init_val = EvalAt<complex_dbl>(f, pt);
 
 	auto fs = bertini::Simplify(f);
 
 	// simplify reorders the arithmetic (like-factor/like-term combining), so compare with a
 	// tolerance rather than for bit-exact equality.
-	BOOST_CHECK_SMALL(std::abs(init_val - EvalAt<dbl>(fs, pt)), 1e-12);
+	BOOST_CHECK_SMALL(std::abs(init_val - EvalAt<complex_dbl>(fs, pt)), 1e-12);
 
 }
 
@@ -355,19 +355,19 @@ BOOST_AUTO_TEST_CASE(complicated4)
 	auto HOM_VAR_0 = Variable::Make("HOM_VAR_0");
 	auto t = Variable::Make("t");
 
-	dbl a(1.4, -0.6);
-	dbl h(-0.8, 0.5);
-	dbl T(0.25, 0.7);
-	std::map<std::string,dbl> pt{ {"x", a}, {"y", dbl(0.3,0.1)}, {"HOM_VAR_0", h}, {"t", T} };
+	complex_dbl a(1.4, -0.6);
+	complex_dbl h(-0.8, 0.5);
+	complex_dbl T(0.25, 0.7);
+	std::map<std::string,complex_dbl> pt{ {"x", a}, {"y", complex_dbl(0.3,0.1)}, {"HOM_VAR_0", h}, {"t", T} };
 
 	auto f = ((zero*(pow((x-(HOM_VAR_0*one)),3)))+((3*(pow((x-(HOM_VAR_0*one)),2))*(-((one*one)+(zero*HOM_VAR_0))))*(one-t)));
 
-	auto f_val_init = EvalAt<dbl>(f, pt);
+	auto f_val_init = EvalAt<complex_dbl>(f, pt);
 	[[maybe_unused]] auto actual_val = 3.*pow((h - a),2)*(T - 1.);
 
 	auto fs = bertini::Simplify(f);
 
-	auto f_val_after = EvalAt<dbl>(fs, pt);
+	auto f_val_after = EvalAt<complex_dbl>(fs, pt);
 	// canonical operand ordering reorders sums/products, so simplify preserves the
 	// value only up to reorder rounding -- compare with a tolerance, not exact equality.
 	BOOST_CHECK_SMALL(std::abs(f_val_init - f_val_after), 1e-12);
@@ -386,15 +386,15 @@ BOOST_AUTO_TEST_CASE(yet_more_complicated)
 
 	// jac_fn(1,2) = (((0*((y^2)-((HOM_VAR_0^2)*(9215126146405988386300422552813438491596469014004/18831809439874092151531390861220941995712612447011,-34979570316540871529966189550041755413443953059471/3298415588464117388268211317293113094514010909093))))+(((2*y*1)-(((2*HOM_VAR_0*0)*(9215126146405988386300422552813438491596469014004/18831809439874092151531390861220941995712612447011,-34979570316540871529966189550041755413443953059471/3298415588464117388268211317293113094514010909093))+(0*(HOM_VAR_0^2))))*t))+((0*((y-(HOM_VAR_0*1))^2))+((2*(y-(HOM_VAR_0*1))*(1-((0*1)+(0*HOM_VAR_0))))*(1-t))))
 
-	std::map<std::string,dbl> pt{ {"x", dbl(0.6,-0.4)}, {"y", dbl(1.2,0.8)},
-		{"t", dbl(0.35,0.15)}, {"HOM_VAR_0", dbl(-0.7,0.3)} };
+	std::map<std::string,complex_dbl> pt{ {"x", complex_dbl(0.6,-0.4)}, {"y", complex_dbl(1.2,0.8)},
+		{"t", complex_dbl(0.35,0.15)}, {"HOM_VAR_0", complex_dbl(-0.7,0.3)} };
 
-	auto init_val = EvalAt<dbl>(f, pt);
+	auto init_val = EvalAt<complex_dbl>(f, pt);
 
 	auto fs = bertini::Simplify(f);
 	// simplify combines like factors/terms, which reorders the arithmetic, so it preserves the
 	// value only up to floating-point reorder rounding -- compare with a tolerance.
-	BOOST_CHECK_SMALL(std::abs(init_val - EvalAt<dbl>(fs, pt)), 1e-12);
+	BOOST_CHECK_SMALL(std::abs(init_val - EvalAt<complex_dbl>(fs, pt)), 1e-12);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // simplify

--- a/core/test/classes/fundamentals_test.cpp
+++ b/core/test/classes/fundamentals_test.cpp
@@ -42,9 +42,9 @@
 
 BOOST_AUTO_TEST_SUITE(super_fundamentals)
 
-using mpfr_float = bertini::mpfr_float;
+using real_mp = bertini::real_mp;
 using mpq_rational = bertini::mpq_rational;
-using dbl = bertini::dbl;
+using complex_dbl = bertini::complex_dbl;
 using bertini::DefaultPrecision;
 #include <limits>
 
@@ -73,7 +73,7 @@ BOOST_AUTO_TEST_CASE(complex_pow_on_real_stays_real)
 	
 	for (int ii=0; ii<100; ++ii)
 	{
-		auto x = dbl(bertini::RandReal());
+		auto x = complex_dbl(bertini::RandReal());
 		auto result = pow(x, 2);
 		BOOST_CHECK_EQUAL(result, x*x);
 		BOOST_CHECK_EQUAL(imag(result), 0);
@@ -83,7 +83,7 @@ BOOST_AUTO_TEST_CASE(complex_pow_on_real_stays_real)
 
 BOOST_AUTO_TEST_CASE(complex_double_nans)
 {
-	dbl x(0., std::numeric_limits<double>::quiet_NaN());
+	complex_dbl x(0., std::numeric_limits<double>::quiet_NaN());
 	using bertini::isnan;
 	BOOST_CHECK(isnan(x));
 }
@@ -91,7 +91,7 @@ BOOST_AUTO_TEST_CASE(complex_double_nans)
 
 BOOST_AUTO_TEST_CASE(complex_double_nans2)
 {
-	dbl x(std::numeric_limits<double>::quiet_NaN(), 0.);
+	complex_dbl x(std::numeric_limits<double>::quiet_NaN(), 0.);
 	using bertini::isnan;
 	BOOST_CHECK(isnan(x));
 }
@@ -99,7 +99,7 @@ BOOST_AUTO_TEST_CASE(complex_double_nans2)
 
 BOOST_AUTO_TEST_CASE(complex_double_nans3)
 {
-	dbl x(std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN());
+	complex_dbl x(std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN());
 	using bertini::isnan;
 	BOOST_CHECK(isnan(x));
 }
@@ -107,14 +107,14 @@ BOOST_AUTO_TEST_CASE(complex_double_nans3)
 
 BOOST_AUTO_TEST_CASE(complex_double_nans4)
 {
-	dbl x(0., 0.);
+	complex_dbl x(0., 0.);
 	using bertini::isnan;
 	BOOST_CHECK(!isnan(x));
 }
 
 BOOST_AUTO_TEST_CASE(complex_double_random_subsequent_not_equal)
 {
-	using T = dbl;
+	using T = complex_dbl;
 
 	auto x = bertini::RandomUnit<T>();
 	auto y = bertini::RandomUnit<T>();
@@ -126,7 +126,7 @@ BOOST_AUTO_TEST_CASE(complex_double_random_subsequent_not_equal)
 BOOST_AUTO_TEST_CASE(mpfr_float_can_be_nan)
 {
 	DefaultPrecision(50);
-	mpfr_float a(std::numeric_limits<double>::quiet_NaN());
+	real_mp a(std::numeric_limits<double>::quiet_NaN());
 	BOOST_CHECK(isnan(a));
 }
 
@@ -134,8 +134,8 @@ BOOST_AUTO_TEST_CASE(mpfr_float_can_be_nan)
 BOOST_AUTO_TEST_CASE(constructing_mpfr_from_double)
 {
 	DefaultPrecision(50);
-	mpfr_float from_double(0.1);
-	mpfr_float from_string("0.1");
+	real_mp from_double(0.1);
+	real_mp from_string("0.1");
 
 	BOOST_CHECK(abs(from_string - from_double) < std::numeric_limits<double>::epsilon());
 }
@@ -152,7 +152,7 @@ BOOST_AUTO_TEST_CASE(construct_rational_from_integers)
 // BOOST_AUTO_TEST_CASE(construct_rational_from_mpfr)
 // {
 // 	DefaultPrecision(50);
-// 	mpfr_float p("1.1");
+// 	real_mp p("1.1");
 // 	mpq_rational q(p);
 // 	BOOST_CHECK_EQUAL(mpq_rational(11,10), q);
 // }
@@ -169,11 +169,11 @@ BOOST_AUTO_TEST_CASE(construct_rational_from_integers)
 // BOOST_AUTO_TEST_CASE(multiple_mpfr_by_double)
 // {
 // 	DefaultPrecision(50);
-// 	mpfr_float a("0.1");
+// 	real_mp a("0.1");
 // 	double factor = 0.1;
 
-// 	mpfr_float result = a*factor;
-// 	mpfr_float expected("0.01");
+// 	real_mp result = a*factor;
+// 	real_mp expected("0.01");
 
 // 	BOOST_CHECK_CLOSE(expected, result, 1e-50);
 // }
@@ -184,8 +184,8 @@ BOOST_AUTO_TEST_CASE(making_mpfr_from_pow_int_base)
 {
 	DefaultPrecision(50);
 
-	mpfr_float result = pow(mpfr_float(10), -5);
-	mpfr_float expected("1e-5");
+	real_mp result = pow(real_mp(10), -5);
+	real_mp expected("1e-5");
 
 	BOOST_CHECK_CLOSE(expected, result, 1e-50);
 }
@@ -194,8 +194,8 @@ BOOST_AUTO_TEST_CASE(making_mpfr_from_pow_str_base)
 {
 	DefaultPrecision(50);
 
-	mpfr_float result = pow(mpfr_float("10"), -5);
-	mpfr_float expected("1e-5");
+	real_mp result = pow(real_mp("10"), -5);
+	real_mp expected("1e-5");
 
 	BOOST_CHECK_CLOSE(expected, result, 1e-50);
 }
@@ -207,8 +207,8 @@ BOOST_AUTO_TEST_CASE(making_mpfr_from_pow_doub_exp)
 
 using boost::multiprecision::pow;
 
-	mpfr_float result = pow(mpfr_float(10), -5);
-	mpfr_float expected("1e-5");
+	real_mp result = pow(real_mp(10), -5);
+	real_mp expected("1e-5");
 
 	BOOST_CHECK_CLOSE(expected, result, 1e-50);
 }
@@ -218,8 +218,8 @@ BOOST_AUTO_TEST_CASE(making_mpfr_from_pow_int_base_mpfr_exp)
 {
 	DefaultPrecision(50);
 
-	mpfr_float result = pow(10, mpfr_float(-5));
-	mpfr_float expected("1e-5");
+	real_mp result = pow(10, real_mp(-5));
+	real_mp expected("1e-5");
 
 	BOOST_CHECK_CLOSE(expected, result, 1e-50);
 }
@@ -270,7 +270,7 @@ BOOST_AUTO_TEST_CASE(RandomMP_default_precision_50)
 {
 	using namespace bertini;
 	DefaultPrecision(50);
-	auto a = RandomMp(mpfr_float(-1),mpfr_float(1));
+	auto a = RandomMp(real_mp(-1),real_mp(1));
 	BOOST_CHECK_EQUAL(a.precision(), DefaultPrecision());
 	BOOST_CHECK_EQUAL(50, DefaultPrecision());
 }
@@ -279,7 +279,7 @@ BOOST_AUTO_TEST_CASE(RandomMP_default_precision_100)
 {
 	using namespace bertini;
 	DefaultPrecision(100);
-	auto a = RandomMp(mpfr_float(-1),mpfr_float(1));
+	auto a = RandomMp(real_mp(-1),real_mp(1));
 	BOOST_CHECK_EQUAL(a.precision(), DefaultPrecision());
 	BOOST_CHECK_EQUAL(100, DefaultPrecision());
 }
@@ -288,7 +288,7 @@ BOOST_AUTO_TEST_CASE(RandomMP_nondefault_precision_100)
 {
 	using namespace bertini;
 	DefaultPrecision(100);
-	mpfr_float a;
+	real_mp a;
 
 	RandomMpAssign(a,500);
 
@@ -307,7 +307,7 @@ BOOST_AUTO_TEST_CASE(RandomMP_honors_global_seed)
 	DefaultPrecision(50);
 
 	auto draw_five = []{
-		std::vector<mpfr_float> v;
+		std::vector<real_mp> v;
 		for (int ii = 0; ii < 5; ++ii)
 			v.push_back(RandomMp(50));
 		return v;
@@ -334,7 +334,7 @@ BOOST_AUTO_TEST_CASE(RandomMP_honors_global_seed)
 
 BOOST_AUTO_TEST_CASE(max_et_on)
 {
-	mpfr_float a(1), b(2), c(4);
+	real_mp a(1), b(2), c(4);
 	// auto d = max(a,b*b+c);
 
 }
@@ -369,17 +369,17 @@ BOOST_AUTO_TEST_CASE(max_et_on)
 struct scoped_mpfr_precision_options_all_threads
 {
    boost::multiprecision::variable_precision_options saved_options;
-   scoped_mpfr_precision_options_all_threads(boost::multiprecision::variable_precision_options opts) : saved_options(mpfr_float::default_variable_precision_options())
+   scoped_mpfr_precision_options_all_threads(boost::multiprecision::variable_precision_options opts) : saved_options(real_mp::default_variable_precision_options())
    {
-      mpfr_float::default_variable_precision_options(opts);
+      real_mp::default_variable_precision_options(opts);
    }
    ~scoped_mpfr_precision_options_all_threads()
    {
-      mpfr_float::default_variable_precision_options(saved_options);
+      real_mp::default_variable_precision_options(saved_options);
    }
    void reset(boost::multiprecision::variable_precision_options opts)
    {
-      mpfr_float::default_variable_precision_options(opts);
+      real_mp::default_variable_precision_options(opts);
    }
 };
 
@@ -392,17 +392,17 @@ struct scoped_mpfr_precision_options_all_threads
 struct scoped_mpfr_precision_options_this_thread
 {
    boost::multiprecision::variable_precision_options saved_options;
-   scoped_mpfr_precision_options_this_thread(boost::multiprecision::variable_precision_options opts) : saved_options(mpfr_float::thread_default_variable_precision_options())
+   scoped_mpfr_precision_options_this_thread(boost::multiprecision::variable_precision_options opts) : saved_options(real_mp::thread_default_variable_precision_options())
    {
-      mpfr_float::thread_default_variable_precision_options(opts);
+      real_mp::thread_default_variable_precision_options(opts);
    }
    ~scoped_mpfr_precision_options_this_thread()
    {
-      mpfr_float::thread_default_variable_precision_options(saved_options);
+      real_mp::thread_default_variable_precision_options(saved_options);
    }
    void reset(boost::multiprecision::variable_precision_options opts)
    {
-      mpfr_float::thread_default_variable_precision_options(opts);
+      real_mp::thread_default_variable_precision_options(opts);
    }
 };
 
@@ -422,7 +422,7 @@ BOOST_AUTO_TEST_CASE(precision_through_arithemetic)
 
 	scoped_mpfr_precision_options_this_thread scoped_opts1(boost::multiprecision::variable_precision_options::preserve_related_precision);
 
-	mpfr_float x("0.01234567890123456789012345678901234567890123456789");
+	real_mp x("0.01234567890123456789012345678901234567890123456789");
 	BOOST_CHECK_EQUAL(x.precision(), 50);
 
 // https://github.com/boostorg/multiprecision/issues/60
@@ -431,12 +431,12 @@ BOOST_AUTO_TEST_CASE(precision_through_arithemetic)
 // Assignment keeps the precision of the target."
 
 	DefaultPrecision(30);
-	mpfr_float y = pow(x,2);
+	real_mp y = pow(x,2);
 	BOOST_CHECK_EQUAL(y.precision(), 50);
 	
 
-	mpfr_float z = x;
-	mpfr_float q(x);
+	real_mp z = x;
+	real_mp q(x);
 	BOOST_CHECK_EQUAL(z.precision(), 50);
 	BOOST_CHECK_EQUAL(q.precision(), 50);
 
@@ -478,13 +478,13 @@ BOOST_AUTO_TEST_CASE(precision_in_construction)
 {
 	DefaultPrecision(50);
 
-	mpfr_float x("0.01234567890123456789012345678901234567890123456789");
+	real_mp x("0.01234567890123456789012345678901234567890123456789");
 	BOOST_CHECK_EQUAL(x.precision(), 50);
 
 	DefaultPrecision(30);
 	
-	mpfr_float a = x;
-	mpfr_float b(x);
+	real_mp a = x;
+	real_mp b(x);
 	BOOST_CHECK_EQUAL(a.precision(), 50);
 	BOOST_CHECK_EQUAL(b.precision(), 50);
 	BOOST_CHECK_EQUAL(a,x);
@@ -492,8 +492,8 @@ BOOST_AUTO_TEST_CASE(precision_in_construction)
 
 	DefaultPrecision(70);
 
-	mpfr_float c = x;
-	mpfr_float d(x);
+	real_mp c = x;
+	real_mp d(x);
 	BOOST_CHECK_EQUAL(c.precision(), 50);
 	BOOST_CHECK_EQUAL(d.precision(), 50);
 	BOOST_CHECK_EQUAL(c,x);
@@ -504,13 +504,13 @@ BOOST_AUTO_TEST_CASE(precision_in_construction)
 BOOST_AUTO_TEST_CASE(precision_through_arithemetic2)
 {
 	DefaultPrecision(50);
-	mpfr_float a(1);
+	real_mp a(1);
 
 	DefaultPrecision(400);
-	mpfr_float b(2);
+	real_mp b(2);
 
 	DefaultPrecision(600);
-	mpfr_float c(3);
+	real_mp c(3);
 
 	a = b;
 	BOOST_CHECK_EQUAL(a.precision(),400); // the precision of source
@@ -524,7 +524,7 @@ BOOST_AUTO_TEST_CASE(precision_through_arithemetic2)
 BOOST_AUTO_TEST_CASE(precision_mpfr_constructed_from_string)
 {
 	DefaultPrecision(30);
-	mpfr_float x("0.01234567890123456789012345678901234567890123456789");
+	real_mp x("0.01234567890123456789012345678901234567890123456789");
 	BOOST_CHECK_EQUAL(x.precision(),30);
 }
 
@@ -584,7 +584,7 @@ BOOST_AUTO_TEST_CASE(num_digits_complex_double)
 
 BOOST_AUTO_TEST_CASE(num_digits_mpfr_float)
 {
-	using T = bertini::mpfr_float;
+	using T = bertini::real_mp;
 	
 	DefaultPrecision(16);
 	BOOST_CHECK_EQUAL(NumTraits<T>::NumDigits(), 16);
@@ -599,7 +599,7 @@ BOOST_AUTO_TEST_CASE(num_digits_mpfr_float)
 
 BOOST_AUTO_TEST_CASE(num_digits_mpfr_complex)
 {
-	using T = bertini::mpfr_complex;
+	using T = bertini::complex_mp;
 	
 	DefaultPrecision(16);
 	BOOST_CHECK_EQUAL(NumTraits<T>::NumDigits(), 16);

--- a/core/test/classes/homogenization_test.cpp
+++ b/core/test/classes/homogenization_test.cpp
@@ -39,13 +39,13 @@ BOOST_AUTO_TEST_SUITE(homogenization)
 
 using Variable = bertini::node::Variable;
 using Complex = bertini::node::Complex;
-using mpfr_float = bertini::mpfr_float;
+using real_mp = bertini::real_mp;
 using Var = std::shared_ptr<bertini::node::Variable>;
 
 using Flt = std::shared_ptr<bertini::node::Complex>;
 using VariableGroup = bertini::VariableGroup;
-using dbl = bertini::dbl;
-using mpfr = bertini::mpfr_complex;
+using complex_dbl = bertini::complex_dbl;
+using mpfr = bertini::complex_mp;
 
 
 
@@ -461,7 +461,7 @@ BOOST_AUTO_TEST_CASE(is_homogeneous_summands_homogeneous)
 	Var y = Variable::Make("y");
 
 	auto a = pow(x,3) / 2;
-	auto b = pow(x,2) * mpfr_float("4.12331") * pow(x,1);
+	auto b = pow(x,2) * real_mp("4.12331") * pow(x,1);
 	
 	auto f1 = a+b;
 	BOOST_CHECK(f1->IsHomogeneous());
@@ -480,7 +480,7 @@ BOOST_AUTO_TEST_CASE(not_homogeneous_summands_inhomogeneous)
 	Var y = Variable::Make("y");
 
 	auto a = pow(x,3) / 2;
-	auto b = pow(x,2) * mpfr_float("4.12331");
+	auto b = pow(x,2) * real_mp("4.12331");
 	
 	auto f1 = a+b;
 	BOOST_CHECK(!f1->IsHomogeneous());

--- a/core/test/classes/interning_test.cpp
+++ b/core/test/classes/interning_test.cpp
@@ -40,7 +40,7 @@ using Nd = std::shared_ptr<bertini::node::Node>;
 using Variable = bertini::node::Variable;
 using Integer = bertini::node::Integer;
 using SumOperator = bertini::node::SumOperator;
-using dbl = bertini::dbl;
+using complex_dbl = bertini::complex_dbl;
 using bertini::test::EvalAt;
 
 BOOST_AUTO_TEST_SUITE(interning)
@@ -63,15 +63,15 @@ BOOST_AUTO_TEST_CASE(simplify_does_not_corrupt_a_shared_single_operand_sum)
 	Nd q = m - n;          // x - y
 	Nd r = p + q + 0*x;    // 2x   (the +0 forces simplification work)
 
-	dbl xv(2.0, -3.0), yv(5.0, 1.0);
-	std::map<std::string,dbl> pt{ {"x", xv}, {"y", yv} };
+	complex_dbl xv(2.0, -3.0), yv(5.0, 1.0);
+	std::map<std::string,complex_dbl> pt{ {"x", xv}, {"y", yv} };
 
 	Nd rs = bertini::Simplify(r);
-	BOOST_CHECK_EQUAL(EvalAt<dbl>(rs, pt), xv + xv);   // == 2x, with the y's cancelled
+	BOOST_CHECK_EQUAL(EvalAt<complex_dbl>(rs, pt), xv + xv);   // == 2x, with the y's cancelled
 
 	// and the reused sub-objects must be intact (not mutated by the simplification above)
-	BOOST_CHECK_EQUAL(EvalAt<dbl>(m, pt), xv);
-	BOOST_CHECK_EQUAL(EvalAt<dbl>(n, pt), yv);
+	BOOST_CHECK_EQUAL(EvalAt<complex_dbl>(m, pt), xv);
+	BOOST_CHECK_EQUAL(EvalAt<complex_dbl>(n, pt), yv);
 }
 
 // ---- basic dedup: structurally equal builds return the same object ----
@@ -132,7 +132,7 @@ BOOST_AUTO_TEST_CASE(eval_correct_with_shared_subexpression)
 	auto x = Variable::Make("x");
 	Nd a = x*x;                 // shared
 	Nd f = a + a + a;           // 3 * x^2, all the same interned 'a'
-	BOOST_CHECK_EQUAL(EvalAt<dbl>(f, {{"x", dbl(2.0, 0.0)}}), dbl(12.0, 0.0));   // 3 * 4
+	BOOST_CHECK_EQUAL(EvalAt<complex_dbl>(f, {{"x", complex_dbl(2.0, 0.0)}}), complex_dbl(12.0, 0.0));   // 3 * 4
 }
 
 // ---- immutability under interning: simplifying never changes a held input ----
@@ -142,13 +142,13 @@ BOOST_AUTO_TEST_CASE(simplify_leaves_a_held_shared_node_untouched)
 	auto x = Variable::Make("x");
 	auto y = Variable::Make("y");
 	Nd held = (x + y) * x;      // hold a shared node
-	std::map<std::string,dbl> pt{ {"x", dbl(3.0, 0.0)}, {"y", dbl(4.0, 0.0)} };
-	auto before = EvalAt<dbl>(held, pt);
+	std::map<std::string,complex_dbl> pt{ {"x", complex_dbl(3.0, 0.0)}, {"y", complex_dbl(4.0, 0.0)} };
+	auto before = EvalAt<complex_dbl>(held, pt);
 
 	Nd s = bertini::Simplify(held + 0*y);   // simplify an expression that contains 'held'
 	(void)s;
 
-	BOOST_CHECK_EQUAL(EvalAt<dbl>(held, pt), before);   // held is unchanged by simplifying around it
+	BOOST_CHECK_EQUAL(EvalAt<complex_dbl>(held, pt), before);   // held is unchanged by simplifying around it
 }
 
 BOOST_AUTO_TEST_SUITE_END() // interning
@@ -199,7 +199,7 @@ BOOST_AUTO_TEST_CASE(commutative_sum_dedups_when_enabled)
 	Nd a = x + y;
 	Nd b = y + x;
 	BOOST_CHECK_EQUAL(a.get(), b.get());          // canonicalized to one node
-	BOOST_CHECK_EQUAL(EvalAt<dbl>(a, {{"x", dbl(2.0, 0.0)}, {"y", dbl(5.0, 0.0)}}), dbl(7.0, 0.0));
+	BOOST_CHECK_EQUAL(EvalAt<complex_dbl>(a, {{"x", complex_dbl(2.0, 0.0)}, {"y", complex_dbl(5.0, 0.0)}}), complex_dbl(7.0, 0.0));
 }
 
 BOOST_AUTO_TEST_CASE(commutative_product_dedups_when_enabled)
@@ -216,7 +216,7 @@ BOOST_AUTO_TEST_CASE(division_stays_correct_under_canonicalization)
 	auto x = Variable::Make("x");
 	auto y = Variable::Make("y");
 	Nd q = y / x;                                 // a divisor must not become the leading factor
-	BOOST_CHECK_EQUAL(EvalAt<dbl>(q, {{"x", dbl(2.0, 0.0)}, {"y", dbl(6.0, 0.0)}}), dbl(3.0, 0.0));  // 6/2
+	BOOST_CHECK_EQUAL(EvalAt<complex_dbl>(q, {{"x", complex_dbl(2.0, 0.0)}, {"y", complex_dbl(6.0, 0.0)}}), complex_dbl(3.0, 0.0));  // 6/2
 	BOOST_CHECK((x/y).get() != (y/x).get());            // x/y and y/x stay distinct
 }
 

--- a/core/test/classes/linear_forms_block_test.cpp
+++ b/core/test/classes/linear_forms_block_test.cpp
@@ -34,9 +34,9 @@ static_assert(bertini::blocks::is_block_v<LinearFormsBlock>,
 //   Jacobian is constant: [[2, 3], [1, -1]]
 static LinearFormsBlock MakeTestBlock()
 {
-	bertini::Mat<mpfr_complex> M(2, 3);
-	M << mpfr_complex(2), mpfr_complex(3),  mpfr_complex(1),
-	     mpfr_complex(1), mpfr_complex(-1), mpfr_complex(4);
+	bertini::Mat<complex_mp> M(2, 3);
+	M << complex_mp(2), complex_mp(3),  complex_mp(1),
+	     complex_mp(1), complex_mp(-1), complex_mp(4);
 	return LinearFormsBlock(2, std::move(M));
 }
 
@@ -55,9 +55,9 @@ BOOST_AUTO_TEST_CASE(eval_double)
 	DefaultPrecision(30);
 	auto block = MakeTestBlock();
 
-	bertini::Vec<dbl> x(2); x << dbl(1), dbl(1);
-	bertini::Vec<dbl> result(2);
-	block.EvalInPlace<dbl>(result, x, dbl(0));
+	bertini::Vec<complex_dbl> x(2); x << complex_dbl(1), complex_dbl(1);
+	bertini::Vec<complex_dbl> result(2);
+	block.EvalInPlace<complex_dbl>(result, x, complex_dbl(0));
 
 	BOOST_CHECK_CLOSE(result(0).real(), 6.0, 1e-11);
 	BOOST_CHECK_CLOSE(result(1).real(), 4.0, 1e-11);
@@ -71,12 +71,12 @@ BOOST_AUTO_TEST_CASE(eval_mpfr)
 	auto block = MakeTestBlock();
 	block.Precision(30);
 
-	bertini::Vec<mpfr_complex> x(2); x << mpfr_complex(1), mpfr_complex(1);
-	bertini::Vec<mpfr_complex> result(2);
-	block.EvalInPlace<mpfr_complex>(result, x, mpfr_complex(0));
+	bertini::Vec<complex_mp> x(2); x << complex_mp(1), complex_mp(1);
+	bertini::Vec<complex_mp> result(2);
+	block.EvalInPlace<complex_mp>(result, x, complex_mp(0));
 
-	BOOST_CHECK(abs(result(0) - mpfr_complex(6)) < mpfr_float("1e-25"));
-	BOOST_CHECK(abs(result(1) - mpfr_complex(4)) < mpfr_float("1e-25"));
+	BOOST_CHECK(abs(result(0) - complex_mp(6)) < real_mp("1e-25"));
+	BOOST_CHECK(abs(result(1) - complex_mp(4)) < real_mp("1e-25"));
 }
 
 BOOST_AUTO_TEST_CASE(jacobian_is_constant_coefficient_matrix)
@@ -85,11 +85,11 @@ BOOST_AUTO_TEST_CASE(jacobian_is_constant_coefficient_matrix)
 	auto block = MakeTestBlock();
 
 	// evaluate the Jacobian at two different points; it must not change.
-	bertini::Mat<dbl> J0(2, 2), J1(2, 2);
-	bertini::Vec<dbl> p0(2); p0 << dbl(1), dbl(1);
-	bertini::Vec<dbl> p1(2); p1 << dbl(-5), dbl(7);
-	block.JacobianInPlace<dbl>(J0, p0, dbl(0));
-	block.JacobianInPlace<dbl>(J1, p1, dbl(0));
+	bertini::Mat<complex_dbl> J0(2, 2), J1(2, 2);
+	bertini::Vec<complex_dbl> p0(2); p0 << complex_dbl(1), complex_dbl(1);
+	bertini::Vec<complex_dbl> p1(2); p1 << complex_dbl(-5), complex_dbl(7);
+	block.JacobianInPlace<complex_dbl>(J0, p0, complex_dbl(0));
+	block.JacobianInPlace<complex_dbl>(J1, p1, complex_dbl(0));
 
 	BOOST_CHECK_CLOSE(J0(0,0).real(), 2.0, 1e-11);
 	BOOST_CHECK_CLOSE(J0(0,1).real(), 3.0, 1e-11);
@@ -102,9 +102,9 @@ BOOST_AUTO_TEST_CASE(time_derivative_is_zero)
 {
 	DefaultPrecision(30);
 	auto block = MakeTestBlock();
-	bertini::Vec<dbl> x(2); x << dbl(3), dbl(4);
-	bertini::Vec<dbl> dt(2);
-	block.TimeDerivInPlace<dbl>(dt, x, dbl(0));
+	bertini::Vec<complex_dbl> x(2); x << complex_dbl(3), complex_dbl(4);
+	bertini::Vec<complex_dbl> dt(2);
+	block.TimeDerivInPlace<complex_dbl>(dt, x, complex_dbl(0));
 	BOOST_CHECK_SMALL(dt.norm(), 1e-12);
 }
 
@@ -112,20 +112,20 @@ BOOST_AUTO_TEST_CASE(time_derivative_is_zero)
 BOOST_AUTO_TEST_CASE(eval_matches_matrix_vector_reference)
 {
 	DefaultPrecision(40);
-	bertini::Mat<mpfr_complex> M(3, 4);
-	M << mpfr_complex(2),  mpfr_complex(-1), mpfr_complex(0),  mpfr_complex(5),
-	     mpfr_complex(1),  mpfr_complex(3),  mpfr_complex(-2), mpfr_complex(-1),
-	     mpfr_complex(0),  mpfr_complex(4),  mpfr_complex(7),  mpfr_complex(2);
+	bertini::Mat<complex_mp> M(3, 4);
+	M << complex_mp(2),  complex_mp(-1), complex_mp(0),  complex_mp(5),
+	     complex_mp(1),  complex_mp(3),  complex_mp(-2), complex_mp(-1),
+	     complex_mp(0),  complex_mp(4),  complex_mp(7),  complex_mp(2);
 	LinearFormsBlock block(3, M);
 	block.Precision(40);
 
-	bertini::Vec<mpfr_complex> x(3); x << mpfr_complex(2), mpfr_complex(-3), mpfr_complex(1);
-	bertini::Vec<mpfr_complex> result(3);
-	block.EvalInPlace<mpfr_complex>(result, x, mpfr_complex(0));
+	bertini::Vec<complex_mp> x(3); x << complex_mp(2), complex_mp(-3), complex_mp(1);
+	bertini::Vec<complex_mp> result(3);
+	block.EvalInPlace<complex_mp>(result, x, complex_mp(0));
 
-	bertini::Vec<mpfr_complex> aug(4); aug << x(0), x(1), x(2), mpfr_complex(1);
-	bertini::Vec<mpfr_complex> reference = M * aug;
-	BOOST_CHECK((result - reference).norm() < mpfr_float("1e-30"));
+	bertini::Vec<complex_mp> aug(4); aug << x(0), x(1), x(2), complex_mp(1);
+	bertini::Vec<complex_mp> reference = M * aug;
+	BOOST_CHECK((result - reference).norm() < real_mp("1e-30"));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/core/test/classes/m_hom_start_system.cpp
+++ b/core/test/classes/m_hom_start_system.cpp
@@ -38,10 +38,10 @@ using Var = std::shared_ptr<Variable>;
 using VariableGroup = bertini::VariableGroup;
 
 using mpq_rational = bertini::mpq_rational;
-using mpfr_float = bertini::mpfr_float;
+using real_mp = bertini::real_mp;
 using mpz_int = bertini::mpz_int;
-using dbl = bertini::dbl;
-using mpfr = bertini::mpfr_complex;
+using complex_dbl = bertini::complex_dbl;
+using mpfr = bertini::complex_mp;
 template<typename NumT> using Vec = bertini::Vec<NumT>;
 template<typename NumT> using Mat = bertini::Mat<NumT>;
 
@@ -140,7 +140,7 @@ BOOST_AUTO_TEST_CASE(start_points_are_roots_of_the_start_system)
 	const auto n = mhom.NumStartPoints();
 	for (unsigned long long i = 0; i < n; ++i)
 	{
-		auto sp = mhom.StartPoint<dbl>(i);
+		auto sp = mhom.StartPoint<complex_dbl>(i);
 		BOOST_CHECK_EQUAL(static_cast<size_t>(sp.size()), mhom.NumVariables());
 		auto v = mhom.Eval(sp);
 		for (Eigen::Index j = 0; j < v.size(); ++j)
@@ -162,16 +162,16 @@ BOOST_AUTO_TEST_CASE(start_points_are_roots_of_the_start_system)
 
 	for (unsigned long long i = 0; i < n; ++i)
 	{
-		auto Hval = H.Eval(mhom.StartPoint<dbl>(i), dbl(1));
+		auto Hval = H.Eval(mhom.StartPoint<complex_dbl>(i), complex_dbl(1));
 		for (Eigen::Index j = 0; j < Hval.size(); ++j)
 			BOOST_CHECK(std::abs(Hval(j)) < 1e-9);
 	}
 
-	bertini::Vec<dbl> xq(H.NumVariables());
+	bertini::Vec<complex_dbl> xq(H.NumVariables());
 	for (Eigen::Index k = 0; k < xq.size(); ++k)
-		xq(k) = dbl(0.37 * static_cast<double>(k + 1) + 0.11, -0.19 * static_cast<double>(k) + 0.07);
-	const dbl tv(0.42, -0.13);
-	const dbl hstep(1e-6, 0);
+		xq(k) = complex_dbl(0.37 * static_cast<double>(k + 1) + 0.11, -0.19 * static_cast<double>(k) + 0.07);
+	const complex_dbl tv(0.42, -0.13);
+	const complex_dbl hstep(1e-6, 0);
 
 	auto J = H.Jacobian(xq, tv);
 	auto f0 = H.Eval(xq, tv);

--- a/core/test/classes/moving_homotopy_test.cpp
+++ b/core/test/classes/moving_homotopy_test.cpp
@@ -35,22 +35,22 @@ using bertini::node::Variable;
 // gamma fixed off the real axis for reproducibility.
 static std::shared_ptr<node::Node> Gamma()
 {
-	return node::Complex::Make(mpfr_complex("0.6", "0.8"));
+	return node::Complex::Make(complex_mp("0.6", "0.8"));
 }
 
 // A LinearFormsBlock-backed single-form system  c.[x;1]  over variables {x,y}.
 static System LinearFormSystem(std::shared_ptr<node::Variable> x, std::shared_ptr<node::Variable> y,
-                               mpfr_complex cx, mpfr_complex cy, mpfr_complex c1)
+                               complex_mp cx, complex_mp cy, complex_mp c1)
 {
 	System s;
 	s.AddVariableGroup(VariableGroup{x, y});
-	Mat<mpfr_complex> M(1, 3);
+	Mat<complex_mp> M(1, 3);
 	M << cx, cy, c1;
 	s.AddBlock(blocks::LinearFormsBlock(2, M));
 	return s;
 }
 
-// H, its expansion twin, agree on values AND Jacobian at several (point, t), in dbl and mpfr.
+// H, its expansion twin, agree on values AND Jacobian at several (point, t), in complex_dbl and mpfr.
 static void AgreesWithExpansionAtTimes(System const& H)
 {
 	System twin = H.ExpandToFunctionTree();
@@ -59,39 +59,39 @@ static void AgreesWithExpansionAtTimes(System const& H)
 	//  counts the path variable t too, so they legitimately differ for a homotopy.)
 
 	const Eigen::Index nv = static_cast<Eigen::Index>(H.NumVariables());
-	std::vector<dbl> times{dbl(1.0), dbl(0.0), dbl(0.37, -0.21)};
+	std::vector<complex_dbl> times{complex_dbl(1.0), complex_dbl(0.0), complex_dbl(0.37, -0.21)};
 
-	Vec<dbl> p(nv);
-	for (Eigen::Index k = 0; k < nv; ++k) p(k) = dbl(0.3 + 0.13 * static_cast<double>(k), 0.4 - 0.07 * static_cast<double>(k));
+	Vec<complex_dbl> p(nv);
+	for (Eigen::Index k = 0; k < nv; ++k) p(k) = complex_dbl(0.3 + 0.13 * static_cast<double>(k), 0.4 - 0.07 * static_cast<double>(k));
 
 	for (auto t : times)
 	{
-		Vec<dbl> a = H.Eval(p, t),  b = twin.Eval(p, t);
+		Vec<complex_dbl> a = H.Eval(p, t),  b = twin.Eval(p, t);
 		for (Eigen::Index i = 0; i < a.size(); ++i)
 			BOOST_CHECK(std::abs(a(i) - b(i)) < 1e-10);
 
-		Mat<dbl> ja = H.Jacobian(p, t), jb = twin.Jacobian(p, t);
+		Mat<complex_dbl> ja = H.Jacobian(p, t), jb = twin.Jacobian(p, t);
 		for (Eigen::Index i = 0; i < ja.rows(); ++i)
 			for (Eigen::Index j = 0; j < ja.cols(); ++j)
 				BOOST_CHECK(std::abs(ja(i, j) - jb(i, j)) < 1e-10);
 
-		Vec<dbl> da = H.TimeDerivative(p, t), db = twin.TimeDerivative(p, t);
+		Vec<complex_dbl> da = H.TimeDerivative(p, t), db = twin.TimeDerivative(p, t);
 		for (Eigen::Index i = 0; i < da.size(); ++i)
 			BOOST_CHECK(std::abs(da(i) - db(i)) < 1e-10);
 	}
 
 	// one mpfr cross-check
 	DefaultPrecision(40);
-	Vec<mpfr_complex> pm(nv);
-	for (Eigen::Index k = 0; k < nv; ++k) pm(k) = mpfr_complex(p(k).real(), p(k).imag());
-	mpfr_complex tm("0.37", "-0.21");
-	Vec<mpfr_complex> am = H.Eval(pm, tm), bm = twin.Eval(pm, tm);
+	Vec<complex_mp> pm(nv);
+	for (Eigen::Index k = 0; k < nv; ++k) pm(k) = complex_mp(p(k).real(), p(k).imag());
+	complex_mp tm("0.37", "-0.21");
+	Vec<complex_mp> am = H.Eval(pm, tm), bm = twin.Eval(pm, tm);
 	for (Eigen::Index i = 0; i < am.size(); ++i)
-		BOOST_CHECK(abs(am(i) - bm(i)) < mpfr_float("1e-30"));
-	Mat<mpfr_complex> jam = H.Jacobian(pm, tm), jbm = twin.Jacobian(pm, tm);
+		BOOST_CHECK(abs(am(i) - bm(i)) < real_mp("1e-30"));
+	Mat<complex_mp> jam = H.Jacobian(pm, tm), jbm = twin.Jacobian(pm, tm);
 	for (Eigen::Index i = 0; i < jam.rows(); ++i)
 		for (Eigen::Index j = 0; j < jam.cols(); ++j)
-			BOOST_CHECK(abs(jam(i, j) - jbm(i, j)) < mpfr_float("1e-30"));
+			BOOST_CHECK(abs(jam(i, j) - jbm(i, j)) < real_mp("1e-30"));
 }
 
 
@@ -120,17 +120,17 @@ BOOST_AUTO_TEST_CASE(endpoints_t0_and_t1)
 	DefaultPrecision(40);
 	System H = CircleMovingSlice();
 
-	Vec<dbl> p(2); p << dbl(0.4, 0.2), dbl(-0.3, 0.5);
-	const dbl circle = p(0)*p(0) + p(1)*p(1) - dbl(1);
+	Vec<complex_dbl> p(2); p << complex_dbl(0.4, 0.2), complex_dbl(-0.3, 0.5);
+	const complex_dbl circle = p(0)*p(0) + p(1)*p(1) - complex_dbl(1);
 
 	// t = 0: moving row = end_moving = y - x ; fixed row = circle.
-	Vec<dbl> at0 = H.Eval(p, dbl(0));
+	Vec<complex_dbl> at0 = H.Eval(p, complex_dbl(0));
 	BOOST_CHECK(std::abs(at0(0) - circle) < 1e-12);
 	BOOST_CHECK(std::abs(at0(1) - (p(1) - p(0))) < 1e-12);
 
 	// t = 1: moving row = gamma * start_moving = gamma * y ; fixed row still circle.
-	const dbl gamma(0.6, 0.8);
-	Vec<dbl> at1 = H.Eval(p, dbl(1));
+	const complex_dbl gamma(0.6, 0.8);
+	Vec<complex_dbl> at1 = H.Eval(p, complex_dbl(1));
 	BOOST_CHECK(std::abs(at1(0) - circle) < 1e-12);
 	BOOST_CHECK(std::abs(at1(1) - gamma * p(1)) < 1e-12);
 }
@@ -140,11 +140,11 @@ BOOST_AUTO_TEST_CASE(fixed_row_is_left_out_of_time_derivative)
 	DefaultPrecision(40);
 	System H = CircleMovingSlice();
 
-	Vec<dbl> p(2); p << dbl(0.4, 0.2), dbl(-0.3, 0.5);
+	Vec<complex_dbl> p(2); p << complex_dbl(0.4, 0.2), complex_dbl(-0.3, 0.5);
 	// dH/dt = [ 0 (circle is t-independent) ; -end + gamma*start = -(y-x) + gamma*y ]
-	Vec<dbl> dt = H.TimeDerivative(p, dbl(0.5));
+	Vec<complex_dbl> dt = H.TimeDerivative(p, complex_dbl(0.5));
 	BOOST_CHECK(std::abs(dt(0)) < 1e-14);                                  // fixed row: exactly out
-	const dbl gamma(0.6, 0.8);
+	const complex_dbl gamma(0.6, 0.8);
 	BOOST_CHECK(std::abs(dt(1) - (-(p(1) - p(0)) + gamma * p(1))) < 1e-12); // moving row
 }
 
@@ -161,18 +161,18 @@ BOOST_AUTO_TEST_CASE(static_slice_and_moving_slice_both_fixed)
 	auto x = Variable::Make("x"), y = Variable::Make("y");
 	System fixed; fixed.AddVariableGroup(VariableGroup{x, y});
 	fixed.AddFunction(x*x + y*y - node::Integer::Make(1));               // row 0: circle (PolynomialBlock)
-	Mat<mpfr_complex> M(1, 3); M << mpfr_complex(1), mpfr_complex(0), mpfr_complex(0);
+	Mat<complex_mp> M(1, 3); M << complex_mp(1), complex_mp(0), complex_mp(0);
 	fixed.AddBlock(blocks::LinearFormsBlock(2, M));                      // row 1: static slice x=0 (LinearFormsBlock)
 
-	System start_moving = LinearFormSystem(x, y, mpfr_complex(0), mpfr_complex(1), mpfr_complex(0));   // y
+	System start_moving = LinearFormSystem(x, y, complex_mp(0), complex_mp(1), complex_mp(0));   // y
 	System end_moving;   end_moving.AddVariableGroup(VariableGroup{x, y}); end_moving.AddFunction(y - x);
 
 	System H = MakeMovingHomotopy(fixed, start_moving, end_moving, "t", Gamma());
 	BOOST_CHECK_EQUAL(H.NumNaturalFunctions(), 3u);
 
 	// both fixed rows (circle, static slice) are out of dH/dt; only the moving row survives.
-	Vec<dbl> p(2); p << dbl(0.4, 0.2), dbl(-0.3, 0.5);
-	Vec<dbl> dt = H.TimeDerivative(p, dbl(0.5));
+	Vec<complex_dbl> p(2); p << complex_dbl(0.4, 0.2), complex_dbl(-0.3, 0.5);
+	Vec<complex_dbl> dt = H.TimeDerivative(p, complex_dbl(0.5));
 	BOOST_CHECK(std::abs(dt(0)) < 1e-14);
 	BOOST_CHECK(std::abs(dt(1)) < 1e-14);
 	BOOST_CHECK(std::abs(dt(2)) > 1e-3);
@@ -186,13 +186,13 @@ BOOST_AUTO_TEST_CASE(deform_products_of_linears_into_polynomial)
 	// static slice y (= the fixed row).
 	DefaultPrecision(40);
 	auto x = Variable::Make("x"), y = Variable::Make("y");
-	System fixed = LinearFormSystem(x, y, mpfr_complex(0), mpfr_complex(1), mpfr_complex(0));  // y (static)
+	System fixed = LinearFormSystem(x, y, complex_mp(0), complex_mp(1), complex_mp(0));  // y (static)
 
 	System start_moving; start_moving.AddVariableGroup(VariableGroup{x, y});
-	Mat<mpfr_complex> f(2, 3);
-	f << mpfr_complex(1), mpfr_complex(0), mpfr_complex(-1),     // (x - 1)
-	     mpfr_complex(1), mpfr_complex(0), mpfr_complex(1);      // (x + 1)
-	start_moving.AddBlock(blocks::ProductsOfLinearsBlock(2, std::vector<Mat<mpfr_complex>>{f}));
+	Mat<complex_mp> f(2, 3);
+	f << complex_mp(1), complex_mp(0), complex_mp(-1),     // (x - 1)
+	     complex_mp(1), complex_mp(0), complex_mp(1);      // (x + 1)
+	start_moving.AddBlock(blocks::ProductsOfLinearsBlock(2, std::vector<Mat<complex_mp>>{f}));
 
 	System end_moving; end_moving.AddVariableGroup(VariableGroup{x, y});
 	end_moving.AddFunction(x*x + y*y - node::Integer::Make(1));
@@ -201,15 +201,15 @@ BOOST_AUTO_TEST_CASE(deform_products_of_linears_into_polynomial)
 	BOOST_CHECK_EQUAL(H.NumNaturalFunctions(), 2u);
 
 	// at t=1 the moving row is gamma*(x-1)(x+1) = gamma*(x^2-1); at t=0 it is the circle.
-	Vec<dbl> p(2); p << dbl(2.0), dbl(3.0);
-	const dbl gamma(0.6, 0.8);
-	Vec<dbl> at1 = H.Eval(p, dbl(1));
-	BOOST_CHECK(std::abs(at1(1) - gamma * (p(0)*p(0) - dbl(1))) < 1e-10);
-	Vec<dbl> at0 = H.Eval(p, dbl(0));
-	BOOST_CHECK(std::abs(at0(1) - (p(0)*p(0) + p(1)*p(1) - dbl(1))) < 1e-10);
+	Vec<complex_dbl> p(2); p << complex_dbl(2.0), complex_dbl(3.0);
+	const complex_dbl gamma(0.6, 0.8);
+	Vec<complex_dbl> at1 = H.Eval(p, complex_dbl(1));
+	BOOST_CHECK(std::abs(at1(1) - gamma * (p(0)*p(0) - complex_dbl(1))) < 1e-10);
+	Vec<complex_dbl> at0 = H.Eval(p, complex_dbl(0));
+	BOOST_CHECK(std::abs(at0(1) - (p(0)*p(0) + p(1)*p(1) - complex_dbl(1))) < 1e-10);
 
 	// fixed (static slice) row out of dH/dt
-	Vec<dbl> dt = H.TimeDerivative(p, dbl(0.5));
+	Vec<complex_dbl> dt = H.TimeDerivative(p, complex_dbl(0.5));
 	BOOST_CHECK(std::abs(dt(0)) < 1e-14);
 
 	AgreesWithExpansionAtTimes(H);
@@ -280,12 +280,12 @@ BOOST_AUTO_TEST_CASE(clone_of_moving_homotopy_reproduces_and_is_independent)
 	System H = CircleMovingSlice();
 	H.Differentiate();
 
-	Vec<dbl> p1(2); p1 << dbl(0.3, 0.1), dbl(-0.2, 0.4);
-	Vec<dbl> p2(2); p2 << dbl(1.5, -0.7), dbl(0.9, 0.2);
-	const dbl t1(0.25, 0.0), t2(0.8, -0.1);
+	Vec<complex_dbl> p1(2); p1 << complex_dbl(0.3, 0.1), complex_dbl(-0.2, 0.4);
+	Vec<complex_dbl> p2(2); p2 << complex_dbl(1.5, -0.7), complex_dbl(0.9, 0.2);
+	const complex_dbl t1(0.25, 0.0), t2(0.8, -0.1);
 
-	const Vec<dbl> f1 = H.Eval(p1, t1);
-	const Mat<dbl> j1 = H.Jacobian(p1, t1);
+	const Vec<complex_dbl> f1 = H.Eval(p1, t1);
+	const Mat<complex_dbl> j1 = H.Jacobian(p1, t1);
 
 	System H_clone = Clone(H);
 

--- a/core/test/classes/named_expression_test.cpp
+++ b/core/test/classes/named_expression_test.cpp
@@ -12,7 +12,7 @@ using bertini::node::Named;
 using bertini::node::NamedExpression;
 using bertini::node::Find;
 using Nd = std::shared_ptr<bertini::node::Node>;
-using dbl = bertini::dbl;
+using complex_dbl = bertini::complex_dbl;
 using bertini::EvalExpression;
 
 BOOST_AUTO_TEST_SUITE(named_expression)
@@ -35,8 +35,8 @@ BOOST_AUTO_TEST_CASE(evaluates_to_its_expression)
 	auto y = Variable::Make("y");
 	Nd a = Named(x*x + y*y, "a");
 	// a at (3,4) = 9 + 16 = 25
-	auto v = EvalExpression<dbl>(a, {{"x", dbl(3,0)}, {"y", dbl(4,0)}});
-	BOOST_CHECK_SMALL(std::abs(v - dbl(25,0)), 1e-12);
+	auto v = EvalExpression<complex_dbl>(a, {{"x", complex_dbl(3,0)}, {"y", complex_dbl(4,0)}});
+	BOOST_CHECK_SMALL(std::abs(v - complex_dbl(25,0)), 1e-12);
 }
 
 // Hash-consed by (expression, name): same -> one node; different name or bare expr -> different.
@@ -59,8 +59,8 @@ BOOST_AUTO_TEST_CASE(usable_as_a_subexpression)
 	auto x = Variable::Make("x");
 	Nd a = Named(x*x, "a");
 	Nd f = a*a + a;   // a^2 + a, with a = x^2; at x=2 -> 16 + 4 = 20
-	auto v = EvalExpression<dbl>(f, {{"x", dbl(2,0)}});
-	BOOST_CHECK_SMALL(std::abs(v - dbl(20,0)), 1e-12);
+	auto v = EvalExpression<complex_dbl>(f, {{"x", complex_dbl(2,0)}});
+	BOOST_CHECK_SMALL(std::abs(v - complex_dbl(20,0)), 1e-12);
 }
 
 // Find<NamedExpression> discovers the named subexpressions in a tree, including nested ones,

--- a/core/test/classes/node_serialization_test.cpp
+++ b/core/test/classes/node_serialization_test.cpp
@@ -63,8 +63,8 @@ using Node = bertini::node::Node;
 using Complex = bertini::node::Complex;
 
 
-using dbl = bertini::dbl;
-using mpfr = bertini::mpfr_complex;
+using complex_dbl = bertini::complex_dbl;
+using mpfr = bertini::complex_mp;
 
 using System = bertini::System;
 
@@ -118,7 +118,7 @@ BOOST_AUTO_TEST_CASE(serialize_float)
 		ia >> two_point_oh_four2;
 	}
 
-	BOOST_CHECK(EvalAt<dbl>(two_point_oh_four)==EvalAt<dbl>(two_point_oh_four2));
+	BOOST_CHECK(EvalAt<complex_dbl>(two_point_oh_four)==EvalAt<complex_dbl>(two_point_oh_four2));
 }
 
 BOOST_AUTO_TEST_CASE(serialize_complicated_expression)
@@ -150,8 +150,8 @@ BOOST_AUTO_TEST_CASE(serialize_complicated_expression)
 
 	BOOST_CHECK(x->name()==x2->name());
 
-	std::map<std::string,dbl> pt{ {"x", dbl(1.2,0.9)} };
-	BOOST_CHECK(abs(EvalAt<dbl>(f, pt) - EvalAt<dbl>(f2, pt)) < threshold_clearance_d);
+	std::map<std::string,complex_dbl> pt{ {"x", complex_dbl(1.2,0.9)} };
+	BOOST_CHECK(abs(EvalAt<complex_dbl>(f, pt) - EvalAt<complex_dbl>(f2, pt)) < threshold_clearance_d);
 
 }
 
@@ -163,10 +163,10 @@ BOOST_AUTO_TEST_CASE(system_serialize_scopes)
 
 
 	
-	Vec<dbl> values(2);
+	Vec<complex_dbl> values(2);
 
-	values(0) = dbl(2.0);
-	values(1) = dbl(3.0);
+	values(0) = complex_dbl(2.0);
+	values(1) = complex_dbl(3.0);
 
 	
 	
@@ -201,7 +201,7 @@ BOOST_AUTO_TEST_CASE(system_serialize_scopes)
 		bertini::System sys2;
 		ia >> sys2;
 
-		Vec<dbl> v = sys2.Eval(values);
+		Vec<complex_dbl> v = sys2.Eval(values);
 
 
 		BOOST_CHECK_EQUAL(v.size(),2);
@@ -224,12 +224,12 @@ BOOST_AUTO_TEST_CASE(system_serialize_scopes_via_parsing)
 
 
 	
-	Vec<dbl> x(2);
+	Vec<complex_dbl> x(2);
 
-	x(0) = dbl(2.0);
-	x(1) = dbl(3.0);
+	x(0) = complex_dbl(2.0);
+	x(1) = complex_dbl(3.0);
 
-	Vec<dbl> y_before(2);
+	Vec<complex_dbl> y_before(2);
 	
 	{ // to create a scope
 
@@ -257,7 +257,7 @@ BOOST_AUTO_TEST_CASE(system_serialize_scopes_via_parsing)
 		bertini::System sys2;
 		ia >> sys2;
 
-		Vec<dbl> y_after = sys2.Eval(x);
+		Vec<complex_dbl> y_after = sys2.Eval(x);
 
 
 		BOOST_CHECK_EQUAL(y_after.size(),2);
@@ -278,10 +278,10 @@ BOOST_AUTO_TEST_CASE(system_serialize_scopes_using_subfunctions_via_parsing)
 
 
 	
-	Vec<dbl> values(2);
+	Vec<complex_dbl> values(2);
 
-	values(0) = dbl(2.0);
-	values(1) = dbl(3.0);
+	values(0) = complex_dbl(2.0);
+	values(1) = complex_dbl(3.0);
 
 	
 	
@@ -310,7 +310,7 @@ BOOST_AUTO_TEST_CASE(system_serialize_scopes_using_subfunctions_via_parsing)
 		bertini::System sys2;
 		ia >> sys2;
 
-		Vec<dbl> v = sys2.Eval(values);
+		Vec<complex_dbl> v = sys2.Eval(values);
 
 
 		BOOST_CHECK_EQUAL(v.size(),2);
@@ -337,12 +337,12 @@ BOOST_AUTO_TEST_CASE(system_clone)
 	auto sys2 = Clone(sys1);
 	
 
-	Vec<dbl> values(2);
+	Vec<complex_dbl> values(2);
 
-	values(0) = dbl(2.0);
-	values(1) = dbl(3.0);
+	values(0) = complex_dbl(2.0);
+	values(1) = complex_dbl(3.0);
 
-	Vec<dbl> v = sys2.Eval(values);
+	Vec<complex_dbl> v = sys2.Eval(values);
 
 	BOOST_CHECK_EQUAL(v.size(),2);
 
@@ -364,9 +364,9 @@ BOOST_AUTO_TEST_CASE(system_clone)
 
 	// Evaluation is still independent: evaluating the original at a different point does not change
 	// the clone's result.
-	Vec<dbl> other(2); other(0) = dbl(5.0); other(1) = dbl(7.0);
+	Vec<complex_dbl> other(2); other(0) = complex_dbl(5.0); other(1) = complex_dbl(7.0);
 	(void) sys1.Eval(other);
-	Vec<dbl> v2 = sys2.Eval(values);
+	Vec<complex_dbl> v2 = sys2.Eval(values);
 	BOOST_CHECK_EQUAL(v2(0), 36.0);
 	BOOST_CHECK_EQUAL(v2(1), 12.0);
 }

--- a/core/test/classes/patch_test.cpp
+++ b/core/test/classes/patch_test.cpp
@@ -53,10 +53,10 @@ template<typename NumT> using Vec = bertini::Vec<NumT>;
 template<typename NumT> using Mat = bertini::Mat<NumT>;
 using Patch = bertini::Patch;
 
-using dbl = bertini::dbl;
-using mpfr = bertini::mpfr_complex;
+using complex_dbl = bertini::complex_dbl;
+using mpfr = bertini::complex_mp;
 
-using mpfr_float = bertini::mpfr_float;
+using real_mp = bertini::real_mp;
 
 
 BOOST_AUTO_TEST_CASE(patch_create)
@@ -87,8 +87,8 @@ BOOST_AUTO_TEST_CASE(patch_eval_two_variable_groups_prec16)
 
 	Patch p(s);
 
-	Vec<dbl> v(5);
-	v << dbl(1),  dbl(1),  dbl(1),  dbl(1),  dbl(1);
+	Vec<complex_dbl> v(5);
+	v << complex_dbl(1),  complex_dbl(1),  complex_dbl(1),  complex_dbl(1),  complex_dbl(1);
 
 	p.Precision(16);
 	
@@ -104,8 +104,8 @@ BOOST_AUTO_TEST_CASE(patch_jacobian_two_variable_groups_prec16)
 
 	Patch p(s);
 
-	Vec<dbl> v(5);
-	v << dbl(1),  dbl(1),  dbl(1),  dbl(1),  dbl(1);
+	Vec<complex_dbl> v(5);
+	v << complex_dbl(1),  complex_dbl(1),  complex_dbl(1),  complex_dbl(1),  complex_dbl(1);
 
 	p.Precision(16);
 
@@ -113,12 +113,12 @@ BOOST_AUTO_TEST_CASE(patch_jacobian_two_variable_groups_prec16)
 	BOOST_CHECK_EQUAL(J.rows(),2);
 	BOOST_CHECK_EQUAL(J.cols(),5);
 
-	BOOST_CHECK_EQUAL(J(0,2),dbl(0));
-	BOOST_CHECK_EQUAL(J(0,3),dbl(0));
-	BOOST_CHECK_EQUAL(J(0,4),dbl(0));
+	BOOST_CHECK_EQUAL(J(0,2),complex_dbl(0));
+	BOOST_CHECK_EQUAL(J(0,3),complex_dbl(0));
+	BOOST_CHECK_EQUAL(J(0,4),complex_dbl(0));
 
-	BOOST_CHECK_EQUAL(J(1,0),dbl(0));
-	BOOST_CHECK_EQUAL(J(1,1),dbl(0));
+	BOOST_CHECK_EQUAL(J(1,0),complex_dbl(0));
+	BOOST_CHECK_EQUAL(J(1,1),complex_dbl(0));
 }
 
 
@@ -137,23 +137,23 @@ BOOST_AUTO_TEST_CASE(patch_jacobian_fully_defines_its_rows_into_a_dirty_buffer)
 	Patch p(s);
 	p.Precision(16);
 
-	Vec<dbl> v(5);
-	v << dbl(1),  dbl(1),  dbl(1),  dbl(1),  dbl(1);
+	Vec<complex_dbl> v(5);
+	v << complex_dbl(1),  complex_dbl(1),  complex_dbl(1),  complex_dbl(1),  complex_dbl(1);
 
-	Mat<dbl> J = Mat<dbl>::Constant(2, 5, dbl(1e300)); // poison every entry
+	Mat<complex_dbl> J = Mat<complex_dbl>::Constant(2, 5, complex_dbl(1e300)); // poison every entry
 
 	p.JacobianInPlace(J, v);
 
 	// off-coefficient entries of each patch row must be overwritten with zero, not left poisoned
-	BOOST_CHECK_EQUAL(J(0,2), dbl(0));
-	BOOST_CHECK_EQUAL(J(0,3), dbl(0));
-	BOOST_CHECK_EQUAL(J(0,4), dbl(0));
-	BOOST_CHECK_EQUAL(J(1,0), dbl(0));
-	BOOST_CHECK_EQUAL(J(1,1), dbl(0));
+	BOOST_CHECK_EQUAL(J(0,2), complex_dbl(0));
+	BOOST_CHECK_EQUAL(J(0,3), complex_dbl(0));
+	BOOST_CHECK_EQUAL(J(0,4), complex_dbl(0));
+	BOOST_CHECK_EQUAL(J(1,0), complex_dbl(0));
+	BOOST_CHECK_EQUAL(J(1,1), complex_dbl(0));
 
 	// the coefficient entries are still written (no longer the poison value)
-	BOOST_CHECK_NE(J(0,0), dbl(1e300));
-	BOOST_CHECK_NE(J(1,2), dbl(1e300));
+	BOOST_CHECK_NE(J(0,0), complex_dbl(1e300));
+	BOOST_CHECK_NE(J(1,2), complex_dbl(1e300));
 }
 
 
@@ -212,8 +212,8 @@ BOOST_AUTO_TEST_CASE(patch_rescale_and_evaluate_prec16)
 	Patch p(s);
 	p.Precision(16);
 
-	Vec<dbl> v(5);
-	v << dbl(1),  dbl(1),  dbl(1),  dbl(1),  dbl(1);
+	Vec<complex_dbl> v(5);
+	v << complex_dbl(1),  complex_dbl(1),  complex_dbl(1),  complex_dbl(1),  complex_dbl(1);
 
 	auto v_rescaled = p.RescalePoint(v);
 

--- a/core/test/classes/precision_propagation_test.cpp
+++ b/core/test/classes/precision_propagation_test.cpp
@@ -29,15 +29,15 @@
 
 using bertini::DefaultPrecision;
 using bertini::Precision;
-using mpfr_float  = bertini::mpfr_float;
-using mpfr_complex = bertini::mpfr_complex;
+using real_mp  = bertini::real_mp;
+using complex_mp = bertini::complex_mp;
 using mpq_rational = bertini::mpq_rational;
 
 // -----------------------------------------------------------------------
 // Helpers
 // -----------------------------------------------------------------------
 
-// Simulate a stale non-local-static mpfr_float: created at STARTUP_PREC
+// Simulate a stale non-local-static real_mp: created at STARTUP_PREC
 // then used in arithmetic at a different target precision.
 static constexpr unsigned STARTUP_PREC = 20;  // BMP default at program start
 
@@ -51,16 +51,16 @@ BOOST_AUTO_TEST_SUITE(precision_propagation)
 BOOST_AUTO_TEST_CASE(default_precision_sets_both_float_and_complex)
 {
 	DefaultPrecision(30);
-	BOOST_CHECK_EQUAL(mpfr_float::default_precision(),  30u);
-	BOOST_CHECK_EQUAL(mpfr_complex::default_precision(), 30u);
+	BOOST_CHECK_EQUAL(real_mp::default_precision(),  30u);
+	BOOST_CHECK_EQUAL(complex_mp::default_precision(), 30u);
 
 	DefaultPrecision(16);
-	BOOST_CHECK_EQUAL(mpfr_float::default_precision(),  16u);
-	BOOST_CHECK_EQUAL(mpfr_complex::default_precision(), 16u);
+	BOOST_CHECK_EQUAL(real_mp::default_precision(),  16u);
+	BOOST_CHECK_EQUAL(complex_mp::default_precision(), 16u);
 
 	DefaultPrecision(50);
-	BOOST_CHECK_EQUAL(mpfr_float::default_precision(),  50u);
-	BOOST_CHECK_EQUAL(mpfr_complex::default_precision(), 50u);
+	BOOST_CHECK_EQUAL(real_mp::default_precision(),  50u);
+	BOOST_CHECK_EQUAL(complex_mp::default_precision(), 50u);
 }
 
 
@@ -72,9 +72,9 @@ BOOST_AUTO_TEST_CASE(default_precision_sets_preserve_related_on_both_types)
 {
 	using bmp = boost::multiprecision::variable_precision_options;
 	DefaultPrecision(30);
-	BOOST_CHECK(mpfr_float::thread_default_variable_precision_options()
+	BOOST_CHECK(real_mp::thread_default_variable_precision_options()
 	            == bmp::preserve_related_precision);
-	BOOST_CHECK(mpfr_complex::thread_default_variable_precision_options()
+	BOOST_CHECK(complex_mp::thread_default_variable_precision_options()
 	            == bmp::preserve_related_precision);
 }
 #endif
@@ -82,54 +82,54 @@ BOOST_AUTO_TEST_CASE(default_precision_sets_preserve_related_on_both_types)
 
 // --- 3. mpq_rational carries no MPFR precision state ------------------
 //
-// Key property: mpq_rational * mpfr_float(prec=N) → result at prec=N.
+// Key property: mpq_rational * real_mp(prec=N) → result at prec=N.
 // This is the fix for EndgameConfig::sample_factor.
 
 BOOST_AUTO_TEST_CASE(mpq_rational_times_mpfr_float_result_at_target_precision)
 {
 	DefaultPrecision(16);
-	mpfr_float t("0.3");
+	real_mp t("0.3");
 	BOOST_REQUIRE_EQUAL(t.precision(), 16u);
 
 	mpq_rational half{1, 2};
-	mpfr_float result = t * half;
+	real_mp result = t * half;
 	BOOST_CHECK_EQUAL(result.precision(), 16u);
 }
 
 BOOST_AUTO_TEST_CASE(mpq_rational_times_mpfr_float_at_high_precision)
 {
 	DefaultPrecision(50);
-	mpfr_float t("0.3");
+	real_mp t("0.3");
 	mpq_rational r{647, 1000};
-	mpfr_float result = t * r;
+	real_mp result = t * r;
 	BOOST_CHECK_EQUAL(result.precision(), 50u);
 }
 
 
-// --- 4. Stale mpfr_float at prec > target contaminates arithmetic -----
+// --- 4. Stale real_mp at prec > target contaminates arithmetic -----
 //
 // DOCUMENTARY test: demonstrates the PROBLEM that motivates using
 // mpq_rational for config fields.  With preserve_related_precision,
-// an mpfr_float stale at prec=STARTUP_PREC poisons results when
+// an real_mp stale at prec=STARTUP_PREC poisons results when
 // STARTUP_PREC > target precision.
 
 BOOST_AUTO_TEST_CASE(stale_mpfr_float_contaminates_when_startup_prec_exceeds_target)
 {
 	// Create a stale config value at "startup precision" (20 digits).
 	DefaultPrecision(STARTUP_PREC);
-	mpfr_float stale_factor("0.5");
+	real_mp stale_factor("0.5");
 	BOOST_REQUIRE_EQUAL(stale_factor.precision(), STARTUP_PREC);
 
 	// Now switch to a lower target precision.
 	DefaultPrecision(16);
-	mpfr_float t("0.3");
+	real_mp t("0.3");
 	BOOST_REQUIRE_EQUAL(t.precision(), 16u);
 
 	// With preserve_related_precision the result takes max(stale, target) = 20 — NOT 16.
 	// This test DOCUMENTS the contamination and is expected to fail/warn until
 	// all config fields that appear in non-local statics are changed to mpq_rational.
 #ifdef BMP_EXPRESSION_TEMPLATES
-	mpfr_float contaminated = t * stale_factor;
+	real_mp contaminated = t * stale_factor;
 	BOOST_WARN_EQUAL(contaminated.precision(), 16u);  // WARN: currently 20 (contaminated)
 	BOOST_CHECK_EQUAL(contaminated.precision(), STARTUP_PREC);  // confirms contamination
 #endif
@@ -138,7 +138,7 @@ BOOST_AUTO_TEST_CASE(stale_mpfr_float_contaminates_when_startup_prec_exceeds_tar
 
 // --- 5. EndgameConfig::sample_factor is mpq_rational (regression guard)
 //
-// If someone changes sample_factor back to mpfr_float, this test
+// If someone changes sample_factor back to real_mp, this test
 // catches the precision contamination at prec < STARTUP_PREC.
 
 BOOST_AUTO_TEST_CASE(endgame_config_sample_factor_no_precision_contamination)
@@ -148,10 +148,10 @@ BOOST_AUTO_TEST_CASE(endgame_config_sample_factor_no_precision_contamination)
 	auto const& cfg = bertini::detail::DefaultConstruct<bertini::endgame::EndgameConfig>::value;
 
 	DefaultPrecision(16);
-	mpfr_float t("0.3");
+	real_mp t("0.3");
 	BOOST_REQUIRE_EQUAL(t.precision(), 16u);
 
-	mpfr_float result = t * mpfr_float(cfg.sample_factor);
+	real_mp result = t * real_mp(cfg.sample_factor);
 	BOOST_CHECK_EQUAL(result.precision(), 16u);
 }
 
@@ -164,7 +164,7 @@ BOOST_AUTO_TEST_CASE(endgame_config_default_sample_factor_is_one_half)
 
 // --- 6. SteppingConfig step-size fields should not contaminate ---------
 //
-// These tests currently FAIL because SteppingConfig uses mpfr_float for
+// These tests currently FAIL because SteppingConfig uses real_mp for
 // its step-size fields — they get initialized at prec=STARTUP_PREC in
 // DefaultConstruct<SteppingConfig>::value.  They will PASS once those
 // fields are changed to mpq_rational (or double for the min_step_size).
@@ -174,10 +174,10 @@ BOOST_AUTO_TEST_CASE(stepping_config_success_factor_no_precision_contamination)
 	auto const& cfg = bertini::detail::DefaultConstruct<bertini::tracking::SteppingConfig>::value;
 
 	DefaultPrecision(16);
-	mpfr_float step("0.1");
+	real_mp step("0.1");
 	BOOST_REQUIRE_EQUAL(step.precision(), 16u);
 
-	mpfr_float result = step * mpfr_float(cfg.step_size_success_factor);
+	real_mp result = step * real_mp(cfg.step_size_success_factor);
 	BOOST_CHECK_EQUAL(result.precision(), 16u);
 }
 
@@ -186,10 +186,10 @@ BOOST_AUTO_TEST_CASE(stepping_config_fail_factor_no_precision_contamination)
 	auto const& cfg = bertini::detail::DefaultConstruct<bertini::tracking::SteppingConfig>::value;
 
 	DefaultPrecision(16);
-	mpfr_float step("0.1");
+	real_mp step("0.1");
 	BOOST_REQUIRE_EQUAL(step.precision(), 16u);
 
-	mpfr_float result = step * mpfr_float(cfg.step_size_fail_factor);
+	real_mp result = step * real_mp(cfg.step_size_fail_factor);
 	BOOST_CHECK_EQUAL(result.precision(), 16u);
 }
 
@@ -199,7 +199,7 @@ BOOST_AUTO_TEST_CASE(stepping_config_max_step_size_no_stale_precision)
 
 	DefaultPrecision(16);
 	// max_step_size itself should be at (or convertible to) target precision without contamination
-	mpfr_float result = mpfr_float(cfg.max_step_size);
+	real_mp result = real_mp(cfg.max_step_size);
 	BOOST_CHECK_EQUAL(result.precision(), 16u);
 }
 

--- a/core/test/classes/products_of_linears_block_test.cpp
+++ b/core/test/classes/products_of_linears_block_test.cpp
@@ -35,14 +35,14 @@ static_assert(bertini::blocks::is_block_v<ProductsOfLinearsBlock>,
 //   df1/dx = 1,               df1/dy = 0
 static ProductsOfLinearsBlock MakeTestBlock()
 {
-	bertini::Mat<mpfr_complex> f0(2, 3);
-	f0 << mpfr_complex(2), mpfr_complex(3),  mpfr_complex(1),
-	      mpfr_complex(1), mpfr_complex(-1), mpfr_complex(4);
+	bertini::Mat<complex_mp> f0(2, 3);
+	f0 << complex_mp(2), complex_mp(3),  complex_mp(1),
+	      complex_mp(1), complex_mp(-1), complex_mp(4);
 
-	bertini::Mat<mpfr_complex> f1(1, 3);
-	f1 << mpfr_complex(1), mpfr_complex(0), mpfr_complex(1);
+	bertini::Mat<complex_mp> f1(1, 3);
+	f1 << complex_mp(1), complex_mp(0), complex_mp(1);
 
-	std::vector<bertini::Mat<mpfr_complex>> factors{f0, f1};
+	std::vector<bertini::Mat<complex_mp>> factors{f0, f1};
 	return ProductsOfLinearsBlock(2, std::move(factors));
 }
 
@@ -60,9 +60,9 @@ BOOST_AUTO_TEST_CASE(eval_double)
 	DefaultPrecision(30);
 	auto block = MakeTestBlock();
 
-	bertini::Vec<dbl> x(2); x << dbl(1), dbl(1);
-	bertini::Vec<dbl> result(2);
-	block.EvalInPlace<dbl>(result, x, dbl(0));
+	bertini::Vec<complex_dbl> x(2); x << complex_dbl(1), complex_dbl(1);
+	bertini::Vec<complex_dbl> result(2);
+	block.EvalInPlace<complex_dbl>(result, x, complex_dbl(0));
 
 	BOOST_CHECK_CLOSE(result(0).real(), 24.0, 1e-11);
 	BOOST_CHECK_CLOSE(result(1).real(), 2.0, 1e-11);
@@ -75,9 +75,9 @@ BOOST_AUTO_TEST_CASE(jacobian_double)
 	DefaultPrecision(30);
 	auto block = MakeTestBlock();
 
-	bertini::Vec<dbl> x(2); x << dbl(1), dbl(1);
-	bertini::Mat<dbl> J(2, 2);
-	block.JacobianInPlace<dbl>(J, x, dbl(0));
+	bertini::Vec<complex_dbl> x(2); x << complex_dbl(1), complex_dbl(1);
+	bertini::Mat<complex_dbl> J(2, 2);
+	block.JacobianInPlace<complex_dbl>(J, x, complex_dbl(0));
 
 	BOOST_CHECK_CLOSE(J(0, 0).real(), 14.0, 1e-11);
 	BOOST_CHECK_CLOSE(J(0, 1).real(),  6.0, 1e-11);
@@ -91,12 +91,12 @@ BOOST_AUTO_TEST_CASE(eval_mpfr)
 	auto block = MakeTestBlock();
 	block.Precision(30);
 
-	bertini::Vec<mpfr_complex> x(2); x << mpfr_complex(1), mpfr_complex(1);
-	bertini::Vec<mpfr_complex> result(2);
-	block.EvalInPlace<mpfr_complex>(result, x, mpfr_complex(0));
+	bertini::Vec<complex_mp> x(2); x << complex_mp(1), complex_mp(1);
+	bertini::Vec<complex_mp> result(2);
+	block.EvalInPlace<complex_mp>(result, x, complex_mp(0));
 
-	BOOST_CHECK(abs(result(0) - mpfr_complex(24)) < mpfr_float("1e-25"));
-	BOOST_CHECK(abs(result(1) - mpfr_complex(2))  < mpfr_float("1e-25"));
+	BOOST_CHECK(abs(result(0) - complex_mp(24)) < real_mp("1e-25"));
+	BOOST_CHECK(abs(result(1) - complex_mp(2))  < real_mp("1e-25"));
 }
 
 BOOST_AUTO_TEST_CASE(jacobian_mpfr)
@@ -105,14 +105,14 @@ BOOST_AUTO_TEST_CASE(jacobian_mpfr)
 	auto block = MakeTestBlock();
 	block.Precision(30);
 
-	bertini::Vec<mpfr_complex> x(2); x << mpfr_complex(1), mpfr_complex(1);
-	bertini::Mat<mpfr_complex> J(2, 2);
-	block.JacobianInPlace<mpfr_complex>(J, x, mpfr_complex(0));
+	bertini::Vec<complex_mp> x(2); x << complex_mp(1), complex_mp(1);
+	bertini::Mat<complex_mp> J(2, 2);
+	block.JacobianInPlace<complex_mp>(J, x, complex_mp(0));
 
-	BOOST_CHECK(abs(J(0, 0) - mpfr_complex(14)) < mpfr_float("1e-25"));
-	BOOST_CHECK(abs(J(0, 1) - mpfr_complex(6))  < mpfr_float("1e-25"));
-	BOOST_CHECK(abs(J(1, 0) - mpfr_complex(1))  < mpfr_float("1e-25"));
-	BOOST_CHECK(abs(J(1, 1))                    < mpfr_float("1e-25"));
+	BOOST_CHECK(abs(J(0, 0) - complex_mp(14)) < real_mp("1e-25"));
+	BOOST_CHECK(abs(J(0, 1) - complex_mp(6))  < real_mp("1e-25"));
+	BOOST_CHECK(abs(J(1, 0) - complex_mp(1))  < real_mp("1e-25"));
+	BOOST_CHECK(abs(J(1, 1))                    < real_mp("1e-25"));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/core/test/classes/randomization_block_test.cpp
+++ b/core/test/classes/randomization_block_test.cpp
@@ -22,7 +22,7 @@
 
 The workhorse oracle is ExpandToFunctionTree(): a randomized system evaluated through its block
 must agree, value-for-value and derivative-for-derivative, with the same system expanded to plain
-function-tree nodes -- in both dbl and mpfr_complex, before AND after homogenization (so the
+function-tree nodes -- in both complex_dbl and complex_mp, before AND after homogenization (so the
 homogenizing-variable power deficits are exercised), for single- and multi-projective systems.
 That cross-check is deterministic on every platform, unlike a heap-dirtiness-dependent bug.
 */
@@ -93,49 +93,49 @@ static void AgreesWithExpansion(System const& sys)
 	const Eigen::Index nv = static_cast<Eigen::Index>(sys.NumVariables());
 
 	// a few non-degenerate complex points
-	std::vector<Vec<dbl>> pts;
+	std::vector<Vec<complex_dbl>> pts;
 	{
-		Vec<dbl> p(nv);
-		for (Eigen::Index k = 0; k < nv; ++k) p(k) = dbl(0.3 + 0.17 * static_cast<double>(k), 0.5 - 0.11 * static_cast<double>(k));
+		Vec<complex_dbl> p(nv);
+		for (Eigen::Index k = 0; k < nv; ++k) p(k) = complex_dbl(0.3 + 0.17 * static_cast<double>(k), 0.5 - 0.11 * static_cast<double>(k));
 		pts.push_back(p);
-		Vec<dbl> q(nv);
-		for (Eigen::Index k = 0; k < nv; ++k) q(k) = dbl(-0.7 + 0.05 * static_cast<double>(k), 0.9 + 0.03 * static_cast<double>(k));
+		Vec<complex_dbl> q(nv);
+		for (Eigen::Index k = 0; k < nv; ++k) q(k) = complex_dbl(-0.7 + 0.05 * static_cast<double>(k), 0.9 + 0.03 * static_cast<double>(k));
 		pts.push_back(q);
 	}
 
 	for (auto const& p : pts)
 	{
-		// --- dbl ---
-		Vec<dbl> ea = sys.Eval(p);
-		Vec<dbl> eb = twin.Eval(p);
+		// --- complex_dbl ---
+		Vec<complex_dbl> ea = sys.Eval(p);
+		Vec<complex_dbl> eb = twin.Eval(p);
 		BOOST_REQUIRE_EQUAL(ea.size(), eb.size());
 		for (Eigen::Index i = 0; i < ea.size(); ++i)
 			BOOST_CHECK(std::abs(ea(i) - eb(i)) < 1e-10);
 
-		Mat<dbl> ja = sys.Jacobian(p);
-		Mat<dbl> jb = twin.Jacobian(p);
+		Mat<complex_dbl> ja = sys.Jacobian(p);
+		Mat<complex_dbl> jb = twin.Jacobian(p);
 		BOOST_REQUIRE_EQUAL(ja.rows(), jb.rows());
 		BOOST_REQUIRE_EQUAL(ja.cols(), jb.cols());
 		for (Eigen::Index i = 0; i < ja.rows(); ++i)
 			for (Eigen::Index j = 0; j < ja.cols(); ++j)
 				BOOST_CHECK(std::abs(ja(i, j) - jb(i, j)) < 1e-10);
 
-		// --- mpfr_complex ---
+		// --- complex_mp ---
 		DefaultPrecision(40);
-		Vec<mpfr_complex> pm(nv);
+		Vec<complex_mp> pm(nv);
 		for (Eigen::Index k = 0; k < nv; ++k)
-			pm(k) = mpfr_complex(p(k).real(), p(k).imag());
+			pm(k) = complex_mp(p(k).real(), p(k).imag());
 
-		Vec<mpfr_complex> ema = sys.Eval(pm);
-		Vec<mpfr_complex> emb = twin.Eval(pm);
+		Vec<complex_mp> ema = sys.Eval(pm);
+		Vec<complex_mp> emb = twin.Eval(pm);
 		for (Eigen::Index i = 0; i < ema.size(); ++i)
-			BOOST_CHECK(abs(ema(i) - emb(i)) < mpfr_float("1e-30"));
+			BOOST_CHECK(abs(ema(i) - emb(i)) < real_mp("1e-30"));
 
-		Mat<mpfr_complex> jma = sys.Jacobian(pm);
-		Mat<mpfr_complex> jmb = twin.Jacobian(pm);
+		Mat<complex_mp> jma = sys.Jacobian(pm);
+		Mat<complex_mp> jmb = twin.Jacobian(pm);
 		for (Eigen::Index i = 0; i < jma.rows(); ++i)
 			for (Eigen::Index j = 0; j < jma.cols(); ++j)
-				BOOST_CHECK(abs(jma(i, j) - jmb(i, j)) < mpfr_float("1e-30"));
+				BOOST_CHECK(abs(jma(i, j) - jmb(i, j)) < real_mp("1e-30"));
 	}
 }
 
@@ -189,8 +189,8 @@ BOOST_AUTO_TEST_CASE(matrix_getter_round_trips_and_is_I_C)
 	BOOST_REQUIRE_EQUAL(R.rows(), 2);
 	BOOST_REQUIRE_EQUAL(R.cols(), 3);
 	// leading 2x2 is the identity (the [I | C] structure after the descending sort)
-	BOOST_CHECK(R(0, 0) == mpfr_complex(1) && R(1, 1) == mpfr_complex(1));
-	BOOST_CHECK(R(0, 1) == mpfr_complex(0) && R(1, 0) == mpfr_complex(0));
+	BOOST_CHECK(R(0, 0) == complex_mp(1) && R(1, 1) == complex_mp(1));
+	BOOST_CHECK(R(0, 1) == complex_mp(0) && R(1, 0) == complex_mp(0));
 }
 
 BOOST_AUTO_TEST_CASE(underdetermined_throws)
@@ -247,18 +247,18 @@ BOOST_AUTO_TEST_CASE(user_supplied_matrix_reproduces_combination)
 	System s = OverdeterminedSingleGroup();    // f0=x^2+y^2-1, f1=x-y, f2=2x^2-1 (order preserved)
 
 	// g0 = 1*f0 + 0*f1 + 0*f2 ; g1 = 3*f0 + 0*f1 + 5*f2  (kept in author order: f0 has max degree)
-	Mat<mpfr_complex> R(2, 3);
-	R << mpfr_complex(1), mpfr_complex(0), mpfr_complex(0),
-	     mpfr_complex(3), mpfr_complex(0), mpfr_complex(5);
+	Mat<complex_mp> R(2, 3);
+	R << complex_mp(1), complex_mp(0), complex_mp(0),
+	     complex_mp(3), complex_mp(0), complex_mp(5);
 	System r = s.Randomize(R);
 
 	BOOST_CHECK_EQUAL(r.NumNaturalFunctions(), 2u);
 
 	// at (x,y) = (2,3):  f0 = 4+9-1 = 12, f2 = 8-1 = 7.  g0 = 12, g1 = 3*12 + 5*7 = 71.
-	Vec<dbl> p(2); p << dbl(2), dbl(3);
-	Vec<dbl> g = r.Eval(p);
-	BOOST_CHECK(std::abs(g(0) - dbl(12)) < 1e-10);
-	BOOST_CHECK(std::abs(g(1) - dbl(71)) < 1e-10);
+	Vec<complex_dbl> p(2); p << complex_dbl(2), complex_dbl(3);
+	Vec<complex_dbl> g = r.Eval(p);
+	BOOST_CHECK(std::abs(g(0) - complex_dbl(12)) < 1e-10);
+	BOOST_CHECK(std::abs(g(1) - complex_dbl(71)) < 1e-10);
 
 	// and it agrees with its own expansion, affine and homogenized
 	AgreesWithExpansion(r);
@@ -270,8 +270,8 @@ BOOST_AUTO_TEST_CASE(user_supplied_matrix_wrong_columns_throws)
 {
 	DefaultPrecision(30);
 	System s = OverdeterminedSingleGroup();   // 3 natural functions
-	Mat<mpfr_complex> R(2, 2);                // 2 columns != 3
-	R << mpfr_complex(1), mpfr_complex(0), mpfr_complex(0), mpfr_complex(1);
+	Mat<complex_mp> R(2, 2);                // 2 columns != 3
+	R << complex_mp(1), complex_mp(0), complex_mp(0), complex_mp(1);
 	BOOST_CHECK_THROW(s.Randomize(R), std::runtime_error);
 }
 
@@ -288,20 +288,20 @@ BOOST_AUTO_TEST_CASE(eval_and_jacobian_fully_define_rows_in_a_dirty_buffer)
 	const Eigen::Index n  = static_cast<Eigen::Index>(r.NumNaturalFunctions());
 	const Eigen::Index nv = static_cast<Eigen::Index>(r.NumVariables());
 
-	Vec<dbl> p(nv);
-	for (Eigen::Index k = 0; k < nv; ++k) p(k) = dbl(0.4 + 0.1 * static_cast<double>(k), 0.2 - 0.05 * static_cast<double>(k));
+	Vec<complex_dbl> p(nv);
+	for (Eigen::Index k = 0; k < nv; ++k) p(k) = complex_dbl(0.4 + 0.1 * static_cast<double>(k), 0.2 - 0.05 * static_cast<double>(k));
 
 	// poison the output buffers with a huge value; the block must overwrite every owned entry.
-	Vec<dbl> seg(n);   seg.setConstant(dbl(1e300, 1e300));
-	Mat<dbl> jac(n, nv); jac.setConstant(dbl(1e300, 1e300));
+	Vec<complex_dbl> seg(n);   seg.setConstant(complex_dbl(1e300, 1e300));
+	Mat<complex_dbl> jac(n, nv); jac.setConstant(complex_dbl(1e300, 1e300));
 
-	block.EvalInPlace<dbl>(seg, p, dbl(0));
-	block.JacobianInPlace<dbl>(jac, p, dbl(0));
+	block.EvalInPlace<complex_dbl>(seg, p, complex_dbl(0));
+	block.JacobianInPlace<complex_dbl>(jac, p, complex_dbl(0));
 
 	// reference: the function-tree expansion of just the block's rows
 	System twin = r.ExpandToFunctionTree();
-	Vec<dbl> seg_ref = twin.Eval(p);
-	Mat<dbl> jac_ref = twin.Jacobian(p);
+	Vec<complex_dbl> seg_ref = twin.Eval(p);
+	Mat<complex_dbl> jac_ref = twin.Jacobian(p);
 
 	for (Eigen::Index i = 0; i < n; ++i)
 		BOOST_CHECK(std::abs(seg(i) - seg_ref(i)) < 1e-10);
@@ -323,9 +323,9 @@ BOOST_AUTO_TEST_CASE(metadata)
 	BOOST_CHECK(!block.HasConstantJacobian());
 
 	// time-derivative is identically zero
-	Vec<dbl> p(2); p << dbl(1), dbl(1);
-	Vec<dbl> dt(2); dt.setConstant(dbl(7));
-	block.TimeDerivInPlace<dbl>(dt, p, dbl(0));
+	Vec<complex_dbl> p(2); p << complex_dbl(1), complex_dbl(1);
+	Vec<complex_dbl> dt(2); dt.setConstant(complex_dbl(7));
+	block.TimeDerivInPlace<complex_dbl>(dt, p, complex_dbl(0));
 	BOOST_CHECK(std::abs(dt(0)) < 1e-14 && std::abs(dt(1)) < 1e-14);
 }
 

--- a/core/test/classes/slice_test.cpp
+++ b/core/test/classes/slice_test.cpp
@@ -95,9 +95,9 @@ static Slice MakeKnownSlice()
 	Var x = Variable::Make("x"), y = Variable::Make("y");
 	VariableGroup vars{x,y};
 
-	Mat<mpfr_complex> M(2,3);
-	M << mpfr_complex(2), mpfr_complex(3),  mpfr_complex(1),
-	     mpfr_complex(1), mpfr_complex(-1), mpfr_complex(4);
+	Mat<complex_mp> M(2,3);
+	M << complex_mp(2), complex_mp(3),  complex_mp(1),
+	     complex_mp(1), complex_mp(-1), complex_mp(4);
 
 	return Slice::FromCoefficients(vars, M);
 }
@@ -111,7 +111,7 @@ BOOST_AUTO_TEST_CASE(from_coefficients_eval)
 	BOOST_CHECK_EQUAL(s.Dimension(),2);
 	BOOST_CHECK_EQUAL(s.NumVariables(),2);
 
-	Vec<dbl> p(2); p << dbl(1), dbl(1);
+	Vec<complex_dbl> p(2); p << complex_dbl(1), complex_dbl(1);
 	auto v = s.Eval(p);
 
 	BOOST_CHECK_EQUAL(v.size(),2);
@@ -127,7 +127,7 @@ BOOST_AUTO_TEST_CASE(jacobian_is_variable_coefficient_block)
 	DefaultPrecision(30);
 	auto s = MakeKnownSlice();
 
-	Vec<dbl> p(2); p << dbl(1), dbl(1);
+	Vec<complex_dbl> p(2); p << complex_dbl(1), complex_dbl(1);
 	auto J = s.Jacobian(p);
 
 	BOOST_CHECK_EQUAL(J.rows(),2);
@@ -151,16 +151,16 @@ BOOST_AUTO_TEST_CASE(head_tail_rows_subsetting)
 	BOOST_CHECK_EQUAL(h.Dimension(),2);
 	BOOST_CHECK_EQUAL(h.NumVariables(),3);
 	// the head's forms are exactly the slice's first two forms.
-	BOOST_CHECK((h.Coefficients() - s.Coefficients().topRows(2)).norm() < mpfr_float("1e-30"));
+	BOOST_CHECK((h.Coefficients() - s.Coefficients().topRows(2)).norm() < real_mp("1e-30"));
 
 	auto t = s.Tail(1);
 	BOOST_CHECK_EQUAL(t.Dimension(),1);
-	BOOST_CHECK((t.Coefficients() - s.Coefficients().bottomRows(1)).norm() < mpfr_float("1e-30"));
+	BOOST_CHECK((t.Coefficients() - s.Coefficients().bottomRows(1)).norm() < real_mp("1e-30"));
 
 	auto r = s.Rows(std::vector<unsigned>{0,3});
 	BOOST_CHECK_EQUAL(r.Dimension(),2);
-	BOOST_CHECK((r.Coefficients().row(0) - s.Coefficients().row(0)).norm() < mpfr_float("1e-30"));
-	BOOST_CHECK((r.Coefficients().row(1) - s.Coefficients().row(3)).norm() < mpfr_float("1e-30"));
+	BOOST_CHECK((r.Coefficients().row(0) - s.Coefficients().row(0)).norm() < real_mp("1e-30"));
+	BOOST_CHECK((r.Coefficients().row(1) - s.Coefficients().row(3)).norm() < real_mp("1e-30"));
 
 	BOOST_CHECK_THROW(s.Head(99), std::runtime_error);
 	BOOST_CHECK_THROW(s.Rows(std::vector<unsigned>{99}), std::runtime_error);
@@ -175,7 +175,7 @@ BOOST_AUTO_TEST_CASE(homogeneous_has_zero_constant_column)
 	auto s = Slice::RandomComplex(vars, 2, /*homogeneous=*/true);
 
 	BOOST_CHECK(s.IsHomogeneous());
-	BOOST_CHECK(s.Coefficients().rightCols(1).norm() < mpfr_float("1e-30"));
+	BOOST_CHECK(s.Coefficients().rightCols(1).norm() < real_mp("1e-30"));
 }
 
 
@@ -187,10 +187,10 @@ BOOST_AUTO_TEST_CASE(precision_roundtrip)
 	s.Precision(50);
 	BOOST_CHECK_EQUAL(s.Precision(),50u);
 
-	Vec<mpfr_complex> p(2); p << mpfr_complex(1), mpfr_complex(1);
+	Vec<complex_mp> p(2); p << complex_mp(1), complex_mp(1);
 	auto v = s.Eval(p);
-	BOOST_CHECK(abs(v(0) - mpfr_complex(6)) < mpfr_float("1e-25"));
-	BOOST_CHECK(abs(v(1) - mpfr_complex(4)) < mpfr_float("1e-25"));
+	BOOST_CHECK(abs(v(0) - complex_mp(6)) < real_mp("1e-25"));
+	BOOST_CHECK(abs(v(1) - complex_mp(4)) < real_mp("1e-25"));
 }
 
 
@@ -201,9 +201,9 @@ BOOST_AUTO_TEST_CASE(add_to_system_agrees_with_slice_eval)
 	Var x = Variable::Make("x"), y = Variable::Make("y");
 	VariableGroup vars{x,y};
 
-	Mat<mpfr_complex> M(2,3);
-	M << mpfr_complex(2), mpfr_complex(3),  mpfr_complex(1),
-	     mpfr_complex(1), mpfr_complex(-1), mpfr_complex(4);
+	Mat<complex_mp> M(2,3);
+	M << complex_mp(2), complex_mp(3),  complex_mp(1),
+	     complex_mp(1), complex_mp(-1), complex_mp(4);
 	auto s = Slice::FromCoefficients(vars, M);
 
 	System sys;
@@ -212,7 +212,7 @@ BOOST_AUTO_TEST_CASE(add_to_system_agrees_with_slice_eval)
 
 	BOOST_CHECK_EQUAL(sys.NumNaturalFunctions(), 2u);
 
-	Vec<dbl> p(2); p << dbl(1), dbl(1);
+	Vec<complex_dbl> p(2); p << complex_dbl(1), complex_dbl(1);
 	auto from_system = sys.Eval(p);
 	auto from_slice  = s.Eval(p);
 
@@ -237,7 +237,7 @@ BOOST_AUTO_TEST_CASE(add_to_homogenized_system_folds_constant_onto_hom_var)
 
 	// an affine slice (built on the two natural variables) added to the homogenized system: AddTo
 	// folds its constant onto the homogenizing variable, so the added form is homogeneous degree 1.
-	Mat<mpfr_complex> M(1,3); M << mpfr_complex(2), mpfr_complex(3), mpfr_complex(1); // 2x + 3y + 1
+	Mat<complex_mp> M(1,3); M << complex_mp(2), complex_mp(3), complex_mp(1); // 2x + 3y + 1
 	auto s = Slice::FromCoefficients(vars, M);
 	s.AddTo(sys);
 
@@ -245,7 +245,7 @@ BOOST_AUTO_TEST_CASE(add_to_homogenized_system_folds_constant_onto_hom_var)
 	BOOST_CHECK(sys.IsHomogeneous());   // the whole system, slice form included, is homogeneous
 
 	// the slice form is now a*x + b*y + c*h with c the old constant (1): vanishes at the origin.
-	Vec<dbl> origin(3); origin << dbl(0), dbl(0), dbl(0);
+	Vec<complex_dbl> origin(3); origin << complex_dbl(0), complex_dbl(0), complex_dbl(0);
 	auto v = sys.Eval(origin);
 	BOOST_CHECK_EQUAL(v.size(), 2);
 	BOOST_CHECK_SMALL(std::abs(v(1)), 1e-11);   // the homogeneous slice form is 0 at the origin
@@ -272,8 +272,8 @@ BOOST_AUTO_TEST_CASE(concatenate_stacks_forms)
 	Var x = Variable::Make("x"), y = Variable::Make("y");
 	VariableGroup vars{x,y};
 
-	Mat<mpfr_complex> A(1,3); A << mpfr_complex(2), mpfr_complex(3),  mpfr_complex(1);  // 2x + 3y + 1
-	Mat<mpfr_complex> B(1,3); B << mpfr_complex(1), mpfr_complex(-1), mpfr_complex(4);  // x - y + 4
+	Mat<complex_mp> A(1,3); A << complex_mp(2), complex_mp(3),  complex_mp(1);  // 2x + 3y + 1
+	Mat<complex_mp> B(1,3); B << complex_mp(1), complex_mp(-1), complex_mp(4);  // x - y + 4
 	auto sa = Slice::FromCoefficients(vars, A);
 	auto sb = Slice::FromCoefficients(vars, B);
 
@@ -281,7 +281,7 @@ BOOST_AUTO_TEST_CASE(concatenate_stacks_forms)
 	BOOST_CHECK_EQUAL(s.Dimension(), 2);
 	BOOST_CHECK_EQUAL(s.NumVariables(), 2);
 
-	Vec<dbl> p(2); p << dbl(1), dbl(1);
+	Vec<complex_dbl> p(2); p << complex_dbl(1), complex_dbl(1);
 	auto v = s.Eval(p);
 	BOOST_CHECK_CLOSE(v(0).real(), 6.0, 1e-11);
 	BOOST_CHECK_CLOSE(v(1).real(), 4.0, 1e-11);
@@ -302,7 +302,7 @@ BOOST_AUTO_TEST_CASE(as_system_evaluates_like_slice)
 	BOOST_CHECK_EQUAL(sys.NumNaturalFunctions(), 2);
 	BOOST_CHECK_EQUAL(sys.NumVariables(), 2);
 
-	Vec<dbl> p(2); p << dbl(1), dbl(1);
+	Vec<complex_dbl> p(2); p << complex_dbl(1), complex_dbl(1);
 	BOOST_CHECK_SMALL((sys.Eval(p) - s.Eval(p)).norm(), 1e-11);
 }
 
@@ -323,7 +323,7 @@ BOOST_AUTO_TEST_CASE(serialization_roundtrip)
 	BOOST_CHECK(!s2.IsHomogeneous());
 
 	// the deserialized slice evaluates exactly like the original.
-	Vec<dbl> p(2); p << dbl(1), dbl(1);
+	Vec<complex_dbl> p(2); p << complex_dbl(1), complex_dbl(1);
 	auto v = s2.Eval(p);
 	BOOST_CHECK_CLOSE(v(0).real(), 6.0, 1e-11);
 	BOOST_CHECK_CLOSE(v(1).real(), 4.0, 1e-11);

--- a/core/test/classes/slp_test.cpp
+++ b/core/test/classes/slp_test.cpp
@@ -13,7 +13,7 @@ using bertini::Operation;
 using SLP = bertini::StraightLineProgram;
 template<typename NumT> using Vec = bertini::Vec<NumT>;
 template<typename NumT> using Mat = bertini::Mat<NumT>;
-using dbl = bertini::dbl;
+using complex_dbl = bertini::complex_dbl;
 
 BOOST_AUTO_TEST_SUITE(SLP_tests)
 
@@ -129,16 +129,16 @@ BOOST_AUTO_TEST_CASE(evaluate_simple_system)
 
 	auto slp = SLP(sys);
 
-	Vec<dbl> values(1);
+	Vec<complex_dbl> values(1);
 
-	values(0) = dbl(2.0);
+	values(0) = complex_dbl(2.0);
 	
 
 	slp.Eval(values);
 
 
-	Vec<dbl> f = slp.GetFuncVals<dbl>();
-	bertini::Mat<dbl> J = slp.GetJacobian<dbl>();
+	Vec<complex_dbl> f = slp.GetFuncVals<complex_dbl>();
+	bertini::Mat<complex_dbl> J = slp.GetJacobian<complex_dbl>();
 
 	// x = 2, and the function is f=x+1
 	BOOST_CHECK_EQUAL(f(0), 3.);
@@ -167,22 +167,22 @@ BOOST_AUTO_TEST_CASE(evaluate_system2)
 	bertini::System sys = TwoVariableTestSystem();
 	auto slp = SLP(sys);
 
-	Vec<dbl> values(2);
+	Vec<complex_dbl> values(2);
 
-	values(0) = dbl(0.5); // x = 0.5
-	values(1) = dbl(0.1); // y = 0.1
+	values(0) = complex_dbl(0.5); // x = 0.5
+	values(1) = complex_dbl(0.1); // y = 0.1
 
 
 
 
 	slp.Eval(values);
-	Vec<dbl> f = slp.GetFuncVals<dbl>();
-	bertini::Mat<dbl> J = slp.GetJacobian<dbl>();
+	Vec<complex_dbl> f = slp.GetFuncVals<complex_dbl>();
+	bertini::Mat<complex_dbl> J = slp.GetJacobian<complex_dbl>();
 
 
 	// not returned yet -- point_d parVals, vec_d parDer,  mat_d Jp
 
-	dbl x{values(0)}, y{values(1)};
+	complex_dbl x{values(0)}, y{values(1)};
 
 	BOOST_CHECK_SMALL(abs(f(0) - (pow(x,2)+pow(y,2)-1.)),1e-15); // x^2+y^2-1
 	BOOST_CHECK_SMALL(abs(f(1) - (x-y)),1e-15);
@@ -201,10 +201,10 @@ BOOST_AUTO_TEST_CASE(evaluate_system2_inplace)
 	bertini::System sys = TwoVariableTestSystem();
 	auto slp = SLP(sys);
 
-	Vec<dbl> values(2);
+	Vec<complex_dbl> values(2);
 
-	values(0) = dbl(0.5); // x = 0.5
-	values(1) = dbl(0.1); // y = 0.1
+	values(0) = complex_dbl(0.5); // x = 0.5
+	values(1) = complex_dbl(0.1); // y = 0.1
 
 
 
@@ -212,17 +212,17 @@ BOOST_AUTO_TEST_CASE(evaluate_system2_inplace)
 	slp.Eval(values);
 
 
-	Vec<dbl> f(slp.NumFunctions());
-	slp.GetFuncValsInPlace<dbl>(f);
+	Vec<complex_dbl> f(slp.NumFunctions());
+	slp.GetFuncValsInPlace<complex_dbl>(f);
 
 
-	bertini::Mat<dbl> J(slp.NumFunctions(), slp.NumVariables());
-	slp.GetJacobianInPlace<dbl>(J);
+	bertini::Mat<complex_dbl> J(slp.NumFunctions(), slp.NumVariables());
+	slp.GetJacobianInPlace<complex_dbl>(J);
 
 
 	// not returned yet -- point_d parVals, vec_d parDer,  mat_d Jp
 
-	dbl x{values(0)}, y{values(1)};
+	complex_dbl x{values(0)}, y{values(1)};
 
 	BOOST_CHECK_SMALL(abs(f(0) - (pow(x,2)+pow(y,2)-1.)),1e-15); // x^2+y^2-1
 	BOOST_CHECK_SMALL(abs(f(1) - (x-y)),1e-15);
@@ -237,16 +237,16 @@ BOOST_AUTO_TEST_CASE(evaluate_system2_inplace)
 
 
 // BOOST_AUTO_TEST_CASE(evaluate){
-	// Vec<dbl> values(2);
+	// Vec<complex_dbl> values(2);
 
-	// values(0) = dbl(2.0);
-	// values(1) = dbl(3.0);
+	// values(0) = complex_dbl(2.0);
+	// values(1) = complex_dbl(3.0);
 
-	// Vec<dbl> v = sys.Eval(values);
+	// Vec<complex_dbl> v = sys.Eval(values);
 // 	auto J = sys.Jacobian(values);
 
-// 	dbl x1 = 2;
-// 	dbl x2 = 3;
+// 	complex_dbl x1 = 2;
+// 	complex_dbl x2 = 3;
 
 // 	BOOST_CHECK_EQUAL(J(0,0), 2*x1*x2*x2);
 // 	BOOST_CHECK_EQUAL(J(0,1), x1*x1*2*x2);
@@ -273,17 +273,17 @@ BOOST_AUTO_TEST_CASE(evaluate_three_variable_system)
 
 	auto slp = SLP(sys);
 
-	Vec<dbl> values(3);
+	Vec<complex_dbl> values(3);
 
-	values(0) = dbl(2.0);
-	values(1) = dbl(3.0);
-	values(2) = dbl(3.0);
+	values(0) = complex_dbl(2.0);
+	values(1) = complex_dbl(3.0);
+	values(2) = complex_dbl(3.0);
 
 
 	slp.Eval(values);
 
-	Vec<dbl> f = slp.GetFuncVals<dbl>();
-	bertini::Mat<dbl> J = slp.GetJacobian<dbl>();
+	Vec<complex_dbl> f = slp.GetFuncVals<complex_dbl>();
+	bertini::Mat<complex_dbl> J = slp.GetJacobian<complex_dbl>();
 
 
 	BOOST_CHECK_EQUAL(f(0), 3.); // f=x+1, x=2 ==> f=3
@@ -417,7 +417,7 @@ BOOST_AUTO_TEST_SUITE_END() // SLP_cse
 BOOST_AUTO_TEST_SUITE(SLP_freeze_partition)
 
 using bertini::node::Integer;
-using mpfr_complex = bertini::mpfr_complex;
+using complex_mp = bertini::complex_mp;
 
 namespace {
 	// f = x + sin(1): sin(1) is a constant unary operation -> a frozen instruction.
@@ -456,18 +456,18 @@ BOOST_AUTO_TEST_CASE(point_only_change_reuses_constants_correctly)
 
 	const double s1 = std::sin(1.0);
 
-	Vec<dbl> p(1);
-	p(0) = dbl(2.0);
+	Vec<complex_dbl> p(1);
+	p(0) = complex_dbl(2.0);
 	slp.Eval(p);
-	BOOST_CHECK_CLOSE(slp.GetFuncVals<dbl>()(0).real(), 2.0 + s1, 1e-10);
+	BOOST_CHECK_CLOSE(slp.GetFuncVals<complex_dbl>()(0).real(), 2.0 + s1, 1e-10);
 
-	p(0) = dbl(5.0); // point-only change: prologue skipped, sin(1) reused
+	p(0) = complex_dbl(5.0); // point-only change: prologue skipped, sin(1) reused
 	slp.Eval(p);
-	BOOST_CHECK_CLOSE(slp.GetFuncVals<dbl>()(0).real(), 5.0 + s1, 1e-10);
+	BOOST_CHECK_CLOSE(slp.GetFuncVals<complex_dbl>()(0).real(), 5.0 + s1, 1e-10);
 
-	p(0) = dbl(2.0); // back again
+	p(0) = complex_dbl(2.0); // back again
 	slp.Eval(p);
-	BOOST_CHECK_CLOSE(slp.GetFuncVals<dbl>()(0).real(), 2.0 + s1, 1e-10);
+	BOOST_CHECK_CLOSE(slp.GetFuncVals<complex_dbl>()(0).real(), 2.0 + s1, 1e-10);
 }
 
 // A precision change must invalidate the frozen prologue so the constant is recomputed at the
@@ -479,18 +479,18 @@ BOOST_AUTO_TEST_CASE(precision_change_recomputes_constants)
 
 	bertini::DefaultPrecision(30);
 	sys.precision(30);
-	Vec<mpfr_complex> p30(1);
-	p30(0) = mpfr_complex(2);
+	Vec<complex_mp> p30(1);
+	p30(0) = complex_mp(2);
 	auto f30 = sys.Eval(p30);
-	BOOST_CHECK(abs(f30(0) - (mpfr_complex(2) + sin(mpfr_complex(1)))) < 1e-25);
+	BOOST_CHECK(abs(f30(0) - (complex_mp(2) + sin(complex_mp(1)))) < 1e-25);
 
 	bertini::DefaultPrecision(50);
 	sys.precision(50);
-	Vec<mpfr_complex> p50(1);
-	p50(0) = mpfr_complex(2);
+	Vec<complex_mp> p50(1);
+	p50(0) = complex_mp(2);
 	auto f50 = sys.Eval(p50);
 	// sin(1) recomputed at 50 digits -> accurate well past 30 digits.
-	BOOST_CHECK(abs(f50(0) - (mpfr_complex(2) + sin(mpfr_complex(1)))) < 1e-40);
+	BOOST_CHECK(abs(f50(0) - (complex_mp(2) + sin(complex_mp(1)))) < 1e-40);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // SLP_freeze_partition

--- a/core/test/classes/start_system_test.cpp
+++ b/core/test/classes/start_system_test.cpp
@@ -47,10 +47,10 @@ using Var = std::shared_ptr<Variable>;
 using VariableGroup = bertini::VariableGroup;
 
 using mpq_rational = bertini::mpq_rational;
-using mpfr_float = bertini::mpfr_float;
+using real_mp = bertini::real_mp;
 using mpz_int = bertini::mpz_int;
-using dbl = bertini::dbl;
-using mpfr = bertini::mpfr_complex;
+using complex_dbl = bertini::complex_dbl;
+using mpfr = bertini::complex_mp;
 
 template<typename NumT> using Vec = bertini::Vec<NumT>;
 template<typename NumT> using Mat = bertini::Mat<NumT>;
@@ -137,7 +137,7 @@ BOOST_AUTO_TEST_CASE(make_total_degree_system_linear)
 
 	sys.AddVariableGroup(v);
 	sys.AddFunction(x + y - 1);
-	sys.AddFunction(x - mpfr_float("0.5")*y - 1);
+	sys.AddFunction(x - real_mp("0.5")*y - 1);
 
 
 	bertini::start_system::TotalDegree TD(sys);
@@ -169,7 +169,7 @@ BOOST_AUTO_TEST_CASE(make_total_degree_system_quadratic)
 
 	sys.AddVariableGroup(v);
 	sys.AddFunction(x*y + y - 1);
-	sys.AddFunction(x*x - mpfr_float("0.5")*y - x*y);
+	sys.AddFunction(x*x - real_mp("0.5")*y - x*y);
 
 
 	bertini::start_system::TotalDegree TD(sys);
@@ -218,13 +218,13 @@ BOOST_AUTO_TEST_CASE(linear_total_degree_start_system)
 
 	BOOST_CHECK_EQUAL(variable_ordering.size(), 2);
 
-	Vec<dbl> vals(2);
-	vals << dbl(1.0),dbl(1.0);
+	Vec<complex_dbl> vals(2);
+	vals << complex_dbl(1.0),complex_dbl(1.0);
 
 	auto sysvals = TD.Eval(vals);
 
 	for (unsigned ii = 0; ii < 2; ++ii)
-		BOOST_CHECK( abs(sysvals(ii) - (1.0 - TD.RandomValue<dbl>(ii))) < threshold_clearance_d);
+		BOOST_CHECK( abs(sysvals(ii) - (1.0 - TD.RandomValue<complex_dbl>(ii))) < threshold_clearance_d);
 
 
 
@@ -237,12 +237,12 @@ BOOST_AUTO_TEST_CASE(linear_total_degree_start_system)
 	BOOST_CHECK_EQUAL(J(1,1),1.0);
 
 
-	vals << dbl(0.0),dbl(0.0);
+	vals << complex_dbl(0.0),complex_dbl(0.0);
 
 	sysvals = TD.Eval(vals);
 
 	for (unsigned ii = 0; ii < 2; ++ii)
-		BOOST_CHECK(abs(sysvals(ii)+TD.RandomValue<dbl>(ii)) < threshold_clearance_d);
+		BOOST_CHECK(abs(sysvals(ii)+TD.RandomValue<complex_dbl>(ii)) < threshold_clearance_d);
 
 
 	J = TD.Jacobian(vals);
@@ -272,7 +272,7 @@ BOOST_AUTO_TEST_CASE(quadratic_cubic_quartic_total_degree_start_system)
 	vars.push_back(x); vars.push_back(y); vars.push_back(z);
 
 	sys.AddVariableGroup(vars);
-	sys.AddFunction(y+x*y + mpfr_float("0.5"));
+	sys.AddFunction(y+x*y + real_mp("0.5"));
 	sys.AddFunction(pow(x,3)+x*y+bertini::node::E());
 	sys.AddFunction(pow(x,2)*pow(y,2)+x*y*z*z - 1);
 
@@ -288,13 +288,13 @@ BOOST_AUTO_TEST_CASE(quadratic_cubic_quartic_total_degree_start_system)
 		BOOST_CHECK_EQUAL(deg[2],4);
 	}
 
-	Vec<dbl> vals(3);
-	vals << dbl(1.0),dbl(1.0),dbl(1.0);
+	Vec<complex_dbl> vals(3);
+	vals << complex_dbl(1.0),complex_dbl(1.0),complex_dbl(1.0);
 
 	auto sysvals = TD.Eval(vals);
 
 	for (unsigned ii = 0; ii < 3; ++ii)
-		BOOST_CHECK( abs(sysvals(ii) - (1.0 - TD.RandomValue<dbl>(ii))) < threshold_clearance_d);
+		BOOST_CHECK( abs(sysvals(ii) - (1.0 - TD.RandomValue<complex_dbl>(ii))) < threshold_clearance_d);
 
 	auto J = TD.Jacobian(vals);
 
@@ -312,12 +312,12 @@ BOOST_AUTO_TEST_CASE(quadratic_cubic_quartic_total_degree_start_system)
 
 
 
-	vals << dbl(0.0),dbl(0.0),dbl(0.0);
+	vals << complex_dbl(0.0),complex_dbl(0.0),complex_dbl(0.0);
 
 	sysvals = TD.Eval(vals);
 
 	for (unsigned ii = 0; ii < 3; ++ii)
-		BOOST_CHECK(abs(sysvals(ii)+TD.RandomValue<dbl>(ii)) < threshold_clearance_d);
+		BOOST_CHECK(abs(sysvals(ii)+TD.RandomValue<complex_dbl>(ii)) < threshold_clearance_d);
 
 	J = TD.Jacobian(vals);
 
@@ -351,7 +351,7 @@ BOOST_AUTO_TEST_CASE(quadratic_cubic_quartic_start_points)
 	VariableGroup vars{x,y,z};
 
 	sys.AddVariableGroup(vars);
-	sys.AddFunction(y+x*y + mpfr_float("0.5"));
+	sys.AddFunction(y+x*y + real_mp("0.5"));
 	sys.AddFunction(pow(x,3)+x*y+bertini::node::E());
 	sys.AddFunction(pow(x,2)*pow(y,2)+x*y*z*z - 1);
 
@@ -359,14 +359,14 @@ BOOST_AUTO_TEST_CASE(quadratic_cubic_quartic_start_points)
 
 	for (decltype(TD.NumStartPoints()) ii = 0; ii < TD.NumStartPoints(); ++ii)
 	{
-		auto start = TD.StartPoint<dbl>(ii);
+		auto start = TD.StartPoint<complex_dbl>(ii);
 		auto function_values = TD.Eval(start);
 
 		const auto& vs = TD.RandomValues();
 
 		for (decltype(function_values.size()) jj = 0; jj < function_values.size(); ++jj)
 			BOOST_CHECK(abs(function_values(jj)) <
-				abs(vs[static_cast<size_t>(jj)]->Value<dbl>())*relaxed_threshold_clearance_d);
+				abs(vs[static_cast<size_t>(jj)]->Value<complex_dbl>())*relaxed_threshold_clearance_d);
 	}
 
 	for (decltype(TD.NumStartPoints()) ii = 0; ii < TD.NumStartPoints(); ++ii)
@@ -395,7 +395,7 @@ BOOST_AUTO_TEST_CASE(quadratic_cubic_quartic_start_points_homogenized_patched)
 	VariableGroup vars{x,y,z};
 
 	sys.AddVariableGroup(vars);
-	sys.AddFunction(y+x*y + mpfr_float("0.5"));
+	sys.AddFunction(y+x*y + real_mp("0.5"));
 	sys.AddFunction(pow(x,3)+x*y+bertini::node::E());
 	sys.AddFunction(pow(x,2)*pow(y,2)+x*y*z*z - 1);
 
@@ -416,7 +416,7 @@ BOOST_AUTO_TEST_CASE(quadratic_cubic_quartic_start_points_homogenized_patched)
 	const auto& vs = TD.RandomValues();
 	for (decltype(TD.NumStartPoints()) ii = 0; ii < TD.NumStartPoints(); ++ii)
 	{
-		auto start = TD.StartPoint<dbl>(ii);
+		auto start = TD.StartPoint<complex_dbl>(ii);
 		auto function_values = TD.Eval(start);
 
 		for (decltype(function_values.size()) jj = 0; jj < function_values.size(); ++jj)
@@ -426,7 +426,7 @@ BOOST_AUTO_TEST_CASE(quadratic_cubic_quartic_start_points_homogenized_patched)
 			// a fixed absolute threshold is scale-naive and flakes when a random r happens
 			// to be large.  Rows with jj >= vs.size() are patch/homogenization equations of
 			// O(1) scale, so a unit scale (absolute floor) is correct for them.
-			double scale = (static_cast<size_t>(jj) < vs.size()) ? abs(vs[static_cast<size_t>(jj)]->Value<dbl>()) : 1.0;
+			double scale = (static_cast<size_t>(jj) < vs.size()) ? abs(vs[static_cast<size_t>(jj)]->Value<complex_dbl>()) : 1.0;
 			if (scale < 1.0) scale = 1.0;
 			BOOST_CHECK(abs(function_values(jj)) < scale*1000*relaxed_threshold_clearance_d);
 		}
@@ -441,8 +441,8 @@ BOOST_AUTO_TEST_CASE(quadratic_cubic_quartic_start_points_homogenized_patched)
 		for (decltype(function_values.size()) jj = 0; jj < function_values.size(); ++jj)
 		{
 			// scale-relative, as in the double-precision loop above
-			mpfr_float scale = (static_cast<size_t>(jj) < vs.size()) ? abs(vs[static_cast<size_t>(jj)]->Value<mpfr>()) : mpfr_float(1);
-			if (scale < 1) scale = mpfr_float(1);
+			real_mp scale = (static_cast<size_t>(jj) < vs.size()) ? abs(vs[static_cast<size_t>(jj)]->Value<mpfr>()) : real_mp(1);
+			if (scale < 1) scale = real_mp(1);
 			BOOST_CHECK(abs(function_values(jj)) < scale*threshold_clearance_mp);
 		}
 	}
@@ -488,7 +488,7 @@ BOOST_AUTO_TEST_CASE(total_degree_start_system_precision_16)
 		DefaultPrecision(static_cast<unsigned int>(this_test_precision));
 		final_system.precision(static_cast<unsigned int>(this_test_precision));
 		TD.precision(static_cast<unsigned int>(this_test_precision));
-		auto start_point = TD.StartPoint<mpfr_complex>(ii);
+		auto start_point = TD.StartPoint<complex_mp>(ii);
 		BOOST_CHECK_EQUAL(bertini::Precision(start_point), this_test_precision);
 	}
 
@@ -537,7 +537,7 @@ BOOST_AUTO_TEST_CASE(total_degree_start_system_homogenized_patched_precision_16)
 		DefaultPrecision(static_cast<unsigned int>(this_test_precision));
 		final_system.precision(static_cast<unsigned int>(this_test_precision));
 		TD.precision(static_cast<unsigned int>(this_test_precision));
-		auto start_point = TD.StartPoint<mpfr_complex>(ii);
+		auto start_point = TD.StartPoint<complex_mp>(ii);
 		BOOST_CHECK_EQUAL(bertini::Precision(start_point), this_test_precision);
 	}
 
@@ -561,7 +561,7 @@ BOOST_AUTO_TEST_CASE(quadratic_cubic_quartic_all_the_way_to_final_system)
 	VariableGroup vars{x,y,z};
 
 	sys.AddVariableGroup(vars);
-	sys.AddFunction(y+x*y + mpfr_float("0.5"));
+	sys.AddFunction(y+x*y + real_mp("0.5"));
 	sys.AddFunction(pow(x,3)+x*y+bertini::node::E());
 	sys.AddFunction(pow(x,2)*pow(y,2)+x*y*z*z - 1);
 

--- a/core/test/classes/system_blocks_test.cpp
+++ b/core/test/classes/system_blocks_test.cpp
@@ -44,10 +44,10 @@ static System MakeBlockSystem()
 	Var x = node::Variable::Make("x"), y = node::Variable::Make("y");
 	sys.AddVariableGroup(VariableGroup{x, y});
 
-	bertini::Mat<mpfr_complex> f(2, 3);
-	f << mpfr_complex(2), mpfr_complex(3),  mpfr_complex(1),
-	     mpfr_complex(1), mpfr_complex(-1), mpfr_complex(4);
-	sys.AddBlock(ProductsOfLinearsBlock(2, std::vector<bertini::Mat<mpfr_complex>>{f}));
+	bertini::Mat<complex_mp> f(2, 3);
+	f << complex_mp(2), complex_mp(3),  complex_mp(1),
+	     complex_mp(1), complex_mp(-1), complex_mp(4);
+	sys.AddBlock(ProductsOfLinearsBlock(2, std::vector<bertini::Mat<complex_mp>>{f}));
 	return sys;
 }
 
@@ -66,7 +66,7 @@ BOOST_AUTO_TEST_CASE(eval_double)
 	DefaultPrecision(30);
 	auto sys = MakeBlockSystem();
 
-	bertini::Vec<dbl> x(2); x << dbl(1), dbl(1);
+	bertini::Vec<complex_dbl> x(2); x << complex_dbl(1), complex_dbl(1);
 	auto v = sys.Eval(x);
 
 	BOOST_CHECK_EQUAL(v.size(), 1);
@@ -79,9 +79,9 @@ BOOST_AUTO_TEST_CASE(jacobian_double)
 	DefaultPrecision(30);
 	auto sys = MakeBlockSystem();
 
-	bertini::Vec<dbl> x(2); x << dbl(1), dbl(1);
+	bertini::Vec<complex_dbl> x(2); x << complex_dbl(1), complex_dbl(1);
 	sys.Eval(x);                       // sets the current variable values
-	auto J = sys.Jacobian<dbl>();      // uses the current variable values
+	auto J = sys.Jacobian<complex_dbl>();      // uses the current variable values
 
 	BOOST_CHECK_EQUAL(J.rows(), 1);
 	BOOST_CHECK_EQUAL(J.cols(), 2);
@@ -95,10 +95,10 @@ BOOST_AUTO_TEST_CASE(eval_mpfr)
 	auto sys = MakeBlockSystem();
 	sys.precision(30);                 // propagate precision to variables and blocks
 
-	bertini::Vec<mpfr_complex> x(2); x << mpfr_complex(1), mpfr_complex(1);
+	bertini::Vec<complex_mp> x(2); x << complex_mp(1), complex_mp(1);
 	auto v = sys.Eval(x);
 
-	BOOST_CHECK(abs(v(0) - mpfr_complex(24)) < mpfr_float("1e-25"));
+	BOOST_CHECK(abs(v(0) - complex_mp(24)) < real_mp("1e-25"));
 }
 
 // round-trip a System through a boost text archive, returning the deserialized copy.
@@ -121,7 +121,7 @@ BOOST_AUTO_TEST_CASE(serialize_products_of_linears_block)
 {
 	DefaultPrecision(30);
 	auto sys = MakeBlockSystem();
-	bertini::Vec<dbl> x(2); x << dbl(1), dbl(1);
+	bertini::Vec<complex_dbl> x(2); x << complex_dbl(1), complex_dbl(1);
 	auto before = sys.Eval(x);
 
 	auto sys2 = RoundTrip(sys);
@@ -139,12 +139,12 @@ BOOST_AUTO_TEST_CASE(serialize_linear_forms_block)
 	Var x = node::Variable::Make("x"), y = node::Variable::Make("y");
 	sys.AddVariableGroup(VariableGroup{x, y});
 	// f0 = 2x + 3y + 1, f1 = x - y + 4   (augmented rows)
-	bertini::Mat<mpfr_complex> M(2, 3);
-	M << mpfr_complex(2), mpfr_complex(3),  mpfr_complex(1),
-	     mpfr_complex(1), mpfr_complex(-1), mpfr_complex(4);
+	bertini::Mat<complex_mp> M(2, 3);
+	M << complex_mp(2), complex_mp(3),  complex_mp(1),
+	     complex_mp(1), complex_mp(-1), complex_mp(4);
 	sys.AddBlock(LinearFormsBlock(2, M));
 
-	bertini::Vec<dbl> p(2); p << dbl(1), dbl(1);
+	bertini::Vec<complex_dbl> p(2); p << complex_dbl(1), complex_dbl(1);
 	auto before = sys.Eval(p);          // [6, 4]
 
 	auto sys2 = RoundTrip(sys);
@@ -178,12 +178,12 @@ BOOST_AUTO_TEST_CASE(serialize_blend_block)
 	std::vector<std::shared_ptr<const System>> operands{ target, start };
 	H.AddBlock(BlendBlock<System>(t, std::move(coeffs), std::move(operands)));
 
-	bertini::Vec<dbl> p(1); p << dbl(1);
-	auto before = H.Eval(p, dbl(0));        // x - 2 - 0 = -1
+	bertini::Vec<complex_dbl> p(1); p << complex_dbl(1);
+	auto before = H.Eval(p, complex_dbl(0));        // x - 2 - 0 = -1
 
 	auto H2 = RoundTrip(H);
 	BOOST_REQUIRE(H2.HasBlocks());
-	auto after = H2.Eval(p, dbl(0));
+	auto after = H2.Eval(p, complex_dbl(0));
 
 	BOOST_REQUIRE_EQUAL(after.size(), 1);
 	BOOST_CHECK_CLOSE(after(0).real(), before(0).real(), 1e-9);  // -1

--- a/core/test/classes/system_printing_test.cpp
+++ b/core/test/classes/system_printing_test.cpp
@@ -89,7 +89,7 @@ BOOST_AUTO_TEST_CASE(linear_forms_placeholder_vs_actual)
 	auto x = Variable::Make("x"), y = Variable::Make("y");
 	System m; m.AddVariableGroup(VariableGroup{x, y});
 	m.AddFunction(x*x + y*y - node::Integer::Make(1));        // row 0: polynomial
-	Mat<mpfr_complex> M(1, 3); M << mpfr_complex(2), mpfr_complex(1), mpfr_complex(-1);
+	Mat<complex_mp> M(1, 3); M << complex_mp(2), complex_mp(1), complex_mp(-1);
 	m.AddBlock(blocks::LinearFormsBlock(2, M));               // row 1: 2x + y - 1
 
 	std::string t = Terse(m);
@@ -107,7 +107,7 @@ BOOST_AUTO_TEST_CASE(moving_homotopy_blend)
 	System fixed; fixed.AddVariableGroup(VariableGroup{x, y}); fixed.AddFunction(x*x + y*y - node::Integer::Make(1));
 	System sm; sm.AddVariableGroup(VariableGroup{x, y}); sm.AddFunction(y);
 	System em; em.AddVariableGroup(VariableGroup{x, y}); em.AddFunction(y - x);
-	System H = MakeMovingHomotopy(fixed, sm, em, "t", node::Complex::Make(mpfr_complex("0.6", "0.8")));
+	System H = MakeMovingHomotopy(fixed, sm, em, "t", node::Complex::Make(complex_mp("0.6", "0.8")));
 
 	std::string t = Terse(H);
 	BOOST_CHECK(Has(t, "f_0 = "));               // the fixed polynomial row

--- a/core/test/classes/system_test.cpp
+++ b/core/test/classes/system_test.cpp
@@ -53,7 +53,7 @@ BOOST_AUTO_TEST_SUITE(system_class)
 
 using Var = std::shared_ptr<bertini::node::Variable>;
 
-using mpfr = bertini::mpfr_complex;
+using mpfr = bertini::complex_mp;
 
 using namespace bertini;
 /**
@@ -99,11 +99,11 @@ BOOST_AUTO_TEST_CASE(parsed_system_has_functions_and_evaluates)
 	BOOST_CHECK(ok);
 	BOOST_CHECK_EQUAL(sys.NumNaturalFunctions(), 2u);
 
-	Vec<dbl> pt(2); pt << dbl(2,0), dbl(3,0);
+	Vec<complex_dbl> pt(2); pt << complex_dbl(2,0), complex_dbl(3,0);
 	auto v = sys.Eval(pt);
 	BOOST_REQUIRE_EQUAL(v.size(), 2);
-	BOOST_CHECK_SMALL(std::abs(v(0) - dbl(6,0)), 1e-12);   // x*y at (2,3)
-	BOOST_CHECK_SMALL(std::abs(v(1) - dbl(5,0)), 1e-12);   // x+y at (2,3)
+	BOOST_CHECK_SMALL(std::abs(v(0) - complex_dbl(6,0)), 1e-12);   // x*y at (2,3)
+	BOOST_CHECK_SMALL(std::abs(v(1) - complex_dbl(5,0)), 1e-12);   // x+y at (2,3)
 }
 
 
@@ -123,10 +123,10 @@ BOOST_AUTO_TEST_CASE(parsed_subfunction_is_a_named_expression)
 	BOOST_CHECK_EQUAL(sys.NumNaturalFunctions(), 1u);
 
 	// f = s + x = x*y + x; at (2,3) -> 6 + 2 = 8
-	Vec<dbl> pt(2); pt << dbl(2,0), dbl(3,0);
+	Vec<complex_dbl> pt(2); pt << complex_dbl(2,0), complex_dbl(3,0);
 	auto v = sys.Eval(pt);
 	BOOST_REQUIRE_EQUAL(v.size(), 1);
-	BOOST_CHECK_SMALL(std::abs(v(0) - dbl(8,0)), 1e-12);
+	BOOST_CHECK_SMALL(std::abs(v(0) - complex_dbl(8,0)), 1e-12);
 
 	std::stringstream ss; ss << sys;
 	const std::string text = ss.str();
@@ -243,7 +243,7 @@ BOOST_AUTO_TEST_CASE(system_differentiate_x)
 	S.AddFunction(f1);
 	S.AddFunction(f2);
 
-	Vec<dbl> v(1);
+	Vec<complex_dbl> v(1);
 	v << 1.0;
 
 	auto J = S.Jacobian(v);
@@ -270,12 +270,12 @@ BOOST_AUTO_TEST_CASE(system_differentiate_x_and_y)
 	S.AddFunction(f1);
 	S.AddFunction(f2);
 
-	Vec<dbl> v(2);
+	Vec<complex_dbl> v(2);
 	v << 1.0 , 2.0;
 
 	auto J = S.Jacobian(v);
 
-	BOOST_CHECK_THROW(S.Jacobian(v,dbl(0.5)), std::runtime_error);
+	BOOST_CHECK_THROW(S.Jacobian(v,complex_dbl(0.5)), std::runtime_error);
 }
 
 
@@ -296,10 +296,10 @@ BOOST_AUTO_TEST_CASE(system_differentiate_x_and_t)
 	S.AddFunction(f1);
 	S.AddFunction(f2);
 
-	Vec<dbl> v(1);
+	Vec<complex_dbl> v(1);
 	v << 1.0;
-	dbl time(0.5,0.2);
-	bertini::Mat<dbl> J = S.Jacobian(v,time);
+	complex_dbl time(0.5,0.2);
+	bertini::Mat<complex_dbl> J = S.Jacobian(v,time);
 
 	BOOST_CHECK_THROW(S.Jacobian(v), std::runtime_error);
 }
@@ -443,12 +443,12 @@ BOOST_AUTO_TEST_CASE(system_evaluate_double)
 	bertini::System sys;
 	[[maybe_unused]] bool s = bertini::parsing::classic::parse(str.begin(), str.end(), sys);
 
-	Vec<dbl> values(2);
+	Vec<complex_dbl> values(2);
 
-	values(0) = dbl(2.0);
-	values(1) = dbl(3.0);
+	values(0) = complex_dbl(2.0);
+	values(1) = complex_dbl(3.0);
 
-	Vec<dbl> v = sys.Eval(values);
+	Vec<complex_dbl> v = sys.Eval(values);
 
 	BOOST_CHECK_EQUAL(v(0), 36.0);
 
@@ -504,9 +504,9 @@ BOOST_AUTO_TEST_CASE(system_jacobian)
 
 	// Modest magnitudes keep the high-degree SLP-vs-analytic rounding comfortably inside the
 	// 1e-15 tolerance below.
-	dbl a(0.5,  0.25);
-	dbl b(0.4, -0.30);
-	dbl c(0.6,  0.20);
+	complex_dbl a(0.5,  0.25);
+	complex_dbl b(0.4, -0.30);
+	complex_dbl c(0.6,  0.20);
 
 	System sys;
 
@@ -515,7 +515,7 @@ BOOST_AUTO_TEST_CASE(system_jacobian)
 	sys.AddFunction(pow(x,2)*pow(y,3)*pow(z,4) + 1);
 	sys.AddFunction(pow(x,3)*pow(y,4)*pow(z,5) + 4);
 
-	Vec<dbl> v(3);
+	Vec<complex_dbl> v(3);
 	v << a, b, c;
 
 	auto J = sys.Jacobian(v);
@@ -564,9 +564,9 @@ BOOST_AUTO_TEST_CASE(add_two_systems)
 	sys1+=sys2;
 
 
-	Vec<dbl> values(2);
+	Vec<complex_dbl> values(2);
 
-	values << dbl(2.0), dbl(3.0);
+	values << complex_dbl(2.0), complex_dbl(3.0);
 
 	auto v = sys1.Eval(values);
 
@@ -591,7 +591,7 @@ BOOST_AUTO_TEST_CASE(add_two_systems)
 \test \b add_two_systems_evaluated_in_mpfr Sibling of add_two_systems, but
 exercises the Vec<mpfr> evaluation path. This is the C++ analog of the
 Python test_add_systems that surfaced the macos-15-intel SIGABRT — the C++
-suite previously only covered the Vec<dbl> path.
+suite previously only covered the Vec<complex_dbl> path.
 */
 BOOST_AUTO_TEST_CASE(add_two_systems_evaluated_in_mpfr)
 {
@@ -642,8 +642,8 @@ BOOST_AUTO_TEST_CASE(add_system_to_self_doubles_under_function_tree_eval)
 	sys.AddFunction(y+1);
 	sys.AddFunction(x*y);
 
-	Vec<dbl> values(2);
-	values << dbl(2.0), dbl(3.0);
+	Vec<complex_dbl> values(2);
+	values << complex_dbl(2.0), complex_dbl(3.0);
 	auto before = sys.Eval(values);   // [4, 6]
 
 	sys += sys;                       // self-add
@@ -674,15 +674,15 @@ BOOST_AUTO_TEST_CASE(operator_plus_equals_invalidates_slp_cache)
 	sys.AddFunction(y+1);
 	sys.AddFunction(x*y);
 
-	Vec<dbl> values(2);
-	values << dbl(2.0), dbl(3.0);
+	Vec<complex_dbl> values(2);
+	values << complex_dbl(2.0), complex_dbl(3.0);
 	(void) sys.Eval(values);          // primes the SLP cache: [y+1, x*y]
 
 	sys += sys;                       // mutates tree to [2(y+1), 2xy] but cache stale
 
 	auto after = sys.Eval(values);    // expected [8, 12], currently [4, 6]
-	BOOST_CHECK_EQUAL(after(0), dbl(8.0));
-	BOOST_CHECK_EQUAL(after(1), dbl(12.0));
+	BOOST_CHECK_EQUAL(after(0), complex_dbl(8.0));
+	BOOST_CHECK_EQUAL(after(1), complex_dbl(12.0));
 }
 
 
@@ -705,14 +705,14 @@ BOOST_AUTO_TEST_CASE(operator_mult_equals_invalidates_slp_cache)
 	sys.AddVariableGroup(vars);
 	sys.AddFunction(x+y);
 
-	Vec<dbl> values(2);
-	values << dbl(1.0), dbl(2.0);
+	Vec<complex_dbl> values(2);
+	values << complex_dbl(1.0), complex_dbl(2.0);
 	(void) sys.Eval(values);          // primes SLP for f = x+y
 
 	sys *= Complex::Make("3.0");        // f should now be 3*(x+y)
 
 	auto after = sys.Eval(values);    // expected [9], currently [3]
-	BOOST_CHECK_EQUAL(after(0), dbl(9.0));
+	BOOST_CHECK_EQUAL(after(0), complex_dbl(9.0));
 }
 
 
@@ -735,15 +735,15 @@ BOOST_AUTO_TEST_CASE(reorder_functions_decreasing_invalidates_slp_cache)
 	sys.AddFunction(x+y);             // degree 1, initially at position 0
 	sys.AddFunction(x*y);             // degree 2, initially at position 1
 
-	Vec<dbl> values(2);
-	values << dbl(2.0), dbl(3.0);
+	Vec<complex_dbl> values(2);
+	values << complex_dbl(2.0), complex_dbl(3.0);
 	(void) sys.Eval(values);          // primes SLP with the [degree1, degree2] order
 
 	sys.ReorderFunctionsByDegreeDecreasing();   // now [degree2, degree1] = [x*y, x+y]
 
 	auto after = sys.Eval(values);
-	BOOST_CHECK_EQUAL(after(0), dbl(6.0));      // x*y at position 0
-	BOOST_CHECK_EQUAL(after(1), dbl(5.0));      // x+y at position 1
+	BOOST_CHECK_EQUAL(after(0), complex_dbl(6.0));      // x*y at position 0
+	BOOST_CHECK_EQUAL(after(1), complex_dbl(5.0));      // x+y at position 1
 }
 
 
@@ -765,15 +765,15 @@ BOOST_AUTO_TEST_CASE(reorder_functions_increasing_invalidates_slp_cache)
 	sys.AddFunction(x*y);             // degree 2, initially at position 0
 	sys.AddFunction(x+y);             // degree 1, initially at position 1
 
-	Vec<dbl> values(2);
-	values << dbl(2.0), dbl(3.0);
+	Vec<complex_dbl> values(2);
+	values << complex_dbl(2.0), complex_dbl(3.0);
 	(void) sys.Eval(values);          // primes SLP with the [degree2, degree1] order
 
 	sys.ReorderFunctionsByDegreeIncreasing();   // now [degree1, degree2] = [x+y, x*y]
 
 	auto after = sys.Eval(values);
-	BOOST_CHECK_EQUAL(after(0), dbl(5.0));      // x+y at position 0
-	BOOST_CHECK_EQUAL(after(1), dbl(6.0));      // x*y at position 1
+	BOOST_CHECK_EQUAL(after(0), complex_dbl(5.0));      // x+y at position 0
+	BOOST_CHECK_EQUAL(after(1), complex_dbl(6.0));      // x*y at position 1
 }
 
 
@@ -794,12 +794,12 @@ BOOST_AUTO_TEST_CASE(eval_wrong_size_input_throws)
 	sys.AddVariableGroup(vars);
 	sys.AddFunction(x+y);
 
-	Vec<dbl> too_small(1);
-	too_small << dbl(1.0);
+	Vec<complex_dbl> too_small(1);
+	too_small << complex_dbl(1.0);
 	BOOST_CHECK_THROW(sys.Eval(too_small), std::runtime_error);
 
-	Vec<dbl> too_big(3);
-	too_big << dbl(1.0), dbl(2.0), dbl(3.0);
+	Vec<complex_dbl> too_big(3);
+	too_big << complex_dbl(1.0), complex_dbl(2.0), complex_dbl(3.0);
 	BOOST_CHECK_THROW(sys.Eval(too_big), std::runtime_error);
 }
 
@@ -827,21 +827,21 @@ BOOST_AUTO_TEST_CASE(add_systems_chain)
 
 	sys1 += sys2 += sys3;      // sys2 becomes sys2+sys3; sys1 becomes sys1+sys2+sys3
 
-	Vec<dbl> v(2);
-	v << dbl(2.0), dbl(3.0);
+	Vec<complex_dbl> v(2);
+	v << complex_dbl(2.0), complex_dbl(3.0);
 
 	// sys1 originally: [x, y] = [2, 3]
 	// sys2 originally: [y, x] = [3, 2]
 	// sys3 originally: [xy, x+y] = [6, 5]
 	// sys1 final:      [2+3+6, 3+2+5] = [11, 10]
 	auto v1 = sys1.Eval(v);
-	BOOST_CHECK_EQUAL(v1(0), dbl(11.0));
-	BOOST_CHECK_EQUAL(v1(1), dbl(10.0));
+	BOOST_CHECK_EQUAL(v1(0), complex_dbl(11.0));
+	BOOST_CHECK_EQUAL(v1(1), complex_dbl(10.0));
 
 	// sys2 final:      [3+6, 2+5] = [9, 7]
 	auto v2 = sys2.Eval(v);
-	BOOST_CHECK_EQUAL(v2(0), dbl(9.0));
-	BOOST_CHECK_EQUAL(v2(1), dbl(7.0));
+	BOOST_CHECK_EQUAL(v2(0), complex_dbl(9.0));
+	BOOST_CHECK_EQUAL(v2(1), complex_dbl(7.0));
 }
 
 
@@ -903,13 +903,13 @@ BOOST_AUTO_TEST_CASE(system_differentiate_wrt_time_linear)
 	S.AddFunction(f1);
 	S.AddFunction(f2);
 
-	Vec<dbl> v(1);
+	Vec<complex_dbl> v(1);
 	v << 1.0;
-	dbl time(0.5,0.2);
+	complex_dbl time(0.5,0.2);
 	auto dS_dt = S.TimeDerivative(v,time);
 
-	BOOST_CHECK_CLOSE( dS_dt(0).real(), dbl(-1).real(), threshold_clearance_d);
-	BOOST_CHECK_CLOSE( dS_dt(1).imag(), dbl(-1).imag(), threshold_clearance_d);
+	BOOST_CHECK_CLOSE( dS_dt(0).real(), complex_dbl(-1).real(), threshold_clearance_d);
+	BOOST_CHECK_CLOSE( dS_dt(1).imag(), complex_dbl(-1).imag(), threshold_clearance_d);
 
 
 }
@@ -931,8 +931,8 @@ BOOST_AUTO_TEST_CASE(system_dehomogenize_FIFO_one_aff_group)
 
 	sys.Homogenize();
 
-	Vec<dbl> v(3);
-	v << dbl(2,3), dbl(3,4), dbl(4,5);
+	Vec<complex_dbl> v(3);
+	v << complex_dbl(2,3), complex_dbl(3,4), complex_dbl(4,5);
 
 	auto d = sys.DehomogenizePoint(v);
 
@@ -959,9 +959,9 @@ BOOST_AUTO_TEST_CASE(system_dehomogenize_FIFO_two_aff_groups)
 
 	sys.Homogenize();
 
-	Vec<dbl> v(6);
-	v << dbl(2,3), dbl(3,4), dbl(4,5), 
-		 dbl(5,6), dbl(6,7), dbl(7,8);
+	Vec<complex_dbl> v(6);
+	v << complex_dbl(2,3), complex_dbl(3,4), complex_dbl(4,5), 
+		 complex_dbl(5,6), complex_dbl(6,7), complex_dbl(7,8);
 
 	auto d = sys.DehomogenizePoint(v);
 
@@ -996,10 +996,10 @@ BOOST_AUTO_TEST_CASE(system_dehomogenize_FIFO_two_aff_groups_one_hom_group)
 
 	sys.Homogenize();
 
-	Vec<dbl> v(8);
-	v << dbl(2,3), dbl(3,4), dbl(4,5), 
-		 dbl(10,11), dbl(11,12),
-		 dbl(5,6), dbl(6,7), dbl(7,8);
+	Vec<complex_dbl> v(8);
+	v << complex_dbl(2,3), complex_dbl(3,4), complex_dbl(4,5), 
+		 complex_dbl(10,11), complex_dbl(11,12),
+		 complex_dbl(5,6), complex_dbl(6,7), complex_dbl(7,8);
 
 	auto d = sys.DehomogenizePoint(v);
 
@@ -1031,8 +1031,8 @@ BOOST_AUTO_TEST_CASE(system_dehomogenize_FIFO_one_hom_group)
 
 	sys.Homogenize();
 
-	Vec<dbl> v(2);
-	v << dbl(2,3), dbl(3,4);
+	Vec<complex_dbl> v(2);
+	v << complex_dbl(2,3), complex_dbl(3,4);
 
 	auto d = sys.DehomogenizePoint(v);
 
@@ -1054,8 +1054,8 @@ BOOST_AUTO_TEST_CASE(system_homogenize_point_unhomogenized_is_identity)
 	VariableGroup vars{x, y};
 	sys.AddVariableGroup(vars);
 
-	Vec<dbl> p(2);
-	p << dbl(3,4), dbl(4,5);
+	Vec<complex_dbl> p(2);
+	p << complex_dbl(3,4), complex_dbl(4,5);
 
 	auto h = sys.HomogenizePoint(p);
 
@@ -1078,13 +1078,13 @@ BOOST_AUTO_TEST_CASE(system_homogenize_point_FIFO_one_aff_group)
 
 	sys.Homogenize();
 
-	Vec<dbl> p(2);
-	p << dbl(3,4), dbl(4,5);
+	Vec<complex_dbl> p(2);
+	p << complex_dbl(3,4), complex_dbl(4,5);
 
 	auto h = sys.HomogenizePoint(p);
 
 	BOOST_CHECK_EQUAL(h.size(),3);
-	BOOST_CHECK(abs(h(0) - dbl(1)) < threshold_clearance_d);
+	BOOST_CHECK(abs(h(0) - complex_dbl(1)) < threshold_clearance_d);
 	BOOST_CHECK(abs(h(1) - p(0)) < threshold_clearance_d);
 	BOOST_CHECK(abs(h(2) - p(1)) < threshold_clearance_d);
 
@@ -1114,21 +1114,21 @@ BOOST_AUTO_TEST_CASE(system_homogenize_point_FIFO_mixed_groups)
 
 	sys.Homogenize();
 
-	Vec<dbl> p(6);
-	p << dbl(3,4), dbl(4,5),
-		 dbl(10,11), dbl(11,12),
-		 dbl(6,7), dbl(7,8);
+	Vec<complex_dbl> p(6);
+	p << complex_dbl(3,4), complex_dbl(4,5),
+		 complex_dbl(10,11), complex_dbl(11,12),
+		 complex_dbl(6,7), complex_dbl(7,8);
 
 	auto h = sys.HomogenizePoint(p);
 
 	BOOST_CHECK_EQUAL(h.size(),8);
 	// [hom0, x, y, hom-group passthrough, hom1, z, w]
-	BOOST_CHECK(abs(h(0) - dbl(1)) < threshold_clearance_d);
+	BOOST_CHECK(abs(h(0) - complex_dbl(1)) < threshold_clearance_d);
 	BOOST_CHECK(abs(h(1) - p(0)) < threshold_clearance_d);
 	BOOST_CHECK(abs(h(2) - p(1)) < threshold_clearance_d);
 	BOOST_CHECK(abs(h(3) - p(2)) < threshold_clearance_d);
 	BOOST_CHECK(abs(h(4) - p(3)) < threshold_clearance_d);
-	BOOST_CHECK(abs(h(5) - dbl(1)) < threshold_clearance_d);
+	BOOST_CHECK(abs(h(5) - complex_dbl(1)) < threshold_clearance_d);
 	BOOST_CHECK(abs(h(6) - p(4)) < threshold_clearance_d);
 	BOOST_CHECK(abs(h(7) - p(5)) < threshold_clearance_d);
 
@@ -1158,8 +1158,8 @@ BOOST_AUTO_TEST_CASE(system_dehomogenize_FIFO_one_hom_group_two_ungrouped_vars)
 
 	sys.Homogenize();
 
-	Vec<dbl> v(4);
-	v << dbl(2,3), dbl(3,4), dbl(4,5), dbl(5,6);
+	Vec<complex_dbl> v(4);
+	v << complex_dbl(2,3), complex_dbl(3,4), complex_dbl(4,5), complex_dbl(5,6);
 
 	auto d = sys.DehomogenizePoint(v);
 
@@ -1196,11 +1196,11 @@ BOOST_AUTO_TEST_CASE(system_dehomogenize_FIFO_one_aff_group_two_ungrouped_vars_a
 
 	sys.Homogenize();
 
-	Vec<dbl> v(10);
-	v << dbl(2,3), dbl(3,4), dbl(4,5), 
-		 dbl(10,11), dbl(11,12),
-		 dbl(5,6), dbl(6,7), dbl(7,8),
-		 dbl(12,13), dbl(13,14);
+	Vec<complex_dbl> v(10);
+	v << complex_dbl(2,3), complex_dbl(3,4), complex_dbl(4,5), 
+		 complex_dbl(10,11), complex_dbl(11,12),
+		 complex_dbl(5,6), complex_dbl(6,7), complex_dbl(7,8),
+		 complex_dbl(12,13), complex_dbl(13,14);
 
 	auto d = sys.DehomogenizePoint(v);
 
@@ -1245,9 +1245,9 @@ BOOST_AUTO_TEST_CASE(system_estimate_coeff_bound_linear)
 	S.AddFunction((1-t)*x + t*(1-x));
 	S.AddFunction(x-t);
 
-	mpfr_float coefficient_bound = S.CoefficientBound<mpfr>();
-	BOOST_CHECK(coefficient_bound < mpfr_float("10"));
-	BOOST_CHECK(coefficient_bound > mpfr_float("0.5"));
+	real_mp coefficient_bound = S.CoefficientBound<mpfr>();
+	BOOST_CHECK(coefficient_bound < real_mp("10"));
+	BOOST_CHECK(coefficient_bound > real_mp("0.5"));
 }
 
 
@@ -1265,13 +1265,13 @@ BOOST_AUTO_TEST_CASE(system_estimate_coeff_bound_quartic)
 	VariableGroup vars{x,y,z};
 
 	sys.AddVariableGroup(vars);  
-	sys.AddFunction(y+x*y + mpfr_float("0.5"));
+	sys.AddFunction(y+x*y + real_mp("0.5"));
 	sys.AddFunction(pow(x,3)+x*y+bertini::node::E());
 	sys.AddFunction(pow(x,2)*pow(y,2)+x*y*z*z - 1);
 
-	mpfr_float coefficient_bound = sys.CoefficientBound<mpfr>();
-	BOOST_CHECK(coefficient_bound < mpfr_float("5"));
-	BOOST_CHECK(coefficient_bound > mpfr_float("2"));
+	real_mp coefficient_bound = sys.CoefficientBound<mpfr>();
+	BOOST_CHECK(coefficient_bound < real_mp("5"));
+	BOOST_CHECK(coefficient_bound > real_mp("2"));
 }
 
 
@@ -1295,16 +1295,16 @@ BOOST_AUTO_TEST_CASE(system_estimate_coeff_bound_homogenized_quartic)
 	VariableGroup vars{x,y,z};
 
 	sys.AddVariableGroup(vars);  
-	sys.AddFunction(y+x*y + mpfr_float("0.5"));
+	sys.AddFunction(y+x*y + real_mp("0.5"));
 	sys.AddFunction(pow(x,3)+x*y+bertini::node::E());
 	sys.AddFunction(pow(x,2)*pow(y,2)+x*y*z*z - 1);
 
 	sys.Homogenize();
 	sys.AutoPatch();
 
-	mpfr_float coefficient_bound = sys.CoefficientBound<mpfr>();
-	BOOST_CHECK(coefficient_bound < mpfr_float("10"));
-	BOOST_CHECK(coefficient_bound > mpfr_float("2"));
+	real_mp coefficient_bound = sys.CoefficientBound<mpfr>();
+	BOOST_CHECK(coefficient_bound < real_mp("10"));
+	BOOST_CHECK(coefficient_bound > real_mp("2"));
 }
 
 
@@ -1322,8 +1322,8 @@ BOOST_AUTO_TEST_CASE(system_homogenize_point_lands_on_patch)
 	sys.Homogenize();
 	sys.AutoPatch();
 
-	Vec<dbl> p(2);
-	p << dbl(3,4), dbl(4,5);
+	Vec<complex_dbl> p(2);
+	p << complex_dbl(3,4), complex_dbl(4,5);
 
 	auto h = sys.HomogenizePoint(p);
 	BOOST_CHECK_EQUAL(h.size(),3);
@@ -1340,8 +1340,8 @@ BOOST_AUTO_TEST_CASE(system_homogenize_point_lands_on_patch)
 
 	// and the round trip from an on-patch internal point is exact:
 	// Hom(Dehom(s)) == s for s on the patch
-	Vec<dbl> v(3);
-	v << dbl(2,3), dbl(3,4), dbl(4,5);
+	Vec<complex_dbl> v(3);
+	v << complex_dbl(2,3), complex_dbl(3,4), complex_dbl(4,5);
 	auto s = sys.RescalePointToFitPatch(v);
 	auto s_again = sys.HomogenizePoint(sys.DehomogenizePoint(s));
 	for (int ii = 0; ii < 3; ++ii)
@@ -1365,8 +1365,8 @@ BOOST_AUTO_TEST_CASE(system_estimate_degree_bound_linear)
 	S.AddFunction((1-t)*x + t*(1-x));
 	S.AddFunction(x-t);
 
-	mpfr_float degree_bound = S.DegreeBound();
-	BOOST_CHECK(degree_bound == mpfr_float("1"));
+	real_mp degree_bound = S.DegreeBound();
+	BOOST_CHECK(degree_bound == real_mp("1"));
 }
 
 
@@ -1384,12 +1384,12 @@ BOOST_AUTO_TEST_CASE(system_estimate_degree_bound_quartic)
 	VariableGroup vars{x,y,z};
 
 	sys.AddVariableGroup(vars);  
-	sys.AddFunction(y+x*y + mpfr_float("0.5"));
+	sys.AddFunction(y+x*y + real_mp("0.5"));
 	sys.AddFunction(pow(x,3)+x*y+bertini::node::E());
 	sys.AddFunction(pow(x,2)*pow(y,2)+x*y*z*z - 1);
 
-	mpfr_float degree_bound = sys.DegreeBound();
-	BOOST_CHECK(degree_bound == mpfr_float("4"));
+	real_mp degree_bound = sys.DegreeBound();
+	BOOST_CHECK(degree_bound == real_mp("4"));
 }
 
 
@@ -1414,7 +1414,7 @@ BOOST_AUTO_TEST_CASE(system_multiply_by_node)
 	sys1.AddFunction(z);
 
 	sys2.AddVariableGroup(vars);  
-	sys2.AddFunction(y+x*y + mpfr_float("0.5"));
+	sys2.AddFunction(y+x*y + real_mp("0.5"));
 	sys2.AddFunction(pow(x,3)+x*y+bertini::node::E());
 	sys2.AddFunction(pow(x,2)*pow(y,2)+x*y*z*z - 1);
 
@@ -1445,7 +1445,7 @@ BOOST_AUTO_TEST_CASE(concatenate_two_systems)
 	sys1.AddFunction(z);
 
 	sys2.AddVariableGroup(vars);  
-	sys2.AddFunction(y+x*y + mpfr_float("0.5"));
+	sys2.AddFunction(y+x*y + real_mp("0.5"));
 	sys2.AddFunction(pow(x,3)+x*y+bertini::node::E());
 	sys2.AddFunction(pow(x,2)*pow(y,2)+x*y*z*z - 1);
 
@@ -1472,16 +1472,16 @@ BOOST_AUTO_TEST_CASE(concatenate_accepts_a_structured_block_system)
 	sys1.AddFunction(x*x + y*y - 1);          // a polynomial: f0 = x^2 + y^2 - 1
 
 	// a system whose two functions live in a LinearFormsBlock (a slice): f = 2x+3y+1, x-y+4
-	bertini::Mat<bertini::mpfr_complex> M(2,3);
-	M << bertini::mpfr_complex(2), bertini::mpfr_complex(3),  bertini::mpfr_complex(1),
-	     bertini::mpfr_complex(1), bertini::mpfr_complex(-1), bertini::mpfr_complex(4);
+	bertini::Mat<bertini::complex_mp> M(2,3);
+	M << bertini::complex_mp(2), bertini::complex_mp(3),  bertini::complex_mp(1),
+	     bertini::complex_mp(1), bertini::complex_mp(-1), bertini::complex_mp(4);
 	auto sys2 = bertini::Slice::FromCoefficients(vars, M).AsSystem();
 
 	auto sys3 = Concatenate(sys1, sys2);      // used to segfault on the structured operand
 	BOOST_CHECK_EQUAL(sys3.NumNaturalFunctions(), 3);
 
 	// at (x,y) = (1,1):  f0 = 1,  f1 = 6,  f2 = 4
-	bertini::Vec<bertini::dbl> p(2); p << bertini::dbl(1), bertini::dbl(1);
+	bertini::Vec<bertini::complex_dbl> p(2); p << bertini::complex_dbl(1), bertini::complex_dbl(1);
 	auto v = sys3.Eval(p);
 	BOOST_CHECK_EQUAL(v.size(), 3);
 	BOOST_CHECK_CLOSE(v(0).real(), 1.0, 1e-11);
@@ -1533,12 +1533,12 @@ BOOST_AUTO_TEST_CASE(parsed_system_evaluates_correctly)
 	bertini::System sys;
 	[[maybe_unused]] bool s = bertini::parsing::classic::parse(str.begin(), str.end(), sys);
 	
-	Vec<dbl> values(2);
+	Vec<complex_dbl> values(2);
 	
-	values(0) = dbl(2.0);
-	values(1) = dbl(3.0);
+	values(0) = complex_dbl(2.0);
+	values(1) = complex_dbl(3.0);
 	
-	Vec<dbl> v(sys.NumNaturalFunctions());
+	Vec<complex_dbl> v(sys.NumNaturalFunctions());
 	sys.EvalInPlace(v, values);
 	
 	BOOST_CHECK_EQUAL(v(0), 36.0);

--- a/core/test/classic/classic_parsing_test.cpp
+++ b/core/test/classic/classic_parsing_test.cpp
@@ -638,7 +638,7 @@ BOOST_AUTO_TEST_CASE(classic_writer_round_trips_a_system)
 	BOOST_CHECK_EQUAL(reparsed.NumNaturalFunctions(), sys.NumNaturalFunctions());
 
 	// identical values at a generic point -> the emitted classic text is a faithful round-trip
-	Vec<dbl> pt(2); pt << dbl(0.3, 0.7), dbl(-0.4, 0.2);
+	Vec<complex_dbl> pt(2); pt << complex_dbl(0.3, 0.7), complex_dbl(-0.4, 0.2);
 	auto a = sys.Eval(pt);
 	auto b = reparsed.Eval(pt);
 	BOOST_REQUIRE_EQUAL(a.size(), b.size());

--- a/core/test/endgames/amp_powerseries_test.cpp
+++ b/core/test/endgames/amp_powerseries_test.cpp
@@ -91,7 +91,7 @@ using namespace bertini::endgame;
 
 using TrackerType = bertini::tracking::AMPTracker; // select a tracker type
 using TestedEGType = EndgameSelector<TrackerType>::PSEG;
-using mpfr = bertini::mpfr_complex;
+using mpfr = bertini::complex_mp;
 
 using namespace bertini;
 BOOST_AUTO_TEST_CASE(ensure_uniform_precision_16_30_40)

--- a/core/test/endgames/generic_cauchy_test.hpp
+++ b/core/test/endgames/generic_cauchy_test.hpp
@@ -44,9 +44,9 @@ using VariableGroup = bertini::VariableGroup;
 
 
 
-using dbl = bertini::dbl;
-using mpfr = bertini::mpfr_complex;
-using mpfr_float = bertini::mpfr_float;
+using complex_dbl = bertini::complex_dbl;
+using mpfr = bertini::complex_mp;
+using real_mp = bertini::real_mp;
 using mpq_rational = bertini::mpq_rational;
 
 using bertini::Precision;

--- a/core/test/endgames/generic_pseg_test.hpp
+++ b/core/test/endgames/generic_pseg_test.hpp
@@ -44,9 +44,9 @@ using VariableGroup = bertini::VariableGroup;
 using SuccessCode = bertini::SuccessCode;
 
 
-using dbl = bertini::dbl;
-using mpfr = bertini::mpfr_complex;
-using mpfr_float = bertini::mpfr_float;
+using complex_dbl = bertini::complex_dbl;
+using mpfr = bertini::complex_mp;
+using real_mp = bertini::real_mp;
 using mpq_rational = bertini::mpq_rational;
 
 using bertini::Precision;

--- a/core/test/endgames/interpolation.cpp
+++ b/core/test/endgames/interpolation.cpp
@@ -41,34 +41,34 @@ BOOST_AUTO_TEST_SUITE(interpolation)
 
 
 BOOST_AUTO_TEST_SUITE(generic_tests_double_16)
-using BaseComplexT = bertini::dbl;
+using BaseComplexT = bertini::complex_dbl;
 unsigned ambient_precision = bertini::DoublePrecision();
 #include "test/endgames/generic_interpolation.hpp"
 BOOST_AUTO_TEST_SUITE_END() // generic tests at some precision
 
 
 BOOST_AUTO_TEST_SUITE(generic_tests_double_30)
-using BaseComplexT = bertini::dbl;
+using BaseComplexT = bertini::complex_dbl;
 unsigned ambient_precision = 30;
 #include "test/endgames/generic_interpolation.hpp"
 BOOST_AUTO_TEST_SUITE_END() // generic tests at some precision
 
 
 BOOST_AUTO_TEST_SUITE(generic_tests_mpfr_16)
-using BaseComplexT = bertini::mpfr_complex;
+using BaseComplexT = bertini::complex_mp;
 unsigned ambient_precision = bertini::DoublePrecision();
 #include "test/endgames/generic_interpolation.hpp"
 BOOST_AUTO_TEST_SUITE_END() // generic tests at some precision
 
 
 BOOST_AUTO_TEST_SUITE(generic_tests_mpfr_30)
-using BaseComplexT = bertini::mpfr_complex;
+using BaseComplexT = bertini::complex_mp;
 unsigned ambient_precision = 30;
 #include "test/endgames/generic_interpolation.hpp"
 BOOST_AUTO_TEST_SUITE_END() // generic tests at some precision
 
 BOOST_AUTO_TEST_SUITE(generic_tests_mpfr_100)
-using BaseComplexT = bertini::mpfr_complex;
+using BaseComplexT = bertini::complex_mp;
 unsigned ambient_precision = 100;
 #include "test/endgames/generic_interpolation.hpp"
 BOOST_AUTO_TEST_SUITE_END() // generic tests at some precision

--- a/core/test/generating/mpfr_complex.cpp
+++ b/core/test/generating/mpfr_complex.cpp
@@ -1,17 +1,17 @@
 //This file is part of Bertini 2.
 //
-//test/generating/mpfr_complex.cpp is free software: you can redistribute it and/or modify
+//test/generating/complex_mp.cpp is free software: you can redistribute it and/or modify
 //it under the terms of the GNU General Public License as published by
 //the Free Software Foundation, either version 3 of the License, or
 //(at your option) any later version.
 //
-//test/generating/mpfr_complex.cpp is distributed in the hope that it will be useful,
+//test/generating/complex_mp.cpp is distributed in the hope that it will be useful,
 //but WITHOUT ANY WARRANTY; without even the implied warranty of
 //MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 //GNU General Public License for more details.
 //
 //You should have received a copy of the GNU General Public License
-//along with test/generating/mpfr_complex.cpp.  If not, see <http://www.gnu.org/licenses/>.
+//along with test/generating/complex_mp.cpp.  If not, see <http://www.gnu.org/licenses/>.
 //
 // Copyright(C) Bertini2 Development Team
 //
@@ -20,7 +20,7 @@
 // additional terms in the b2/licenses/ directory.
 
 /**
-\file test/generating/mpfr_complex.cpp  Tests the generating of text from mpfr_complex's.
+\file test/generating/complex_mp.cpp  Tests the generating of text from complex_mp's.
 */
 
 
@@ -31,7 +31,7 @@
 
 
 
-using mpfr = bertini::mpfr_complex;
+using mpfr = bertini::complex_mp;
 
 BOOST_AUTO_TEST_SUITE(mpfr_complex_generating)
 

--- a/core/test/generating/mpfr_float.cpp
+++ b/core/test/generating/mpfr_float.cpp
@@ -1,17 +1,17 @@
 //This file is part of Bertini 2.
 //
-//test/generating/mpfr_float.cpp is free software: you can redistribute it and/or modify
+//test/generating/real_mp.cpp is free software: you can redistribute it and/or modify
 //it under the terms of the GNU General Public License as published by
 //the Free Software Foundation, either version 3 of the License, or
 //(at your option) any later version.
 //
-//test/generating/mpfr_float.cpp is distributed in the hope that it will be useful,
+//test/generating/real_mp.cpp is distributed in the hope that it will be useful,
 //but WITHOUT ANY WARRANTY; without even the implied warranty of
 //MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 //GNU General Public License for more details.
 //
 //You should have received a copy of the GNU General Public License
-//along with test/generating/mpfr_float.cpp.  If not, see <http://www.gnu.org/licenses/>.
+//along with test/generating/real_mp.cpp.  If not, see <http://www.gnu.org/licenses/>.
 //
 // Copyright(C) Bertini2 Development Team
 //
@@ -20,7 +20,7 @@
 // additional terms in the b2/licenses/ directory.
 
 /**
-\file test/generating/mpfr_float.cpp  Tests the generating of text from mpfr_float's.
+\file test/generating/real_mp.cpp  Tests the generating of text from real_mp's.
 */
 
 
@@ -31,7 +31,7 @@
 
 
 
-using mpfr_float = bertini::mpfr_float;
+using real_mp = bertini::real_mp;
 
 BOOST_AUTO_TEST_SUITE(mpfr_float_generating)
 
@@ -42,7 +42,7 @@ BOOST_AUTO_TEST_SUITE(round_trip)
 BOOST_AUTO_TEST_CASE(zero)
 {	
 	bertini::DefaultPrecision(30);
-	mpfr_float z(0);
+	real_mp z(0);
 
 
 	std::string result;
@@ -50,7 +50,7 @@ BOOST_AUTO_TEST_CASE(zero)
 
     BOOST_CHECK(bertini::generators::Classic::generate(sink, z));
 
-    mpfr_float rt;
+    real_mp rt;
 	BOOST_CHECK(bertini::parsing::classic::parse(result.begin(), result.end(), rt));
     BOOST_CHECK_EQUAL(rt,z);
 }
@@ -58,7 +58,7 @@ BOOST_AUTO_TEST_CASE(zero)
 BOOST_AUTO_TEST_CASE(one)
 {	
 	bertini::DefaultPrecision(30);
-	mpfr_float z(1);
+	real_mp z(1);
 
 
 	std::string result;
@@ -66,7 +66,7 @@ BOOST_AUTO_TEST_CASE(one)
 
     BOOST_CHECK(bertini::generators::Classic::generate(sink, z));
 
-    mpfr_float rt;
+    real_mp rt;
 	BOOST_CHECK(bertini::parsing::classic::parse(result.begin(), result.end(), rt));
     BOOST_CHECK_EQUAL(rt,z);
 }
@@ -74,7 +74,7 @@ BOOST_AUTO_TEST_CASE(one)
 BOOST_AUTO_TEST_CASE(sqrt_2)
 {   
     bertini::DefaultPrecision(30);
-    mpfr_float z = sqrt(mpfr_float(2));
+    real_mp z = sqrt(real_mp(2));
 
 
     std::string result;
@@ -82,7 +82,7 @@ BOOST_AUTO_TEST_CASE(sqrt_2)
 
     BOOST_CHECK(bertini::generators::Classic::generate(sink, z));
 
-    mpfr_float rt;
+    real_mp rt;
 	BOOST_CHECK(bertini::parsing::classic::parse(result.begin(), result.end(), rt));
     BOOST_CHECK_EQUAL(rt,z);
 }
@@ -90,7 +90,7 @@ BOOST_AUTO_TEST_CASE(sqrt_2)
 BOOST_AUTO_TEST_CASE(precision)
 {   
     bertini::DefaultPrecision(30);
-    mpfr_float z = sqrt(mpfr_float(2));
+    real_mp z = sqrt(real_mp(2));
 
 
     std::string result;
@@ -100,7 +100,7 @@ BOOST_AUTO_TEST_CASE(precision)
 
     bertini::DefaultPrecision(20);
 
-    mpfr_float rt;
+    real_mp rt;
 	BOOST_CHECK(bertini::parsing::classic::parse(result.begin(), result.end(), rt));
 
     BOOST_CHECK_EQUAL(rt,z);

--- a/core/test/nag_algorithms/threaded_solve.cpp
+++ b/core/test/nag_algorithms/threaded_solve.cpp
@@ -147,7 +147,7 @@ BOOST_AUTO_TEST_SUITE(threaded_solve)
 
 namespace {
 
-using Sol  = bertini::Vec<bertini::dbl>;
+using Sol  = bertini::Vec<bertini::complex_dbl>;
 using Sols = std::vector<Sol>;
 
 template<typename ZD>

--- a/core/test/nag_algorithms/zero_dim.cpp
+++ b/core/test/nag_algorithms/zero_dim.cpp
@@ -210,7 +210,7 @@ BOOST_AUTO_TEST_CASE(user_homotopy_parameter_homotopy_solves)
 {
 	using namespace bertini;
 	using namespace tracking;
-	using mpfr = bertini::mpfr_complex;
+	using mpfr = bertini::complex_mp;
 
 	auto x = Variable::Make("x");
 	auto t = Variable::Make("t");
@@ -248,17 +248,17 @@ BOOST_AUTO_TEST_CASE(user_homotopy_parameter_homotopy_solves)
 
 	auto const& sols = zd.SolutionsUserCoords();
 	auto const& md   = zd.FinalSolutionMetadata();
-	std::vector<dbl> ends;
+	std::vector<complex_dbl> ends;
 	for (size_t i = 0; i < sols.size(); ++i)
 		if (md[i].endgame_success == SuccessCode::Success && sols[i].size() == 1)
-			ends.push_back(dbl(sols[i](0)));
+			ends.push_back(complex_dbl(sols[i](0)));
 
 	BOOST_CHECK_EQUAL(ends.size(), 2u);
 	bool has_pos = false, has_neg = false;
 	for (auto const& e : ends)
 	{
-		if (std::abs(e - dbl(3,0))  < 1e-7) has_pos = true;
-		if (std::abs(e - dbl(-3,0)) < 1e-7) has_neg = true;
+		if (std::abs(e - complex_dbl(3,0))  < 1e-7) has_pos = true;
+		if (std::abs(e - complex_dbl(-3,0)) < 1e-7) has_neg = true;
 	}
 	BOOST_CHECK(has_pos); // tracked +2 -> +3
 	BOOST_CHECK(has_neg); // tracked -2 -> -3
@@ -308,13 +308,13 @@ BOOST_AUTO_TEST_CASE(mhom_solves_two_variable_group_system)
 
 	BOOST_REQUIRE_EQUAL(good.size(), 2u); // both MHom paths solved (the m-homogeneous Bezout number)
 
-	for (auto const& s : good)   // AMP returns mpfr_complex coords; double is plenty for a root check
+	for (auto const& s : good)   // AMP returns complex_mp coords; double is plenty for a root check
 	{
-		dbl a(s(0)), b(s(1));
-		BOOST_CHECK_SMALL(std::abs(a * b - dbl(1)), 1e-8);
+		complex_dbl a(s(0)), b(s(1));
+		BOOST_CHECK_SMALL(std::abs(a * b - complex_dbl(1)), 1e-8);
 		BOOST_CHECK_SMALL(std::abs(a + b), 1e-8);
 	}
-	BOOST_CHECK_GT(std::abs(dbl(good[0](0)) - dbl(good[1](0))), 1e-3); // the two distinct roots
+	BOOST_CHECK_GT(std::abs(complex_dbl(good[0](0)) - complex_dbl(good[1](0))), 1e-3); // the two distinct roots
 }
 
 
@@ -375,9 +375,9 @@ BOOST_AUTO_TEST_CASE(mhom_homotopy_block_matches_function_tree)
 	// double, including t very close to 0 (endgame region, where the spike lives)
 	for (int trial = 0; trial < 10; ++trial)
 	{
-		Vec<dbl> p = Vec<dbl>::Random(n);
-		dbl t = (trial < 5) ? dbl(0.4, -0.3) * dbl(trial + 1)
-		                    : dbl(std::pow(10.0, -(trial - 1)), 0.0); // 1e-4 .. 1e-8
+		Vec<complex_dbl> p = Vec<complex_dbl>::Random(n);
+		complex_dbl t = (trial < 5) ? complex_dbl(0.4, -0.3) * complex_dbl(trial + 1)
+		                    : complex_dbl(std::pow(10.0, -(trial - 1)), 0.0); // 1e-4 .. 1e-8
 		compare(H.Eval(p, t),     He.Eval(p, t),     1e-11);
 		compare(H.Jacobian(p, t), He.Jacobian(p, t), 1e-11);
 	}
@@ -388,8 +388,8 @@ BOOST_AUTO_TEST_CASE(mhom_homotopy_block_matches_function_tree)
 	He.precision(80);
 	for (int trial = 0; trial < 5; ++trial)
 	{
-		Vec<mpfr_complex> p = RandomOfUnits<mpfr_complex>(static_cast<unsigned int>(n));
-		mpfr_complex t = RandomOfUnits<mpfr_complex>(1)(0);
+		Vec<complex_mp> p = RandomOfUnits<complex_mp>(static_cast<unsigned int>(n));
+		complex_mp t = RandomOfUnits<complex_mp>(1)(0);
 		compare(H.Eval(p, t),     He.Eval(p, t),     1e-70);
 		compare(H.Jacobian(p, t), He.Jacobian(p, t), 1e-70);
 	}
@@ -404,7 +404,7 @@ BOOST_AUTO_TEST_CASE(solve_report_buckets_metadata_and_flags_failures)
 	using bertini::algorithm::SummarizeSolve;
 	using bertini::algorithm::MidpathCheckReport;
 	using SC = bertini::SuccessCode;
-	using CT = bertini::dbl;
+	using CT = bertini::complex_dbl;
 
 	auto set = [](SolutionMetaData<CT>& m, SC code, bool finite, int mult,
 	              bool real, bool sing, double cond){
@@ -708,19 +708,19 @@ BOOST_AUTO_TEST_SUITE_END()
 // reports no crossings and the new accessors work.
 BOOST_AUTO_TEST_SUITE(crossed_paths)
 
-using bertini::dbl_complex;
+using bertini::complex_dbl;
 using bertini::Vec;
 using bertini::SuccessCode;
 using MidPathConfig = bertini::algorithm::MidPathConfig;
-using BoundaryMD = bertini::algorithm::EGBoundaryMetaData<dbl_complex>;
-using Checker = bertini::algorithm::MidpathChecker<double, dbl_complex, BoundaryMD>;
+using BoundaryMD = bertini::algorithm::EGBoundaryMetaData<complex_dbl>;
+using Checker = bertini::algorithm::MidpathChecker<double, complex_dbl, BoundaryMD>;
 
 namespace {
 	// Minimal stand-in providing just the StartPoint<ComplexT>(index) interface MidpathChecker
 	// needs, so the test controls both the boundary points and the start points.
 	struct MockStartSystem
 	{
-		std::vector<Vec<dbl_complex>> pts;
+		std::vector<Vec<complex_dbl>> pts;
 
 		template<typename ComplexT>
 		Vec<ComplexT> StartPoint(unsigned long long i) const
@@ -729,14 +729,14 @@ namespace {
 		}
 	};
 
-	Vec<dbl_complex> Pt(dbl_complex a, dbl_complex b)
+	Vec<complex_dbl> Pt(complex_dbl a, complex_dbl b)
 	{
-		Vec<dbl_complex> v(2);
+		Vec<complex_dbl> v(2);
 		v << a, b;
 		return v;
 	}
 
-	BoundaryMD MakeBoundaryPoint(Vec<dbl_complex> const& p)
+	BoundaryMD MakeBoundaryPoint(Vec<complex_dbl> const& p)
 	{
 		return BoundaryMD(p, SuccessCode::Success, 0.01, 16);
 	}

--- a/core/test/nag_datatypes/numerical_irreducible_decomposition.cpp
+++ b/core/test/nag_datatypes/numerical_irreducible_decomposition.cpp
@@ -42,7 +42,7 @@ BOOST_AUTO_TEST_SUITE(nid)
 		using sp = std::shared_ptr<T>;
 
 		using NID = bertini::nag_datatype::NumericalIrreducibleDecomposition<
-			bertini::mpfr_complex>;
+			bertini::complex_mp>;
 
 		BOOST_AUTO_TEST_CASE(something)
 		{	

--- a/core/test/nag_datatypes/witness_set.cpp
+++ b/core/test/nag_datatypes/witness_set.cpp
@@ -44,7 +44,7 @@ BOOST_AUTO_TEST_SUITE(witness_set)
 
 	BOOST_AUTO_TEST_SUITE(default_storage_policy)
 
-		using WitnessSet = bertini::nag_datatype::WitnessSet<bertini::mpfr_complex>;
+		using WitnessSet = bertini::nag_datatype::WitnessSet<bertini::complex_mp>;
 
 		BOOST_AUTO_TEST_CASE(make_a_witness_set)
 		{
@@ -70,7 +70,7 @@ BOOST_AUTO_TEST_SUITE(witness_set)
 		{
 			WitnessSet w;
 
-			bertini::Vec<bertini::mpfr_complex> p;
+			bertini::Vec<bertini::complex_mp> p;
 
 			w.AddPoint(p);
 
@@ -83,8 +83,8 @@ BOOST_AUTO_TEST_SUITE(witness_set)
 		{
 			auto sys = bertini::system::Precon::GriewankOsborn();
 
-			bertini::Vec<bertini::mpfr_complex> p(sys.NumVariables());
-			bertini::nag_datatype::PointCont<bertini::Vec<bertini::mpfr_complex>> points;
+			bertini::Vec<bertini::complex_mp> p(sys.NumVariables());
+			bertini::nag_datatype::PointCont<bertini::Vec<bertini::complex_mp>> points;
 			for (unsigned ii = 0; ii < 3; ++ii)
 				points.push_back(p);
 
@@ -114,8 +114,8 @@ BOOST_AUTO_TEST_SUITE(witness_set)
 		{
 			auto sys = bertini::system::Precon::Sphere();
 
-			bertini::Vec<bertini::mpfr_complex> p(sys.NumVariables());
-			bertini::nag_datatype::PointCont<bertini::Vec<bertini::mpfr_complex>> points;
+			bertini::Vec<bertini::complex_mp> p(sys.NumVariables());
+			bertini::nag_datatype::PointCont<bertini::Vec<bertini::complex_mp>> points;
 			for (unsigned ii = 0; ii < 2; ++ii)
 				points.push_back(p);
 
@@ -141,11 +141,11 @@ BOOST_AUTO_TEST_SUITE(witness_set)
 		{
 			auto sys = bertini::system::Precon::Sphere();
 
-			bertini::Vec<bertini::mpfr_complex> p(sys.NumVariables());
+			bertini::Vec<bertini::complex_mp> p(sys.NumVariables());
 			for (unsigned ii = 0; ii < sys.NumVariables(); ++ii)
-				p(ii) = bertini::mpfr_complex(1);
+				p(ii) = bertini::complex_mp(1);
 
-			bertini::nag_datatype::PointCont<bertini::Vec<bertini::mpfr_complex>> points;
+			bertini::nag_datatype::PointCont<bertini::Vec<bertini::complex_mp>> points;
 			points.push_back(p);
 			points.push_back(p);
 
@@ -178,7 +178,7 @@ BOOST_AUTO_TEST_SUITE(witness_set)
 
 	BOOST_AUTO_TEST_SUITE(policy_by_reference)
 
-		using WitnessSet = bertini::nag_datatype::WitnessSet<bertini::mpfr_complex, bertini::System, bertini::nag_datatype::policy::Reference>;
+		using WitnessSet = bertini::nag_datatype::WitnessSet<bertini::complex_mp, bertini::System, bertini::nag_datatype::policy::Reference>;
 
 
 		// check whether can construct a witness set from a set of points, a slice, and a system
@@ -186,8 +186,8 @@ BOOST_AUTO_TEST_SUITE(witness_set)
 		{
 			auto sys = bertini::system::Precon::GriewankOsborn();
 
-			bertini::Vec<bertini::mpfr_complex> p(sys.NumVariables());
-			bertini::nag_datatype::PointCont<std::reference_wrapper<bertini::Vec<bertini::mpfr_complex>>> points;
+			bertini::Vec<bertini::complex_mp> p(sys.NumVariables());
+			bertini::nag_datatype::PointCont<std::reference_wrapper<bertini::Vec<bertini::complex_mp>>> points;
 			for (unsigned ii = 0; ii < 3; ++ii)
 				points.push_back(p);
 
@@ -216,7 +216,7 @@ BOOST_AUTO_TEST_SUITE(witness_set)
 		using sp = std::shared_ptr<T>;
 
 		using WitnessSet = bertini::nag_datatype::WitnessSet<
-			bertini::mpfr_complex, 
+			bertini::complex_mp, 
 			bertini::System, 
 			bertini::nag_datatype::policy::SharedPtr>;
 
@@ -230,9 +230,9 @@ BOOST_AUTO_TEST_SUITE(witness_set)
 			auto n_vars = sys->NumVariables();
 			const auto vars = sys->VariableGroups()[0];
 
-			nag_datatype::PointCont< sp<Vec<mpfr_complex>> > points;
+			nag_datatype::PointCont< sp<Vec<complex_mp>> > points;
 			for (unsigned ii = 0; ii < 3; ++ii)
-				points.push_back(std::make_shared<Vec<mpfr_complex>>(n_vars));
+				points.push_back(std::make_shared<Vec<complex_mp>>(n_vars));
 
 
 			auto slice = std::make_shared<Slice>(Slice::RandomComplex(vars, 1));

--- a/core/test/pools/pool_test.cpp
+++ b/core/test/pools/pool_test.cpp
@@ -123,7 +123,7 @@ using namespace bertini;
 
 BOOST_AUTO_TEST_CASE(make_double_point_point)
 {
-	[[maybe_unused]] PointPool<dbl> pool;
+	[[maybe_unused]] PointPool<complex_dbl> pool;
 }
 BOOST_AUTO_TEST_SUITE_END()
 

--- a/core/test/settings/settings_test.cpp
+++ b/core/test/settings/settings_test.cpp
@@ -54,8 +54,8 @@
 
 #include "test/utility/enable_logging.hpp"
 
-using mpfr = bertini::mpfr_complex;
-using mpfr_float = bertini::mpfr_float;
+using mpfr = bertini::complex_mp;
+using real_mp = bertini::real_mp;
 using mpq_rational = bertini::mpq_rational;
 
 namespace algorithm = bertini::algorithm;
@@ -356,7 +356,7 @@ BOOST_AUTO_TEST_CASE(read_stepping)
 	using namespace bertini::tracking;
 
 
-	mpfr_float tol{"1e-25"}; // settings are parsed as mpfr_float at current default precision, so values are far more accurate than double
+	real_mp tol{"1e-25"}; // settings are parsed as real_mp at current default precision, so values are far more accurate than double
 	SplitInputFile inputfile = ParseInputFile("Config \n heLlo: 9 \n StepSuccessFactor  : 4.2;  FinalTol: 1.845e-7;\n MaxNumberSteps: 234; % the predictor type\nMaxStepSize: 1e-2; StepsForIncrease: 7;\n end;  \n iNpUt % \n  \n variable x; \n ENd;");
 
 
@@ -374,9 +374,9 @@ BOOST_AUTO_TEST_CASE(read_stepping)
 
 	BOOST_CHECK(parsed && iter == end);
 
-	BOOST_CHECK(abs(structure.max_step_size - mpfr_float("1e-2")) < tol);
-	BOOST_CHECK(abs(structure.step_size_success_factor - mpfr_float("4.2")) < tol);
-	BOOST_CHECK(abs(structure.step_size_fail_factor - mpfr_float(1)/2) < tol); // not set in the input, so should be the default value
+	BOOST_CHECK(abs(structure.max_step_size - real_mp("1e-2")) < tol);
+	BOOST_CHECK(abs(structure.step_size_success_factor - real_mp("4.2")) < tol);
+	BOOST_CHECK(abs(structure.step_size_fail_factor - real_mp(1)/2) < tol); // not set in the input, so should be the default value
 
 	BOOST_CHECK_EQUAL(structure.consecutive_successful_steps_before_stepsize_increase, 7);
 	BOOST_CHECK_EQUAL(structure.max_num_steps, 234);
@@ -610,11 +610,11 @@ BOOST_AUTO_TEST_CASE(all_config_settings)
 	bertini::endgame::EndgameConfig end = std::get<bertini::endgame::EndgameConfig>(sets);
 	
 	BOOST_CHECK(pred == Predictor::RKDormandPrince56);
-	BOOST_CHECK_EQUAL( steps.max_step_size, mpfr_float(1)/10); // not set in the input, so should be the default value
+	BOOST_CHECK_EQUAL( steps.max_step_size, real_mp(1)/10); // not set in the input, so should be the default value
 	BOOST_CHECK_EQUAL(newt.max_num_newton_iterations, 7);
 	BOOST_CHECK_EQUAL(newt.min_num_newton_iterations, 1);
 	BOOST_CHECK(abs(tols.final_tolerance - 1.845e-7) < tol);
-	BOOST_CHECK(abs(end.sample_factor - mpfr_float("0.647")) < mpfr_float("1e-25"));
+	BOOST_CHECK(abs(end.sample_factor - real_mp("0.647")) < real_mp("1e-25"));
 	BOOST_CHECK_EQUAL(end.num_sample_points, 7);
 	BOOST_CHECK_EQUAL(end.min_track_time, 1e-100);
 }

--- a/core/test/tracking_basics/amp_criteria_test.cpp
+++ b/core/test/tracking_basics/amp_criteria_test.cpp
@@ -36,7 +36,7 @@
 
 
 extern double threshold_clearance_d;
-extern bertini::mpfr_float threshold_clearance_mp;
+extern bertini::real_mp threshold_clearance_mp;
 extern unsigned TRACKING_TEST_MPFR_DEFAULT_DIGITS;
 
 
@@ -53,9 +53,9 @@ using VariableGroup = bertini::VariableGroup;
 
 
 using mpq_rational = bertini::mpq_rational;
-using dbl = std::complex<double>;
-using mpfr = bertini::mpfr_complex;
-using mpfr_float = bertini::mpfr_float;
+using complex_dbl = std::complex<double>;
+using mpfr = bertini::complex_mp;
+using real_mp = bertini::real_mp;
 
 
 template<typename NumT> using Vec = bertini::Vec<NumT>;
@@ -70,12 +70,12 @@ BOOST_AUTO_TEST_CASE(AMP_criteriaA_double)
 	Also, saftey_digits_1 has been set to 32000 to set off the AMPCriterionB condition. 
 	*/
 	//Setting upt current space and time values for evaluation
-	Vec<dbl> current_space(2);
-	current_space << dbl(256185069753.4088,-387520022558.0519),
-					 dbl(-0.021,-0.177);
+	Vec<complex_dbl> current_space(2);
+	current_space << complex_dbl(256185069753.4088,-387520022558.0519),
+					 complex_dbl(-0.021,-0.177);
 
-	dbl current_time(0,0);
-	dbl delta_t(.1,0);
+	complex_dbl current_time(0,0);
+	complex_dbl delta_t(.1,0);
 	current_time += delta_t;
 
 	//Defining the system and variables. 
@@ -89,11 +89,11 @@ BOOST_AUTO_TEST_CASE(AMP_criteriaA_double)
 	sys.AddFunction(y - pow(x,2));
 
 	//For Criterion A to be checked we need Norm_J and inverse of Norm_J these were taken from Euler.hpp
-	Mat<dbl> dh_dx = sys.Jacobian(current_space, current_time); 
-	Eigen::PartialPivLU<Mat<dbl>> LU = dh_dx.lu();
+	Mat<complex_dbl> dh_dx = sys.Jacobian(current_space, current_time); 
+	Eigen::PartialPivLU<Mat<complex_dbl>> LU = dh_dx.lu();
 
-	Vec<dbl> randy = Vec<dbl>::Random(static_cast<Eigen::Index>(sys.NumVariables()));
-	Vec<dbl> temp_soln = LU.solve(randy);
+	Vec<complex_dbl> randy = Vec<complex_dbl>::Random(static_cast<Eigen::Index>(sys.NumVariables()));
+	Vec<complex_dbl> temp_soln = LU.solve(randy);
 					
 	auto norm_J = double(dh_dx.norm());
 	auto norm_J_inverse = double(temp_soln.norm());
@@ -103,7 +103,7 @@ BOOST_AUTO_TEST_CASE(AMP_criteriaA_double)
 	auto AMP = bertini::tracking::AMPConfigFrom(sys);
 	AMP.safety_digits_1 = 32000;
 
-	auto CritA = bertini::tracking::amp::CriterionA<dbl>(norm_J,norm_J_inverse,AMP);
+	auto CritA = bertini::tracking::amp::CriterionA<complex_dbl>(norm_J,norm_J_inverse,AMP);
 
 
 	//Check to make sure we failed.
@@ -168,12 +168,12 @@ BOOST_AUTO_TEST_CASE(AMP_criteriaB_double)
 	Also, saftey_digits_1 has been set to 32000 to set off the AMPCriterionB condition. 
 	*/
 	//Setting upt current space and time values for evaluation
-	Vec<dbl> current_space(2);
-	current_space << dbl(256185069753.4088,-387520022558.0519),
-					 dbl(-0.021,-0.177);
+	Vec<complex_dbl> current_space(2);
+	current_space << complex_dbl(256185069753.4088,-387520022558.0519),
+					 complex_dbl(-0.021,-0.177);
 
-	dbl current_time(0,0);
-	dbl delta_t(.1,0);
+	complex_dbl current_time(0,0);
+	complex_dbl delta_t(.1,0);
 	current_time += delta_t;
 
 	//Defining the system and variables. 
@@ -188,12 +188,12 @@ BOOST_AUTO_TEST_CASE(AMP_criteriaB_double)
 
 	//For Criterion A to be checked we need Norm_J and inverse of Norm_J these were taken from Euler.hpp
 	auto f = sys.Eval(current_space, current_time);
-	Mat<dbl> dh_dx = sys.Jacobian(current_space, current_time); 
-	Eigen::PartialPivLU<Mat<dbl>> LU = dh_dx.lu();
-	Vec<dbl> delta_z = LU.solve(-f);
+	Mat<complex_dbl> dh_dx = sys.Jacobian(current_space, current_time); 
+	Eigen::PartialPivLU<Mat<complex_dbl>> LU = dh_dx.lu();
+	Vec<complex_dbl> delta_z = LU.solve(-f);
 
-	Vec<dbl> randy = Vec<dbl>::Random(static_cast<Eigen::Index>(sys.NumVariables()));
-	Vec<dbl> temp_soln = LU.solve(randy);
+	Vec<complex_dbl> randy = Vec<complex_dbl>::Random(static_cast<Eigen::Index>(sys.NumVariables()));
+	Vec<complex_dbl> temp_soln = LU.solve(randy);
 					
 	auto norm_J = double(dh_dx.norm());
 	auto norm_J_inverse = double(temp_soln.norm());
@@ -206,7 +206,7 @@ BOOST_AUTO_TEST_CASE(AMP_criteriaB_double)
 	unsigned int num_newton_iterations_remaining = 1;
 	auto TrackTolBeforeEG = 1e-5; //Obtained from Bertini Book.
 
-	auto CritB = bertini::tracking::amp::CriterionB<dbl>(norm_J,norm_J_inverse,num_newton_iterations_remaining,TrackTolBeforeEG,delta_z.norm(),AMP);
+	auto CritB = bertini::tracking::amp::CriterionB<complex_dbl>(norm_J,norm_J_inverse,num_newton_iterations_remaining,TrackTolBeforeEG,delta_z.norm(),AMP);
 
 
 	//Check to make sure we failed.
@@ -273,12 +273,12 @@ BOOST_AUTO_TEST_CASE(AMP_criteriaC_double)
 	Also, saftey_digits_1 has been set to 32000 to set off the AMPCriterionB condition. 
 	*/
 	//Setting upt current space and time values for evaluation
-	Vec<dbl> current_space(2);
-	current_space << dbl(256185069753.4088,-387520022558.0519),
-					 dbl(-0.021,-0.177);
+	Vec<complex_dbl> current_space(2);
+	current_space << complex_dbl(256185069753.4088,-387520022558.0519),
+					 complex_dbl(-0.021,-0.177);
 
-	dbl current_time(0,0);
-	dbl delta_t(.1,0);
+	complex_dbl current_time(0,0);
+	complex_dbl delta_t(.1,0);
 	current_time += delta_t;
 
 	//Defining the system and variables. 
@@ -292,11 +292,11 @@ BOOST_AUTO_TEST_CASE(AMP_criteriaC_double)
 	sys.AddFunction(y - pow(x,2));
 
 	//For Criterion A to be checked we need Norm_J and inverse of Norm_J these were taken from Euler.hpp
-	Mat<dbl> dh_dx = sys.Jacobian(current_space, current_time); 
-	Eigen::PartialPivLU<Mat<dbl>> LU = dh_dx.lu();
+	Mat<complex_dbl> dh_dx = sys.Jacobian(current_space, current_time); 
+	Eigen::PartialPivLU<Mat<complex_dbl>> LU = dh_dx.lu();
 
-	Vec<dbl> randy = Vec<dbl>::Random(static_cast<Eigen::Index>(sys.NumVariables()));
-	Vec<dbl> temp_soln = LU.solve(randy);
+	Vec<complex_dbl> randy = Vec<complex_dbl>::Random(static_cast<Eigen::Index>(sys.NumVariables()));
+	Vec<complex_dbl> temp_soln = LU.solve(randy);
 	auto norm_J_inverse = double(temp_soln.norm());
 
 
@@ -305,7 +305,7 @@ BOOST_AUTO_TEST_CASE(AMP_criteriaC_double)
 	AMP.safety_digits_2 = 32000;
 	auto TrackTolBeforeEG = 1e-5; //Obtained from Bertini Book.
 
-	auto CritC = bertini::tracking::amp::CriterionC<dbl>(norm_J_inverse,current_space,TrackTolBeforeEG,AMP);
+	auto CritC = bertini::tracking::amp::CriterionC<complex_dbl>(norm_J_inverse,current_space,TrackTolBeforeEG,AMP);
 
 
 	//Check to make sure we failed.

--- a/core/test/tracking_basics/amp_jacobian_estimate_test.cpp
+++ b/core/test/tracking_basics/amp_jacobian_estimate_test.cpp
@@ -43,7 +43,7 @@ a reported huge ||J^{-1}|| reflects a genuine near-singularity, not an estimatio
 
 BOOST_AUTO_TEST_SUITE(amp_jacobian_estimate)
 
-using dbl = bertini::dbl;
+using complex_dbl = bertini::complex_dbl;
 template <typename T> using Vec = bertini::Vec<T>;
 template <typename T> using Mat = bertini::Mat<T>;
 
@@ -51,22 +51,22 @@ namespace {
 
 	// The corrector's estimate: ||J^{-1} r|| for a random unit-modulus r (max over a few draws,
 	// as a path accumulates many draws).  This mirrors newton_corrector.hpp.
-	double NormJInverseEstimate(Mat<dbl> const& J, int draws = 12)
+	double NormJInverseEstimate(Mat<complex_dbl> const& J, int draws = 12)
 	{
 		double best = 0.0;
 		auto lu = J.partialPivLu();
 		for (int i = 0; i < draws; ++i)
 		{
-			Vec<dbl> r = bertini::RandomOfUnits<dbl>(static_cast<unsigned>(J.cols()));
+			Vec<complex_dbl> r = bertini::RandomOfUnits<complex_dbl>(static_cast<unsigned>(J.cols()));
 			best = std::max(best, lu.solve(r).norm());
 		}
 		return best;
 	}
 
 	// True spectral ||J^{-1}|| = 1 / smallest singular value of J.
-	double TrueNormJInverse(Mat<dbl> const& J)
+	double TrueNormJInverse(Mat<complex_dbl> const& J)
 	{
-		Eigen::JacobiSVD<Mat<dbl>> svd(J);
+		Eigen::JacobiSVD<Mat<complex_dbl>> svd(J);
 		double sigma_min = svd.singularValues()(svd.singularValues().size() - 1);
 		return 1.0 / sigma_min;
 	}
@@ -81,7 +81,7 @@ BOOST_AUTO_TEST_CASE(estimate_tracks_truth_well_conditioned)
 	for (int n = 2; n <= 6; ++n)
 		for (int trial = 0; trial < 20; ++trial)
 		{
-			Mat<dbl> J = Mat<dbl>::Random(n, n);
+			Mat<complex_dbl> J = Mat<complex_dbl>::Random(n, n);
 			double est  = NormJInverseEstimate(J);
 			double tru  = TrueNormJInverse(J);
 
@@ -99,30 +99,30 @@ BOOST_AUTO_TEST_CASE(estimate_tracks_truth_well_conditioned)
 // it nor inflating it by orders.  This is the case the DigitsB~147 spike falls into.
 BOOST_AUTO_TEST_CASE(estimate_reflects_genuine_near_singularity)
 {
-	using mpfr_complex = bertini::mpfr_complex;
-	using mpfr_float   = bertini::mpfr_float;
+	using complex_mp = bertini::complex_mp;
+	using real_mp   = bertini::real_mp;
 
 	for (int k = 20; k <= 140; k += 40)
 	{
 		bertini::DefaultPrecision(static_cast<unsigned int>(k + 50)); // enough digits to represent eps = 1e-k
 
-		mpfr_float eps = pow(mpfr_float(10), -k);
+		real_mp eps = pow(real_mp(10), -k);
 		// J = [[1, 1], [1, 1+eps]] : det = eps, so ||J^{-1}||_2 ~ 2/eps ~ 1e+k (analytic).
-		Mat<mpfr_complex> J(2, 2);
-		J(0,0) = mpfr_complex(1); J(0,1) = mpfr_complex(1);
-		J(1,0) = mpfr_complex(1); J(1,1) = mpfr_complex(1) + mpfr_complex(eps);
+		Mat<complex_mp> J(2, 2);
+		J(0,0) = complex_mp(1); J(0,1) = complex_mp(1);
+		J(1,0) = complex_mp(1); J(1,1) = complex_mp(1) + complex_mp(eps);
 
 		auto lu = J.partialPivLu();
-		mpfr_float best(0);
+		real_mp best(0);
 		for (int i = 0; i < 12; ++i)
 		{
-			Vec<mpfr_complex> r = bertini::RandomOfUnits<mpfr_complex>(2);
-			mpfr_float nrm = lu.solve(r).norm();
+			Vec<complex_mp> r = bertini::RandomOfUnits<complex_mp>(2);
+			real_mp nrm = lu.solve(r).norm();
 			if (nrm > best) best = nrm;
 		}
 
 		double log_est = static_cast<double>(log10(best));
-		double log_tru = static_cast<double>(log10(mpfr_float(2) / eps)); // ~ k
+		double log_tru = static_cast<double>(log10(real_mp(2) / eps)); // ~ k
 
 		// the estimate is the right order of magnitude (within ~2 decades) of the true value --
 		// so a DigitsB spike of ~147 means a genuinely ~1e145 ||J^{-1}||, NOT an estimation artifact.

--- a/core/test/tracking_basics/amp_tracker_test.cpp
+++ b/core/test/tracking_basics/amp_tracker_test.cpp
@@ -32,7 +32,7 @@
 
 
 extern double threshold_clearance_d;
-extern bertini::mpfr_float threshold_clearance_mp;
+extern bertini::real_mp threshold_clearance_mp;
 extern unsigned TRACKING_TEST_MPFR_DEFAULT_DIGITS;
 
 
@@ -47,9 +47,9 @@ using Var = std::shared_ptr<Variable>;
 using VariableGroup = bertini::VariableGroup;
 
 
-using dbl = std::complex<double>;
-using mpfr = bertini::mpfr_complex;
-using mpfr_float = bertini::mpfr_float;
+using complex_dbl = std::complex<double>;
+using mpfr = bertini::complex_mp;
+using real_mp = bertini::real_mp;
 
 
 template<typename NumT> using Vec = bertini::Vec<NumT>;
@@ -60,11 +60,11 @@ BOOST_AUTO_TEST_CASE(minstepsize)
 {
 	DefaultPrecision(30);
 	using namespace bertini::tracking;
-	mpfr_float remaining_time("1e-10");
+	real_mp remaining_time("1e-10");
 	
-	BOOST_CHECK_EQUAL(MinStepSizeForPrecision(16, remaining_time),mpfr_float("1e-23"));
+	BOOST_CHECK_EQUAL(MinStepSizeForPrecision(16, remaining_time),real_mp("1e-23"));
 
-	BOOST_CHECK_CLOSE(MinStepSizeForPrecision(40, remaining_time),mpfr_float("1e-47"), mpfr_float("1e-28"));
+	BOOST_CHECK_CLOSE(MinStepSizeForPrecision(40, remaining_time),real_mp("1e-47"), real_mp("1e-28"));
 }
 
 
@@ -73,9 +73,9 @@ BOOST_AUTO_TEST_CASE(mindigits)
 	DefaultPrecision(30);
 	using namespace bertini::tracking;
 
-	mpfr_float remaining_time("1e-30");
-	mpfr_float min_stepsize("1e-35");
-	mpfr_float max_stepsize("1e-33");
+	real_mp remaining_time("1e-30");
+	real_mp min_stepsize("1e-35");
+	real_mp max_stepsize("1e-33");
 
 	auto digits = MinDigitsForStepsizeInterval(min_stepsize, max_stepsize, remaining_time);
 
@@ -839,7 +839,7 @@ BOOST_AUTO_TEST_CASE(AMP_track_total_degree_start_system)
 	unsigned num_occurences(0);
 	for (auto s : solutions)
 	{
-		if ( (s-solution_1).norm() < mpfr_float("1e-5"))
+		if ( (s-solution_1).norm() < real_mp("1e-5"))
 			num_occurences++;
 	}
 	BOOST_CHECK_EQUAL(num_occurences,1);
@@ -847,7 +847,7 @@ BOOST_AUTO_TEST_CASE(AMP_track_total_degree_start_system)
 	num_occurences = 0;
 	for (auto s : solutions)
 	{
-		if ( (s-solution_2).norm() < mpfr_float("1e-5"))
+		if ( (s-solution_2).norm() < real_mp("1e-5"))
 			num_occurences++;
 	}
 	BOOST_CHECK_EQUAL(num_occurences,1);
@@ -931,7 +931,7 @@ BOOST_AUTO_TEST_CASE(AMP_track_TD_functionalized)
 	unsigned num_occurences(0);
 	for (auto s : solutions)
 	{
-		if ( (s-solution_1).norm() < mpfr_float("1e-5"))
+		if ( (s-solution_1).norm() < real_mp("1e-5"))
 			num_occurences++;
 	}
 	BOOST_CHECK_EQUAL(num_occurences,1);
@@ -939,7 +939,7 @@ BOOST_AUTO_TEST_CASE(AMP_track_TD_functionalized)
 	num_occurences = 0;
 	for (auto s : solutions)
 	{
-		if ( (s-solution_2).norm() < mpfr_float("1e-5"))
+		if ( (s-solution_2).norm() < real_mp("1e-5"))
 			num_occurences++;
 	}
 	BOOST_CHECK_EQUAL(num_occurences,1);
@@ -1015,9 +1015,9 @@ BOOST_AUTO_TEST_CASE(minimize_tracking_cost_skips_precision_below_min_stepsize)
 	using namespace bertini::tracking;
 
 	unsigned new_precision = 0;
-	mpfr_float new_stepsize("0");
-	mpfr_float min_stepsize("1e-5");
-	mpfr_float max_stepsize("1");
+	real_mp new_stepsize("0");
+	real_mp min_stepsize("1e-5");
+	real_mp max_stepsize("1");
 
 	MinimizeTrackingCost(new_precision, new_stepsize,
 	                     bertini::DoublePrecision(), min_stepsize,
@@ -1036,9 +1036,9 @@ BOOST_AUTO_TEST_CASE(minimize_tracking_cost_throws_when_no_precision_satisfies_m
 	using namespace bertini::tracking;
 
 	unsigned new_precision = 0;
-	mpfr_float new_stepsize("0");
-	mpfr_float min_stepsize("2");
-	mpfr_float max_stepsize("10");
+	real_mp new_stepsize("0");
+	real_mp min_stepsize("2");
+	real_mp max_stepsize("10");
 
 	BOOST_CHECK_THROW(
 	    MinimizeTrackingCost(new_precision, new_stepsize,

--- a/core/test/tracking_basics/euler_test.cpp
+++ b/core/test/tracking_basics/euler_test.cpp
@@ -37,7 +37,7 @@
 
 
 extern double threshold_clearance_d;
-extern bertini::mpfr_float threshold_clearance_mp;
+extern bertini::real_mp threshold_clearance_mp;
 extern unsigned TRACKING_TEST_MPFR_DEFAULT_DIGITS;
 
 
@@ -55,9 +55,9 @@ using Var = std::shared_ptr<Variable>;
 using VariableGroup = bertini::VariableGroup;
 
 
-using dbl = std::complex<double>;
-using mpfr = bertini::mpfr_complex;
-using mpfr_float = bertini::mpfr_float;
+using complex_dbl = std::complex<double>;
+using mpfr = bertini::complex_mp;
+using real_mp = bertini::real_mp;
 
 
 template<typename NumT> using Vec = bertini::Vec<NumT>;
@@ -70,13 +70,13 @@ BOOST_AUTO_TEST_CASE(circle_line_euler_double)
 	
 	
 	// Starting point in spacetime step
-	Vec<dbl> current_space(2);
-	current_space << dbl(2.3,0.2), dbl(1.1, 1.87);
+	Vec<complex_dbl> current_space(2);
+	current_space << complex_dbl(2.3,0.2), complex_dbl(1.1, 1.87);
 	
 	// Starting time
-	dbl current_time(0.9);
+	complex_dbl current_time(0.9);
 	// Time step
-	dbl delta_t(-0.1);
+	complex_dbl delta_t(-0.1);
 	
 	
 	
@@ -101,11 +101,11 @@ BOOST_AUTO_TEST_CASE(circle_line_euler_double)
 	
 	double norm_J, norm_J_inverse, size_proportion;
 	
-	Vec<dbl> predicted(2);
-	predicted << dbl(2.40310963516214640018253210912048,0.187706567388887830930493342816564),
-	dbl(0.370984337833979085688209698697074, 1.30889906180158745272421523674049);
+	Vec<complex_dbl> predicted(2);
+	predicted << complex_dbl(2.40310963516214640018253210912048,0.187706567388887830930493342816564),
+	complex_dbl(0.370984337833979085688209698697074, 1.30889906180158745272421523674049);
 	
-	Vec<dbl> euler_prediction_result;
+	Vec<complex_dbl> euler_prediction_result;
 	
 	double tracking_tolerance(1e-5);
 	double condition_number_estimate;
@@ -213,13 +213,13 @@ BOOST_AUTO_TEST_CASE(circle_line_euler_double)
 		bertini::DefaultPrecision(TRACKING_TEST_MPFR_DEFAULT_DIGITS);
 		
 		// Starting point in spacetime step
-		Vec<dbl> current_space(2);
-		current_space << dbl(4.641588833612776e-1), dbl(7.416198487095662e-1);
+		Vec<complex_dbl> current_space(2);
+		current_space << complex_dbl(4.641588833612776e-1), complex_dbl(7.416198487095662e-1);
 		
 		// Starting time
-		dbl current_time(0.7);
+		complex_dbl current_time(0.7);
 		// Time step
-		dbl delta_t(-0.01);
+		complex_dbl delta_t(-0.01);
 		
 		
 		
@@ -234,7 +234,7 @@ BOOST_AUTO_TEST_CASE(circle_line_euler_double)
 		
 		// Define homotopy system
 		sys.AddFunction( t*(pow(x,3)-1) + (1-t)*(pow(x,3) + 2) );
-		sys.AddFunction( t*(pow(y,2)-1) + (1-t)*(pow(y,2) + mpfr_float("0.5")) );
+		sys.AddFunction( t*(pow(y,2)-1) + (1-t)*(pow(y,2) + real_mp("0.5")) );
 		
 		
 		auto AMP = bertini::tracking::AMPConfigFrom(sys);
@@ -243,11 +243,11 @@ BOOST_AUTO_TEST_CASE(circle_line_euler_double)
 		AMP.coefficient_bound = 2;
 		
 		
-		Vec<dbl> predicted(2);
-		predicted << dbl(0.417742995025149735840732480384),
-		dbl(0.731506850772617663577442383933525);
+		Vec<complex_dbl> predicted(2);
+		predicted << complex_dbl(0.417742995025149735840732480384),
+		complex_dbl(0.731506850772617663577442383933525);
 		
-		Vec<dbl> euler_prediction_result;
+		Vec<complex_dbl> euler_prediction_result;
 		
 		double tracking_tolerance(1e-5);
 		double condition_number_estimate;
@@ -302,7 +302,7 @@ BOOST_AUTO_TEST_CASE(circle_line_euler_double)
 		
 		// Define homotopy system
 		sys.AddFunction( t*(pow(x,3)-1) + (1-t)*(pow(x,3) + 2) );
-		sys.AddFunction( t*(pow(y,2)-1) + (1-t)*(pow(y,2) + mpfr_float("0.5")) );
+		sys.AddFunction( t*(pow(y,2)-1) + (1-t)*(pow(y,2) + real_mp("0.5")) );
 		
 		
 		auto AMP = bertini::tracking::AMPConfigFrom(sys);
@@ -345,13 +345,13 @@ BOOST_AUTO_TEST_CASE(circle_line_euler_double)
 		// Circle line homotopy has singular point at (x,y) = (1,-4) and t = .75
 		
 		// Starting point in spacetime step
-		Vec<dbl> current_space(2);
-		current_space << dbl(1.0), dbl(-4.0);
+		Vec<complex_dbl> current_space(2);
+		current_space << complex_dbl(1.0), complex_dbl(-4.0);
 		
 		// Starting time
-		dbl current_time(.75+1e-13);
+		complex_dbl current_time(.75+1e-13);
 		// Time step
-		dbl delta_t(-0.1);
+		complex_dbl delta_t(-0.1);
 		
 		
 		
@@ -378,7 +378,7 @@ BOOST_AUTO_TEST_CASE(circle_line_euler_double)
 		unsigned num_steps_since_last_cond_num_est = 1;
 		unsigned freq_of_CN_estimation = 1;
 		
-		Vec<dbl> prediction_result;
+		Vec<complex_dbl> prediction_result;
 		
 		
 		std::shared_ptr<ExplicitRKPredictor> predictor = std::make_shared< ExplicitRKPredictor >(bertini::tracking::Predictor::Euler,sys);
@@ -461,13 +461,13 @@ BOOST_AUTO_TEST_CASE(circle_line_euler_double)
 		// Circle line homotopy has singular point at (x,y) = (1,-4) and t = .75
 		
 		// Starting point in spacetime step
-		Vec<dbl> current_space(2);
-		current_space << dbl(1.0), dbl(-4.0);
+		Vec<complex_dbl> current_space(2);
+		current_space << complex_dbl(1.0), complex_dbl(-4.0);
 		
 		// Starting time
-		dbl current_time(.8);
+		complex_dbl current_time(.8);
 		// Time step
-		dbl delta_t(-0.1);
+		complex_dbl delta_t(-0.1);
 		
 		
 		
@@ -497,7 +497,7 @@ BOOST_AUTO_TEST_CASE(circle_line_euler_double)
 		unsigned num_steps_since_last_cond_num_est = 1;
 		unsigned freq_of_CN_estimation = 1;
 		
-		Vec<dbl> prediction_result;
+		Vec<complex_dbl> prediction_result;
 		
 		
 		std::shared_ptr<ExplicitRKPredictor> predictor = std::make_shared< ExplicitRKPredictor >(bertini::tracking::Predictor::Euler,sys);
@@ -583,13 +583,13 @@ BOOST_AUTO_TEST_CASE(circle_line_euler_double)
 		// Circle line homotopy has singular point at (x,y) = (1,-4) and t = .75
 		
 		// Starting point in spacetime step
-		Vec<dbl> current_space(2);
-		current_space << dbl(1.0), dbl(-4.0);
+		Vec<complex_dbl> current_space(2);
+		current_space << complex_dbl(1.0), complex_dbl(-4.0);
 		
 		// Starting time
-		dbl current_time(.8);
+		complex_dbl current_time(.8);
 		// Time step
-		dbl delta_t(-0.1);
+		complex_dbl delta_t(-0.1);
 		
 		
 		
@@ -621,7 +621,7 @@ BOOST_AUTO_TEST_CASE(circle_line_euler_double)
 		unsigned num_steps_since_last_cond_num_est = 1;
 		unsigned freq_of_CN_estimation = 1;
 		
-		Vec<dbl> prediction_result;
+		Vec<complex_dbl> prediction_result;
 		
 		std::shared_ptr<ExplicitRKPredictor> predictor = std::make_shared< ExplicitRKPredictor >(bertini::tracking::Predictor::Euler,sys);
 		

--- a/core/test/tracking_basics/expand_to_function_tree_test.cpp
+++ b/core/test/tracking_basics/expand_to_function_tree_test.cpp
@@ -41,8 +41,8 @@ BOOST_AUTO_TEST_SUITE(expand_to_function_tree)
 using System        = bertini::System;
 using Variable      = bertini::node::Variable;
 using VariableGroup = bertini::VariableGroup;
-using dbl           = bertini::dbl;
-using mpfr_complex  = bertini::mpfr_complex;
+using complex_dbl           = bertini::complex_dbl;
+using complex_mp  = bertini::complex_mp;
 template <typename T> using Vec = bertini::Vec<T>;
 template <typename T> using Mat = bertini::Mat<T>;
 
@@ -63,9 +63,9 @@ namespace {
 			}
 	}
 
-	Vec<dbl> RandomVecD(int n)
+	Vec<complex_dbl> RandomVecD(int n)
 	{
-		return Vec<dbl>::Random(n);
+		return Vec<complex_dbl>::Random(n);
 	}
 
 	// compare block vs expanded system on eval + Jacobian at a point (autonomous overload)
@@ -102,13 +102,13 @@ BOOST_AUTO_TEST_CASE(polynomial_block_roundtrip)
 	System expanded = sys.ExpandToFunctionTree();
 
 	for (int trial = 0; trial < 8; ++trial)
-		CompareEvalJac<dbl>(sys, expanded, RandomVecD(2), 1e-13);
+		CompareEvalJac<complex_dbl>(sys, expanded, RandomVecD(2), 1e-13);
 
 	DefaultPrecision(50);
 	sys.precision(50);
 	expanded.precision(50);
 	for (int trial = 0; trial < 4; ++trial)
-		CompareEvalJac<mpfr_complex>(sys, expanded, RandomOfUnits<mpfr_complex>(2), 1e-40);
+		CompareEvalJac<complex_mp>(sys, expanded, RandomOfUnits<complex_mp>(2), 1e-40);
 }
 
 
@@ -124,14 +124,14 @@ BOOST_AUTO_TEST_CASE(products_of_linears_block_matches)
 	sys.AddVariableGroup(VariableGroup{x, y});
 
 	// f0 = (2x + 3y - 1)(x - y + 4);  f1 = (x + 5)( -y + 2)( x + y )   (3 factors)
-	std::vector<Mat<mpfr_complex>> factors;
+	std::vector<Mat<complex_mp>> factors;
 	{
-		Mat<mpfr_complex> M0(2, 3); // rows = factors, cols = (x, y, const)
+		Mat<complex_mp> M0(2, 3); // rows = factors, cols = (x, y, const)
 		M0(0,0) = 2; M0(0,1) = 3;  M0(0,2) = -1;
 		M0(1,0) = 1; M0(1,1) = -1; M0(1,2) = 4;
 		factors.push_back(M0);
 
-		Mat<mpfr_complex> M1(3, 3);
+		Mat<complex_mp> M1(3, 3);
 		M1(0,0) = 1; M1(0,1) = 0;  M1(0,2) = 5;
 		M1(1,0) = 0; M1(1,1) = -1; M1(1,2) = 2;
 		M1(2,0) = 1; M1(2,1) = 1;  M1(2,2) = 0;
@@ -142,13 +142,13 @@ BOOST_AUTO_TEST_CASE(products_of_linears_block_matches)
 	System expanded = sys.ExpandToFunctionTree();
 
 	for (int trial = 0; trial < 8; ++trial)
-		CompareEvalJac<dbl>(sys, expanded, RandomVecD(2), 1e-12);
+		CompareEvalJac<complex_dbl>(sys, expanded, RandomVecD(2), 1e-12);
 
 	DefaultPrecision(50);
 	sys.precision(50);
 	expanded.precision(50);
 	for (int trial = 0; trial < 4; ++trial)
-		CompareEvalJac<mpfr_complex>(sys, expanded, RandomOfUnits<mpfr_complex>(2), 1e-40);
+		CompareEvalJac<complex_mp>(sys, expanded, RandomOfUnits<complex_mp>(2), 1e-40);
 }
 
 
@@ -188,8 +188,8 @@ BOOST_AUTO_TEST_CASE(blend_block_matches)
 
 	for (int trial = 0; trial < 8; ++trial)
 	{
-		dbl tau = dbl(0.3, -0.2) * dbl(trial + 1);
-		CompareEvalJac<dbl>(H, expanded, RandomVecD(2), tau, 1e-12);
+		complex_dbl tau = complex_dbl(0.3, -0.2) * complex_dbl(trial + 1);
+		CompareEvalJac<complex_dbl>(H, expanded, RandomVecD(2), tau, 1e-12);
 	}
 
 	DefaultPrecision(50);
@@ -197,9 +197,9 @@ BOOST_AUTO_TEST_CASE(blend_block_matches)
 	expanded.precision(50);
 	for (int trial = 0; trial < 4; ++trial)
 	{
-		Vec<mpfr_complex> p = RandomOfUnits<mpfr_complex>(2);
-		mpfr_complex tau = RandomOfUnits<mpfr_complex>(1)(0);
-		CompareEvalJac<mpfr_complex>(H, expanded, p, tau, 1e-40);
+		Vec<complex_mp> p = RandomOfUnits<complex_mp>(2);
+		complex_mp tau = RandomOfUnits<complex_mp>(1)(0);
+		CompareEvalJac<complex_mp>(H, expanded, p, tau, 1e-40);
 	}
 }
 

--- a/core/test/tracking_basics/fixed_precision_tracker_test.cpp
+++ b/core/test/tracking_basics/fixed_precision_tracker_test.cpp
@@ -32,7 +32,7 @@
 
 
 extern double threshold_clearance_d;
-extern bertini::mpfr_float threshold_clearance_mp;
+extern bertini::real_mp threshold_clearance_mp;
 extern unsigned TRACKING_TEST_MPFR_DEFAULT_DIGITS;
 
 
@@ -47,9 +47,9 @@ using Var = std::shared_ptr<Variable>;
 using VariableGroup = bertini::VariableGroup;
 
 
-using dbl = std::complex<double>;
-using mpfr = bertini::mpfr_complex;
-using mpfr_float = bertini::mpfr_float;
+using complex_dbl = std::complex<double>;
+using mpfr = bertini::complex_mp;
+using real_mp = bertini::real_mp;
 
 
 template<typename NumT> using Vec = bertini::Vec<NumT>;
@@ -87,13 +87,13 @@ BOOST_AUTO_TEST_CASE(double_tracker_track_linear)
 					newton_preferences);
 
 	
-	dbl t_start(1);
-	dbl t_end(0);
+	complex_dbl t_start(1);
+	complex_dbl t_end(0);
 	
-	Vec<dbl> y_start(1);
-	y_start << dbl(1);
+	Vec<complex_dbl> y_start(1);
+	y_start << complex_dbl(1);
 
-	Vec<dbl> y_end;
+	Vec<complex_dbl> y_end;
 
 	auto obs = GoryDetailLogger<DoublePrecisionTracker>();
 		tracker.AddObserver(obs);
@@ -102,7 +102,7 @@ BOOST_AUTO_TEST_CASE(double_tracker_track_linear)
 	BOOST_CHECK(code==bertini::SuccessCode::Success);
 
 	BOOST_CHECK_EQUAL(y_end.size(),1);
-	BOOST_CHECK(abs(y_end(0)-dbl(0)) < 1e-5);
+	BOOST_CHECK(abs(y_end(0)-complex_dbl(0)) < 1e-5);
 
 }
 	

--- a/core/test/tracking_basics/heun_test.cpp
+++ b/core/test/tracking_basics/heun_test.cpp
@@ -35,7 +35,7 @@
 
 
 extern double threshold_clearance_d;
-extern bertini::mpfr_float threshold_clearance_mp;
+extern bertini::real_mp threshold_clearance_mp;
 extern unsigned TRACKING_TEST_MPFR_DEFAULT_DIGITS;
 
 
@@ -54,9 +54,9 @@ using Var = std::shared_ptr<Variable>;
 using VariableGroup = bertini::VariableGroup;
 
 
-using dbl = std::complex<double>;
-using mpfr = bertini::mpfr_complex;
-using mpfr_float = bertini::mpfr_float;
+using complex_dbl = std::complex<double>;
+using mpfr = bertini::complex_mp;
+using real_mp = bertini::real_mp;
 
 
 template<typename NumT> using Vec = bertini::Vec<NumT>;
@@ -67,13 +67,13 @@ BOOST_AUTO_TEST_CASE(circle_line_heun_double)
 {
 	
 	// Starting point in spacetime step
-	Vec<dbl> current_space(2);
-	current_space << dbl(2.3,0.2), dbl(1.1, 1.87);
+	Vec<complex_dbl> current_space(2);
+	current_space << complex_dbl(2.3,0.2), complex_dbl(1.1, 1.87);
 	
 	// Starting time
-	dbl current_time(0.9);
+	complex_dbl current_time(0.9);
 	// Time step
-	dbl delta_t(-0.1);
+	complex_dbl delta_t(-0.1);
 	
 	
 	
@@ -98,12 +98,12 @@ BOOST_AUTO_TEST_CASE(circle_line_heun_double)
 	
 	double norm_J, norm_J_inverse, size_proportion, error_est;
 	
-	Vec<dbl> predicted(2);
-	predicted << dbl(2.38948874619536140814029774733947,0.208678935223681033727262214382917),
-	dbl(0.524558056401030798191044945035673, 1.43029356995029310361616395235936);
+	Vec<complex_dbl> predicted(2);
+	predicted << complex_dbl(2.38948874619536140814029774733947,0.208678935223681033727262214382917),
+	complex_dbl(0.524558056401030798191044945035673, 1.43029356995029310361616395235936);
 	double predicted_error = .197349645229023708608160063982175;
 	
-	Vec<dbl> heun_prediction_result;
+	Vec<complex_dbl> heun_prediction_result;
 
 	double tracking_tolerance(1e-5);
 	double condition_number_estimate;
@@ -228,13 +228,13 @@ BOOST_AUTO_TEST_CASE(circle_line_heun_double)
 		bertini::DefaultPrecision(TRACKING_TEST_MPFR_DEFAULT_DIGITS);
 		
 		// Starting point in spacetime step
-		Vec<dbl> current_space(2);
-		current_space << dbl(0.464158883361277585510862309093), dbl(0.74161984870956629487113974408);
+		Vec<complex_dbl> current_space(2);
+		current_space << complex_dbl(0.464158883361277585510862309093), complex_dbl(0.74161984870956629487113974408);
 		
 		// Starting time
-		dbl current_time(0.7);
+		complex_dbl current_time(0.7);
 		// Time step
-		dbl delta_t(-0.01);
+		complex_dbl delta_t(-0.01);
 		
 		
 		
@@ -262,12 +262,12 @@ BOOST_AUTO_TEST_CASE(circle_line_heun_double)
 		AMP.coefficient_bound = 2;
 		
 		
-		Vec<dbl> predicted(2);
-		predicted << dbl(0.412299156269677938503694812160886),
-		dbl(0.731436945256924470273568899877140);
+		Vec<complex_dbl> predicted(2);
+		predicted << complex_dbl(0.412299156269677938503694812160886),
+		complex_dbl(0.731436945256924470273568899877140);
 		double predicted_error = 0.00544428757292458409463632380167773;
 		
-		Vec<dbl> heun_prediction_result;
+		Vec<complex_dbl> heun_prediction_result;
 		[[maybe_unused]] double next_time;
 		
 		double tracking_tolerance(1e-5);
@@ -387,13 +387,13 @@ BOOST_AUTO_TEST_CASE(circle_line_heun_double)
 		// Circle line homotopy has singular point at (x,y) = (1,-4) and t = .75
 		
 		// Starting point in spacetime step
-		Vec<dbl> current_space(2);
-		current_space << dbl(1.0), dbl(-4.0);
+		Vec<complex_dbl> current_space(2);
+		current_space << complex_dbl(1.0), complex_dbl(-4.0);
 		
 		// Starting time
-		dbl current_time(.75);
+		complex_dbl current_time(.75);
 		// Time step
-		dbl delta_t(-0.1);
+		complex_dbl delta_t(-0.1);
 		
 		
 		
@@ -422,7 +422,7 @@ BOOST_AUTO_TEST_CASE(circle_line_heun_double)
 		unsigned num_steps_since_last_condition_number_computation = 1;
 		unsigned frequency_of_CN_estimation = 1;
 		
-		Vec<dbl> heun_prediction_result;
+		Vec<complex_dbl> heun_prediction_result;
 		
 		
 		std::shared_ptr<ExplicitRKPredictor> predictor = std::make_shared< ExplicitRKPredictor >(bertini::tracking::Predictor::HeunEuler,sys);
@@ -514,13 +514,13 @@ BOOST_AUTO_TEST_CASE(circle_line_heun_double)
 		// Circle line homotopy has singular point at (x,y) = (1,-4) and t = .75
 		
 		// Starting point in spacetime step
-		Vec<dbl> current_space(2);
-		current_space << dbl(1.0), dbl(-4.0);
+		Vec<complex_dbl> current_space(2);
+		current_space << complex_dbl(1.0), complex_dbl(-4.0);
 		
 		// Starting time
-		dbl current_time(.8);
+		complex_dbl current_time(.8);
 		// Time step
-		dbl delta_t(-0.1);
+		complex_dbl delta_t(-0.1);
 		
 		
 		
@@ -550,7 +550,7 @@ BOOST_AUTO_TEST_CASE(circle_line_heun_double)
 		unsigned num_steps_since_last_condition_number_computation = 1;
 		unsigned frequency_of_CN_estimation = 1;
 		
-		Vec<dbl> heun_prediction_result;
+		Vec<complex_dbl> heun_prediction_result;
 		
 		
 		std::shared_ptr<ExplicitRKPredictor> predictor = std::make_shared< ExplicitRKPredictor >(bertini::tracking::Predictor::HeunEuler,sys);
@@ -638,13 +638,13 @@ BOOST_AUTO_TEST_CASE(circle_line_heun_double)
 		// Circle line homotopy has singular point at (x,y) = (1,-4) and t = .75
 		
 		// Starting point in spacetime step
-		Vec<dbl> current_space(2);
-		current_space << dbl(1.0), dbl(-4.0);
+		Vec<complex_dbl> current_space(2);
+		current_space << complex_dbl(1.0), complex_dbl(-4.0);
 		
 		// Starting time
-		dbl current_time(.8);
+		complex_dbl current_time(.8);
 		// Time step
-		dbl delta_t(-0.1);
+		complex_dbl delta_t(-0.1);
 		
 		
 		
@@ -676,7 +676,7 @@ BOOST_AUTO_TEST_CASE(circle_line_heun_double)
 		unsigned num_steps_since_last_condition_number_computation = 1;
 		unsigned frequency_of_CN_estimation = 1;
 		
-		Vec<dbl> heun_prediction_result;
+		Vec<complex_dbl> heun_prediction_result;
 		
 		std::shared_ptr<ExplicitRKPredictor> predictor = std::make_shared< ExplicitRKPredictor >(bertini::tracking::Predictor::HeunEuler,sys);
 		

--- a/core/test/tracking_basics/higher_predictor_test.cpp
+++ b/core/test/tracking_basics/higher_predictor_test.cpp
@@ -37,7 +37,7 @@
 
 
 extern double threshold_clearance_d;
-extern bertini::mpfr_float threshold_clearance_mp;
+extern bertini::real_mp threshold_clearance_mp;
 extern unsigned TRACKING_TEST_MPFR_DEFAULT_DIGITS;
 
 
@@ -54,9 +54,9 @@ using Var = std::shared_ptr<Variable>;
 using VariableGroup = bertini::VariableGroup;
 
 
-using dbl = std::complex<double>;
-using mpfr = bertini::mpfr_complex;
-using mpfr_float = bertini::mpfr_float;
+using complex_dbl = std::complex<double>;
+using mpfr = bertini::complex_mp;
+using real_mp = bertini::real_mp;
 
 
 template<typename NumT> using Vec = bertini::Vec<NumT>;
@@ -85,13 +85,13 @@ BOOST_AUTO_TEST_CASE(circle_line_RK4_double)
 {
 	
 	// Starting point in spacetime step
-	Vec<dbl> current_space(2);
-	current_space << dbl(2.3,0.2), dbl(1.1, 1.87);
+	Vec<complex_dbl> current_space(2);
+	current_space << complex_dbl(2.3,0.2), complex_dbl(1.1, 1.87);
 	
 	// Starting time
-	dbl current_time(0.9);
+	complex_dbl current_time(0.9);
 	// Time step
-	dbl delta_t(-0.1);
+	complex_dbl delta_t(-0.1);
 	
 	
 	
@@ -116,11 +116,11 @@ BOOST_AUTO_TEST_CASE(circle_line_RK4_double)
 	
 	double norm_J, norm_J_inverse, size_proportion;
 	
-	Vec<dbl> predicted(2);
-	predicted << dbl(2.39187197874999601460772208561997,0.215631510575697758920211277830812),
-	dbl(0.524028449166667552309395092084449, 1.42874855320540049801773082714871);
+	Vec<complex_dbl> predicted(2);
+	predicted << complex_dbl(2.39187197874999601460772208561997,0.215631510575697758920211277830812),
+	complex_dbl(0.524028449166667552309395092084449, 1.42874855320540049801773082714871);
 	
-	Vec<dbl> RK4_prediction_result;
+	Vec<complex_dbl> RK4_prediction_result;
 
 	double tracking_tolerance(1e-5);
 	double condition_number_estimate;
@@ -229,13 +229,13 @@ BOOST_AUTO_TEST_CASE(monodromy_RK4_d)
 	DefaultPrecision(TRACKING_TEST_MPFR_DEFAULT_DIGITS);
 	
 	// Starting point in spacetime step
-	Vec<dbl> current_space(2);
-	current_space << dbl(4.641588833612776e-1), dbl(7.416198487095662e-1);
+	Vec<complex_dbl> current_space(2);
+	current_space << complex_dbl(4.641588833612776e-1), complex_dbl(7.416198487095662e-1);
 	
 	// Starting time
-	dbl current_time(0.7);
+	complex_dbl current_time(0.7);
 	// Time step
-	dbl delta_t(-0.01);
+	complex_dbl delta_t(-0.01);
 	
 	
 	
@@ -250,7 +250,7 @@ BOOST_AUTO_TEST_CASE(monodromy_RK4_d)
 	
 	// Define homotopy system
 	sys.AddFunction( t*(pow(x,3)-1) + (1-t)*(pow(x,3) + 2) );
-	sys.AddFunction( t*(pow(y,2)-1) + (1-t)*(pow(y,2) + mpfr_float("0.5")) );
+	sys.AddFunction( t*(pow(y,2)-1) + (1-t)*(pow(y,2) + real_mp("0.5")) );
 	
 	
 	auto AMP = bertini::tracking::AMPConfigFrom(sys);
@@ -259,11 +259,11 @@ BOOST_AUTO_TEST_CASE(monodromy_RK4_d)
 	AMP.coefficient_bound = 2;
 	
 	
-	Vec<dbl> predicted(2);
-	predicted << dbl(0.412127272215145744043367969788438),
-	dbl(0.731436941908745436117221142349986);
+	Vec<complex_dbl> predicted(2);
+	predicted << complex_dbl(0.412127272215145744043367969788438),
+	complex_dbl(0.731436941908745436117221142349986);
 	
-	Vec<dbl> RK4_prediction_result;
+	Vec<complex_dbl> RK4_prediction_result;
 	[[maybe_unused]] double next_time;
 	
 	double tracking_tolerance(1e-5);
@@ -319,7 +319,7 @@ BOOST_AUTO_TEST_CASE(monodromy_RK4_mp)
 	
 	// Define homotopy system
 	sys.AddFunction( t*(pow(x,3)-1) + (1-t)*(pow(x,3) + 2) );
-	sys.AddFunction( t*(pow(y,2)-1) + (1-t)*(pow(y,2) + mpfr_float("0.5")) );
+	sys.AddFunction( t*(pow(y,2)-1) + (1-t)*(pow(y,2) + real_mp("0.5")) );
 	
 	
 	auto AMP = bertini::tracking::AMPConfigFrom(sys);
@@ -390,13 +390,13 @@ BOOST_AUTO_TEST_CASE(circle_line_RKF45_double)
 {
 	
 	// Starting point in spacetime step
-	Vec<dbl> current_space(2);
-	current_space << dbl(2.3,0.2), dbl(1.1, 1.87);
+	Vec<complex_dbl> current_space(2);
+	current_space << complex_dbl(2.3,0.2), complex_dbl(1.1, 1.87);
 	
 	// Starting time
-	dbl current_time(0.9);
+	complex_dbl current_time(0.9);
 	// Time step
-	dbl delta_t(-0.1);
+	complex_dbl delta_t(-0.1);
 	
 	
 	
@@ -421,12 +421,12 @@ BOOST_AUTO_TEST_CASE(circle_line_RKF45_double)
 	
 	double norm_J, norm_J_inverse, size_proportion, error_est;
 	
-	Vec<dbl> predicted(2);
-	predicted << dbl(2.39189497719010446148169962134860,0.215706089331670902152009632918759),
-	dbl(0.524023229576057910435628847490594, 1.42873163348439955724728985152555);
+	Vec<complex_dbl> predicted(2);
+	predicted << complex_dbl(2.39189497719010446148169962134860,0.215706089331670902152009632918759),
+	complex_dbl(0.524023229576057910435628847490594, 1.42873163348439955724728985152555);
 	double predicted_error = 0.0000106466724075688025735071053994891;
 	
-	Vec<dbl> RKF45_prediction_result;
+	Vec<complex_dbl> RKF45_prediction_result;
 
 	double tracking_tolerance(1e-5);
 	double condition_number_estimate;
@@ -553,13 +553,13 @@ BOOST_AUTO_TEST_CASE(monodromy_RKF45_d)
 	DefaultPrecision(TRACKING_TEST_MPFR_DEFAULT_DIGITS);
 	
 	// Starting point in spacetime step
-	Vec<dbl> current_space(2);
-	current_space << dbl(0.464158883361277585510862309093), dbl(0.74161984870956629487113974408);
+	Vec<complex_dbl> current_space(2);
+	current_space << complex_dbl(0.464158883361277585510862309093), complex_dbl(0.74161984870956629487113974408);
 	
 	// Starting time
-	dbl current_time(0.7);
+	complex_dbl current_time(0.7);
 	// Time step
-	dbl delta_t(-0.01);
+	complex_dbl delta_t(-0.01);
 	
 	
 	
@@ -587,12 +587,12 @@ BOOST_AUTO_TEST_CASE(monodromy_RKF45_d)
 	AMP.coefficient_bound = 2;
 	
 	
-	Vec<dbl> predicted(2);
-	predicted << dbl(0.412128542780464095503570026382729),
-	dbl(0.731436941916416473300161135742533);
+	Vec<complex_dbl> predicted(2);
+	predicted << complex_dbl(0.412128542780464095503570026382729),
+	complex_dbl(0.731436941916416473300161135742533);
 	double predicted_error = 7.17724133646795598396247354053062e-8;
 	
-	Vec<dbl> RKF45_prediction_result;
+	Vec<complex_dbl> RKF45_prediction_result;
 	[[maybe_unused]] double next_time;
 	
 	double tracking_tolerance(1e-5);
@@ -739,13 +739,13 @@ BOOST_AUTO_TEST_CASE(circle_line_RKCK45_double)
 {
 	
 	// Starting point in spacetime step
-	Vec<dbl> current_space(2);
-	current_space << dbl(2.3,0.2), dbl(1.1, 1.87);
+	Vec<complex_dbl> current_space(2);
+	current_space << complex_dbl(2.3,0.2), complex_dbl(1.1, 1.87);
 	
 	// Starting time
-	dbl current_time(0.9);
+	complex_dbl current_time(0.9);
 	// Time step
-	dbl delta_t(-0.1);
+	complex_dbl delta_t(-0.1);
 	
 	
 	
@@ -770,12 +770,12 @@ BOOST_AUTO_TEST_CASE(circle_line_RKCK45_double)
 	
 	double norm_J, norm_J_inverse, size_proportion, error_est;
 	
-	Vec<dbl> predicted(2);
-	predicted << dbl(2.39189687053703334440737233377404,0.215710089694839238261207432302796),
-	dbl(0.524023000601737797891275060536396, 1.42873127596071439996076584113815);
+	Vec<complex_dbl> predicted(2);
+	predicted << complex_dbl(2.39189687053703334440737233377404,0.215710089694839238261207432302796),
+	complex_dbl(0.524023000601737797891275060536396, 1.42873127596071439996076584113815);
 	double predicted_error = 0.00000353010590253211978478006394088836;
 	
-	Vec<dbl> RKCK45_prediction_result;
+	Vec<complex_dbl> RKCK45_prediction_result;
 
 	double tracking_tolerance(1e-5);
 	double condition_number_estimate;
@@ -902,13 +902,13 @@ BOOST_AUTO_TEST_CASE(monodromy_RKCK45_d)
 	DefaultPrecision(TRACKING_TEST_MPFR_DEFAULT_DIGITS);
 	
 	// Starting point in spacetime step
-	Vec<dbl> current_space(2);
-	current_space << dbl(0.464158883361277585510862309093), dbl(0.74161984870956629487113974408);
+	Vec<complex_dbl> current_space(2);
+	current_space << complex_dbl(0.464158883361277585510862309093), complex_dbl(0.74161984870956629487113974408);
 	
 	// Starting time
-	dbl current_time(0.7);
+	complex_dbl current_time(0.7);
 	// Time step
-	dbl delta_t(-0.01);
+	complex_dbl delta_t(-0.01);
 	
 	
 	
@@ -936,12 +936,12 @@ BOOST_AUTO_TEST_CASE(monodromy_RKCK45_d)
 	AMP.coefficient_bound = 2;
 	
 	
-	Vec<dbl> predicted(2);
-	predicted << dbl(0.412128535278042242819741034030722),
-	dbl(0.731436941916396784391576913351911);
+	Vec<complex_dbl> predicted(2);
+	predicted << complex_dbl(0.412128535278042242819741034030722),
+	complex_dbl(0.731436941916396784391576913351911);
 	double predicted_error = 4.51352044466211707817977052519894e-9;
 	
-	Vec<dbl> RKCK45_prediction_result;
+	Vec<complex_dbl> RKCK45_prediction_result;
 	[[maybe_unused]] double next_time;
 	
 	double tracking_tolerance(1e-5);
@@ -1220,13 +1220,13 @@ BOOST_AUTO_TEST_CASE(circle_line_RKDP56_double)
 {
 	
 	// Starting point in spacetime step
-	Vec<dbl> current_space(2);
-	current_space << dbl(2.3,0.2), dbl(1.1, 1.87);
+	Vec<complex_dbl> current_space(2);
+	current_space << complex_dbl(2.3,0.2), complex_dbl(1.1, 1.87);
 	
 	// Starting time
-	dbl current_time(0.9);
+	complex_dbl current_time(0.9);
 	// Time step
-	dbl delta_t(-0.1);
+	complex_dbl delta_t(-0.1);
 	
 	
 	
@@ -1251,12 +1251,12 @@ BOOST_AUTO_TEST_CASE(circle_line_RKDP56_double)
 	
 	double norm_J, norm_J_inverse, size_proportion, error_est;
 	
-	Vec<dbl> predicted(2);
-	predicted << dbl(2.39189763095027864748166494355925,0.215711752936893239277981497324557),
-	dbl(0.524022748677715856115185568097945, 1.42873072156957928016044855615010);
+	Vec<complex_dbl> predicted(2);
+	predicted << complex_dbl(2.39189763095027864748166494355925,0.215711752936893239277981497324557),
+	complex_dbl(0.524022748677715856115185568097945, 1.42873072156957928016044855615010);
 	double predicted_error = 6.79397491522542193110307157970405e-7;
 	
-	Vec<dbl> RKDP56_prediction_result;
+	Vec<complex_dbl> RKDP56_prediction_result;
 
 	double tracking_tolerance(1e-5);
 	double condition_number_estimate;
@@ -1519,13 +1519,13 @@ BOOST_AUTO_TEST_CASE(monodromy_RKDP56_d)
 	DefaultPrecision(TRACKING_TEST_MPFR_DEFAULT_DIGITS);
 	
 	// Starting point in spacetime step
-	Vec<dbl> current_space(2);
-	current_space << dbl(0.464158883361277585510862309093), dbl(0.74161984870956629487113974408);
+	Vec<complex_dbl> current_space(2);
+	current_space << complex_dbl(0.464158883361277585510862309093), complex_dbl(0.74161984870956629487113974408);
 	
 	// Starting time
-	dbl current_time(0.7);
+	complex_dbl current_time(0.7);
 	// Time step
-	dbl delta_t(-0.01);
+	complex_dbl delta_t(-0.01);
 	
 	
 	
@@ -1553,12 +1553,12 @@ BOOST_AUTO_TEST_CASE(monodromy_RKDP56_d)
 	AMP.coefficient_bound = 2;
 	
 	
-	Vec<dbl> predicted(2);
-	predicted << dbl(0.412128532164122346459968880922735),
-	dbl(0.731436941916392989685864031055020);
+	Vec<complex_dbl> predicted(2);
+	predicted << complex_dbl(0.412128532164122346459968880922735),
+	complex_dbl(0.731436941916392989685864031055020);
 	double predicted_error = 3.85904197101299548102733617445410e-9;
 	
-	Vec<dbl> RKDP56_prediction_result;
+	Vec<complex_dbl> RKDP56_prediction_result;
 	[[maybe_unused]] double next_time;
 	
 	double tracking_tolerance(1e-5);
@@ -1692,13 +1692,13 @@ BOOST_AUTO_TEST_CASE(circle_line_RKV67_double)
 {
 	
 	// Starting point in spacetime step
-	Vec<dbl> current_space(2);
-	current_space << dbl(2.3,0.2), dbl(1.1, 1.87);
+	Vec<complex_dbl> current_space(2);
+	current_space << complex_dbl(2.3,0.2), complex_dbl(1.1, 1.87);
 	
 	// Starting time
-	dbl current_time(0.9);
+	complex_dbl current_time(0.9);
 	// Time step
-	dbl delta_t(-0.1);
+	complex_dbl delta_t(-0.1);
 	
 	
 	
@@ -1723,12 +1723,12 @@ BOOST_AUTO_TEST_CASE(circle_line_RKV67_double)
 	
 	double norm_J, norm_J_inverse, size_proportion, error_est;
 	
-	Vec<dbl> predicted(2);
-	predicted << dbl(2.39189815934576660586899846426669,0.215712712024488132602524062094065),
-	dbl(0.524022631256496309806889230162953, 1.42873050843900263719943909731242);
+	Vec<complex_dbl> predicted(2);
+	predicted << complex_dbl(2.39189815934576660586899846426669,0.215712712024488132602524062094065),
+	complex_dbl(0.524022631256496309806889230162953, 1.42873050843900263719943909731242);
 	double predicted_error = 0.00000128891520195955347062706145253149;
 	
-	Vec<dbl> RKV67_prediction_result;
+	Vec<complex_dbl> RKV67_prediction_result;
 
 	double tracking_tolerance(1e-5);
 	double condition_number_estimate;
@@ -1855,13 +1855,13 @@ BOOST_AUTO_TEST_CASE(monodromy_RKV67_d)
 	DefaultPrecision(TRACKING_TEST_MPFR_DEFAULT_DIGITS);
 	
 	// Starting point in spacetime step
-	Vec<dbl> current_space(2);
-	current_space << dbl(0.464158883361277585510862309093), dbl(0.74161984870956629487113974408);
+	Vec<complex_dbl> current_space(2);
+	current_space << complex_dbl(0.464158883361277585510862309093), complex_dbl(0.74161984870956629487113974408);
 	
 	// Starting time
-	dbl current_time(0.7);
+	complex_dbl current_time(0.7);
 	// Time step
-	dbl delta_t(-0.01);
+	complex_dbl delta_t(-0.01);
 	
 	
 	
@@ -1889,12 +1889,12 @@ BOOST_AUTO_TEST_CASE(monodromy_RKV67_d)
 	AMP.coefficient_bound = 2;
 	
 	
-	Vec<dbl> predicted(2);
-	predicted << dbl(0.412128533889452110491490000899263),
-	dbl(0.731436941916389669876029584806957);
+	Vec<complex_dbl> predicted(2);
+	predicted << complex_dbl(0.412128533889452110491490000899263),
+	complex_dbl(0.731436941916389669876029584806957);
 	double predicted_error = 1.42794733055750714441060080061e-8;
 	
-	Vec<dbl> RKV67_prediction_result;
+	Vec<complex_dbl> RKV67_prediction_result;
 	[[maybe_unused]] double next_time;
 	
 	double tracking_tolerance(1e-5);
@@ -2018,8 +2018,8 @@ namespace {
 	// build the smooth test homotopy + a generic on-path point used by the size_proportion tests.
 	struct PredFixture {
 		bertini::System sys;
-		Vec<dbl> current_space{2};
-		dbl current_time{0.9};
+		Vec<complex_dbl> current_space{2};
+		complex_dbl current_time{0.9};
 		bertini::tracking::AdaptiveMultiplePrecisionConfig AMP;
 		PredFixture() {
 			Var x = Variable::Make("x"), y = Variable::Make("y"), t = Variable::Make("t");
@@ -2027,7 +2027,7 @@ namespace {
 			sys.AddPathVariable(t);
 			sys.AddFunction( t*(pow(x,2)-1) + (1-t)*(pow(x,2) + pow(y,2) - 4) );
 			sys.AddFunction( t*(y-1) + (1-t)*(2*x + 5*y) );
-			current_space << dbl(2.3,0.2), dbl(1.1,1.87);
+			current_space << complex_dbl(2.3,0.2), complex_dbl(1.1,1.87);
 			AMP = bertini::tracking::AMPConfigFrom(sys);
 			AMP.coefficient_bound = 5;
 		}
@@ -2047,13 +2047,13 @@ BOOST_AUTO_TEST_CASE(rkf45_size_proportion_stays_bounded_as_step_shrinks)
 	auto predictor = std::make_shared<ExplicitRKPredictor>(bertini::tracking::Predictor::RKF45, f.sys);
 
 	double tracking_tolerance(1e-5), cn(0); unsigned nsc(1), freq(1);
-	Vec<dbl> result; double err_est(0), size_prop(0), nJ(0), nJinv(0);
+	Vec<complex_dbl> result; double err_est(0), size_prop(0), nJ(0), nJinv(0);
 
 	double sp_max = 0.0, sp_min = 1e300;
 	for (double h : {-0.1, -0.05, -0.025, -0.0125}) // step shrinks 8x; err_est stays above roundoff
 	{
 		auto code = predictor->Predict(result, err_est, size_prop, nJ, nJinv, f.sys,
-		                               f.current_space, f.current_time, dbl(h),
+		                               f.current_space, f.current_time, complex_dbl(h),
 		                               cn, nsc, freq, tracking_tolerance, f.AMP);
 		BOOST_REQUIRE(code == bertini::SuccessCode::Success);
 		BOOST_REQUIRE(size_prop > 0.0);
@@ -2073,12 +2073,12 @@ BOOST_AUTO_TEST_CASE(rkf45_error_estimate_has_order_p_plus_1)
 	const unsigned p = bertini::tracking::predict::Order(bertini::tracking::Predictor::RKF45); // 4
 
 	double tracking_tolerance(1e-5), cn(0); unsigned nsc(1), freq(1);
-	Vec<dbl> result; double size_prop(0), nJ(0), nJinv(0);
+	Vec<complex_dbl> result; double size_prop(0), nJ(0), nJinv(0);
 
 	auto err_at = [&](double h) {
 		double err_est(0);
 		auto code = predictor->Predict(result, err_est, size_prop, nJ, nJinv, f.sys,
-		                               f.current_space, f.current_time, dbl(h),
+		                               f.current_space, f.current_time, complex_dbl(h),
 		                               cn, nsc, freq, tracking_tolerance, f.AMP);
 		BOOST_REQUIRE(code == bertini::SuccessCode::Success);
 		return err_est;
@@ -2106,14 +2106,14 @@ BOOST_AUTO_TEST_CASE(euler_size_proportion_stays_bounded_as_step_shrinks)
 	auto predictor = std::make_shared<ExplicitRKPredictor>(bertini::tracking::Predictor::Euler, f.sys);
 
 	double tracking_tolerance(1e-5), cn(0); unsigned nsc(1), freq(1);
-	Vec<dbl> result; double size_prop(0), nJ(0), nJinv(0);
+	Vec<complex_dbl> result; double size_prop(0), nJ(0), nJinv(0);
 
 	double sp_max = 0.0, sp_min = 1e300;
 	for (double h : {-0.1, -0.05, -0.025, -0.0125}) // step shrinks 8x
 	{
 		// Euler has no error estimate, so use the size_proportion-only Predict overload.
 		auto code = predictor->Predict(result, size_prop, nJ, nJinv, f.sys,
-		                               f.current_space, f.current_time, dbl(h),
+		                               f.current_space, f.current_time, complex_dbl(h),
 		                               cn, nsc, freq, tracking_tolerance, f.AMP);
 		BOOST_REQUIRE(code == bertini::SuccessCode::Success);
 		BOOST_REQUIRE(size_prop > 0.0);

--- a/core/test/tracking_basics/newton_correct_test.cpp
+++ b/core/test/tracking_basics/newton_correct_test.cpp
@@ -34,7 +34,7 @@
 
 
 extern double threshold_clearance_d;
-extern bertini::mpfr_float threshold_clearance_mp;
+extern bertini::real_mp threshold_clearance_mp;
 extern unsigned TRACKING_TEST_MPFR_DEFAULT_DIGITS;
 
 
@@ -51,9 +51,9 @@ using NewtonCorrector = bertini::tracking::correct::NewtonCorrector;
 
 
 
-using dbl = std::complex<double>;
-using mpfr = bertini::mpfr_complex;
-using mpfr_float = bertini::mpfr_float;
+using complex_dbl = std::complex<double>;
+using mpfr = bertini::complex_mp;
+using real_mp = bertini::real_mp;
 using mpq_rational = bertini::mpq_rational;
 
 template<typename NumT> using Vec = bertini::Vec<NumT>;
@@ -67,11 +67,11 @@ BOOST_AUTO_TEST_CASE(circle_line_one_corrector_step_double)
 {
 	
 	// Starting point in spacetime step
-	Vec<dbl> current_space(2);
-	current_space << dbl(2.3,0.2), dbl(1.1, 1.87);
+	Vec<complex_dbl> current_space(2);
+	current_space << complex_dbl(2.3,0.2), complex_dbl(1.1, 1.87);
 	
 	// Starting time
-	dbl current_time(0.9);
+	complex_dbl current_time(0.9);
 	// Time step
 	
 	
@@ -98,11 +98,11 @@ BOOST_AUTO_TEST_CASE(circle_line_one_corrector_step_double)
 	double tracking_tolerance(1e-5);
 	
 	
-	Vec<dbl> corrected(2);
-	corrected << dbl(1.36296628875178620892887063382866,0.135404746200380445814213878747082),
-	dbl(0.448147673035459113010161338024478, -0.0193435351714829208306019826781546);
+	Vec<complex_dbl> corrected(2);
+	corrected << complex_dbl(1.36296628875178620892887063382866,0.135404746200380445814213878747082),
+	complex_dbl(0.448147673035459113010161338024478, -0.0193435351714829208306019826781546);
 	
-	Vec<dbl> newton_correction_result;
+	Vec<complex_dbl> newton_correction_result;
 	
 	tracking_tolerance = 1e1;
 	unsigned max_num_newton_iterations = 1;
@@ -191,11 +191,11 @@ BOOST_AUTO_TEST_CASE(circle_line_one_corrector_step_double)
 	{
 		
 		// Starting point in spacetime step
-		Vec<dbl> current_space(2);
-		current_space << dbl(2.3,0.2), dbl(1.1, 1.87);
+		Vec<complex_dbl> current_space(2);
+		current_space << complex_dbl(2.3,0.2), complex_dbl(1.1, 1.87);
 		
 		// Starting time
-		dbl current_time(0.9);
+		complex_dbl current_time(0.9);
 		// Time step
 		
 		
@@ -222,11 +222,11 @@ BOOST_AUTO_TEST_CASE(circle_line_one_corrector_step_double)
 		double tracking_tolerance(1e-5);
 		
 		
-		Vec<dbl> corrected(2);
-		corrected << dbl(1.14542104415948767661671388923986, 0.0217584797792294631577151109622764),
-		dbl(0.47922556512007318905475515868002, -0.00310835425417563759395930156603948);
+		Vec<complex_dbl> corrected(2);
+		corrected << complex_dbl(1.14542104415948767661671388923986, 0.0217584797792294631577151109622764),
+		complex_dbl(0.47922556512007318905475515868002, -0.00310835425417563759395930156603948);
 		
-		Vec<dbl> newton_correction_result;
+		Vec<complex_dbl> newton_correction_result;
 		
 		tracking_tolerance = 1e1;
 		unsigned max_num_newton_iterations = 2;
@@ -321,12 +321,12 @@ BOOST_AUTO_TEST_CASE(circle_line_one_corrector_step_double)
 		 Have trimmed current_space to have 16 digits after decimal point. Also, saftey_digits_1 has been set to 32000
 		 to set off the AMPCriterionB condition.
 		 */
-		Vec<dbl> current_space(2);
-		current_space << dbl(25.4088532364492429,-38.0519122331723744),
-		dbl(-0.0212298348984663,-0.1778146465316983);
+		Vec<complex_dbl> current_space(2);
+		current_space << complex_dbl(25.4088532364492429,-38.0519122331723744),
+		complex_dbl(-0.0212298348984663,-0.1778146465316983);
 		
-		dbl current_time(0);
-		dbl delta_t(.1);
+		complex_dbl current_time(0);
+		complex_dbl delta_t(.1);
 		
 		current_time += delta_t;
 		
@@ -351,7 +351,7 @@ BOOST_AUTO_TEST_CASE(circle_line_one_corrector_step_double)
 		AMP.safety_digits_1 = 32000;
 		
 		
-		Vec<dbl> newton_correction_result;
+		Vec<complex_dbl> newton_correction_result;
 		
 		double tracking_tolerance = double(10);
 		unsigned max_num_newton_iterations = 1;

--- a/core/test/tracking_basics/path_observers.cpp
+++ b/core/test/tracking_basics/path_observers.cpp
@@ -36,7 +36,7 @@
 
 
 extern double threshold_clearance_d;
-extern bertini::mpfr_float threshold_clearance_mp;
+extern bertini::real_mp threshold_clearance_mp;
 extern unsigned TRACKING_TEST_MPFR_DEFAULT_DIGITS;
 
 
@@ -54,9 +54,9 @@ using Var = std::shared_ptr<Variable>;
 using VariableGroup = bertini::VariableGroup;
 
 
-using dbl = std::complex<double>;
-using mpfr = bertini::mpfr_complex;
-using mpfr_float = bertini::mpfr_float;
+using complex_dbl = std::complex<double>;
+using mpfr = bertini::complex_mp;
+using real_mp = bertini::real_mp;
 
 
 template<typename NumT> using Vec = bertini::Vec<NumT>;

--- a/core/test/tracking_basics/tracking_basics_test.cpp
+++ b/core/test/tracking_basics/tracking_basics_test.cpp
@@ -41,7 +41,7 @@
 
 
 double threshold_clearance_d(1e-15);
-bertini::mpfr_float threshold_clearance_mp("1e-28");
+bertini::real_mp threshold_clearance_mp("1e-28");
 unsigned TRACKING_TEST_MPFR_DEFAULT_DIGITS(30);
 
 

--- a/python_bindings/include/eigenpy_interaction.hpp
+++ b/python_bindings/include/eigenpy_interaction.hpp
@@ -51,18 +51,18 @@ namespace eigenpy
 		};
 
 		template <>
-		struct mpfr_slot<bertini::mpfr_float>
+		struct mpfr_slot<bertini::real_mp>
 		{
-			static bool uninitialized(bertini::mpfr_float const& x)
+			static bool uninitialized(bertini::real_mp const& x)
 			{
 				return x.backend().data()[0]._mpfr_d == 0;
 			}
 		};
 
 		template <>
-		struct mpfr_slot<bertini::mpfr_complex>
+		struct mpfr_slot<bertini::complex_mp>
 		{
-			static bool uninitialized(bertini::mpfr_complex const& x)
+			static bool uninitialized(bertini::complex_mp const& x)
 			{
 				return x.backend().data()[0].re->_mpfr_d == 0;
 			}
@@ -78,9 +78,9 @@ namespace eigenpy
 
 		// template specialization for real numbers
 		template <>
-		struct getitem<bertini::mpfr_float>
+		struct getitem<bertini::real_mp>
 		{
-			using NumT = bertini::mpfr_float;
+			using NumT = bertini::real_mp;
 
 			static PyObject *run(void *data, void * /* arr */)
 			{
@@ -98,9 +98,9 @@ namespace eigenpy
 
 		// a template specialization for complex numbers
 		template <>
-		struct getitem<bertini::mpfr_complex>
+		struct getitem<bertini::complex_mp>
 		{
-			using NumT = bertini::mpfr_complex;
+			using NumT = bertini::complex_mp;
 
 			static PyObject *run(void *data, void * /* arr */)
 			{
@@ -333,22 +333,22 @@ namespace eigenpy
 	// `to[i] = eigenpy::cast<From,To>::run(from[i])`, reading From slots
 	// unguarded.  The primary template is documented as specializable.
 	template <typename To>
-	struct cast<bertini::mpfr_float, To>
+	struct cast<bertini::real_mp, To>
 	{
-		static To run(bertini::mpfr_float const& from)
+		static To run(bertini::real_mp const& from)
 		{
-			if (internal::mpfr_slot<bertini::mpfr_float>::uninitialized(from))
+			if (internal::mpfr_slot<bertini::real_mp>::uninitialized(from))
 				return To(0);
 			return static_cast<To>(from);
 		}
 	};
 
 	template <typename To>
-	struct cast<bertini::mpfr_complex, To>
+	struct cast<bertini::complex_mp, To>
 	{
-		static To run(bertini::mpfr_complex const& from)
+		static To run(bertini::complex_mp const& from)
 		{
-			if (internal::mpfr_slot<bertini::mpfr_complex>::uninitialized(from))
+			if (internal::mpfr_slot<bertini::complex_mp>::uninitialized(from))
 				return To(0);
 			return static_cast<To>(from);
 		}
@@ -416,7 +416,7 @@ namespace eigenpy
 	// versions from internal:: above (eigenpy's read input slots unguarded —
 	// see the header comment), and the ordering comparitors are a compile-time
 	// option because they are NOT defined for complex types (instantiating
-	// them for mpfr_complex would be a hard error).
+	// them for complex_mp would be a hard error).
 	template <typename Scalar, bool WithOrderingComparitors>
 	void registerGuardedUfunct()
 	{

--- a/python_bindings/include/mpfr_export.hpp
+++ b/python_bindings/include/mpfr_export.hpp
@@ -320,7 +320,7 @@ namespace bertini{
 			using RealT = typename NumTraits<T>::Real;
 
 		private:
-			static void set_real(T &c, mpfr_float const& r) { c.real(r);}
+			static void set_real(T &c, real_mp const& r) { c.real(r);}
 			static RealT get_real(T const&c) { return c.real();}
 
 			static void set_imag(T &c, RealT const& r) { c.imag(r);}

--- a/python_bindings/include/node_export.hpp
+++ b/python_bindings/include/node_export.hpp
@@ -87,9 +87,9 @@ namespace bertini{
 
 			// Addition operators
 			Nodeptr(*addNodeNode)(Nodeptr, const Nodeptr&) = &(operator+);
-			Nodeptr(*addNodeMpfr)(Nodeptr, const mpfr_complex&) = &(operator+);
+			Nodeptr(*addNodeMpfr)(Nodeptr, const complex_mp&) = &(operator+);
 			
-			static Nodeptr raddNodeMpfr(Nodeptr  y, const mpfr_complex & x)
+			static Nodeptr raddNodeMpfr(Nodeptr  y, const complex_mp & x)
 			{
 				return x+y;
 			}
@@ -121,7 +121,7 @@ namespace bertini{
 
 			// Subtraction operators
 			Nodeptr(*subNodeNode)(Nodeptr, const Nodeptr&) = &(operator-);
-			Nodeptr(*subNodeMpfr)(Nodeptr, const mpfr_complex&) = &(operator-);
+			Nodeptr(*subNodeMpfr)(Nodeptr, const complex_mp&) = &(operator-);
 			Nodeptr(*subNodeInt)(Nodeptr, int) = &(operator-);
 			static Nodeptr isubNodeNode(Nodeptr  lhs, const Nodeptr & rhs)
 			{
@@ -134,7 +134,7 @@ namespace bertini{
 			}
 
 
-			static Nodeptr rsubNodeMpfr(Nodeptr  y, const mpfr_complex & x)
+			static Nodeptr rsubNodeMpfr(Nodeptr  y, const complex_mp & x)
 			{
 				return x-y;
 			}
@@ -156,7 +156,7 @@ namespace bertini{
 
 			// Multiplication operators
 			Nodeptr(*multNodeNode)(Nodeptr, const Nodeptr&) = &(operator*);
-			Nodeptr(*multNodeMpfr)(Nodeptr, const mpfr_complex&) = &(operator*);
+			Nodeptr(*multNodeMpfr)(Nodeptr, const complex_mp&) = &(operator*);
 			Nodeptr(*multNodeRat)(Nodeptr, const mpq_rational&) = &(operator*);
 			Nodeptr(*multNodeInt)(Nodeptr, int) = &(operator*);
 			static Nodeptr imultNodeNode(Nodeptr  lhs, const Nodeptr & rhs)
@@ -167,7 +167,7 @@ namespace bertini{
 			Nodeptr(*imultMultNode)(std::shared_ptr<node::MultOperator> &, const Nodeptr &) = &(operator*=);
 
 
-			static Nodeptr rmultNodeMpfr(Nodeptr  y, const mpfr_complex & x)
+			static Nodeptr rmultNodeMpfr(Nodeptr  y, const complex_mp & x)
 			{
 				return x*y;
 			}
@@ -188,7 +188,7 @@ namespace bertini{
 			// Division operators
 			Nodeptr(*divNodeNode)(Nodeptr, const Nodeptr&) = &(operator/);
 			Nodeptr(*divNodeRat)(Nodeptr, const mpq_rational&) = &(operator/);
-			Nodeptr(*divNodeMpfr)(Nodeptr, mpfr_complex) = &(operator/);
+			Nodeptr(*divNodeMpfr)(Nodeptr, complex_mp) = &(operator/);
 			Nodeptr(*divNodeInt)(Nodeptr, int) = &(operator/);
 			static Nodeptr idivNodeNode(Nodeptr  lhs, const Nodeptr & rhs)
 			{
@@ -198,7 +198,7 @@ namespace bertini{
 			Nodeptr(*idivMultNode)(std::shared_ptr<node::MultOperator> &, const Nodeptr &) = &(operator/=);
 
 
-			static Nodeptr rdivNodeMpfr(Nodeptr  y, const mpfr_complex & x)
+			static Nodeptr rdivNodeMpfr(Nodeptr  y, const complex_mp & x)
 			{
 				return x/y;
 			}
@@ -217,7 +217,7 @@ namespace bertini{
 
 			// Power operators
 			Nodeptr(*powNodeNode)(const Nodeptr &, const Nodeptr&) = &pow;
-			Nodeptr(*powNodeMpfr)(const Nodeptr&, mpfr_complex) = &pow;
+			Nodeptr(*powNodeMpfr)(const Nodeptr&, complex_mp) = &pow;
 			Nodeptr(*powNodeRat)(const Nodeptr&, const mpq_rational&) = &pow;
 			Nodeptr(*powNodeInt)( Nodeptr const&, int) = &pow;
 

--- a/python_bindings/include/python_common.hpp
+++ b/python_bindings/include/python_common.hpp
@@ -59,8 +59,8 @@
 
 
 using namespace boost::python;
-using mpfr_float = bertini::mpfr_float;
-using mpfr_complex = bertini::mpfr_complex;
+using real_mp = bertini::real_mp;
+using complex_mp = bertini::complex_mp;
 
 namespace bertini { namespace python {
 

--- a/python_bindings/include/system_export.hpp
+++ b/python_bindings/include/system_export.hpp
@@ -55,8 +55,8 @@ namespace bertini{
 		template<typename T> using Vec = Eigen::Matrix<T, Eigen::Dynamic, 1>;
 		template<typename T> using Mat = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
 		
-		using dbl = std::complex<double>;
-		using mpfr = bertini::mpfr_complex;
+		using complex_dbl = std::complex<double>;
+		using mpfr = bertini::complex_mp;
 		
 		
 		
@@ -95,8 +95,8 @@ namespace bertini{
 			static void AddJustFn(bertini::System& self, std::shared_ptr<node::Node> const& f) { return self.AddFunction(f);}
 			
 
-//			Vec<dbl> (System::*sysEval1)(const Vec<dbl> &) = &System::template Eval<dbl>;
-//			Vec<dbl> (System::*sysEval1)(const Vec<dbl> &) = &System::template Eval<dbl>;
+//			Vec<complex_dbl> (System::*sysEval1)(const Vec<complex_dbl> &) = &System::template Eval<complex_dbl>;
+//			Vec<complex_dbl> (System::*sysEval1)(const Vec<complex_dbl> &) = &System::template Eval<complex_dbl>;
 			
 			std::vector<int> (bertini::System::*sysDeg1)() const = &bertini::System::Degrees;
 			std::vector<int> (bertini::System::*sysDeg2)(VariableGroup const&) const = &bertini::System::Degrees;

--- a/python_bindings/include/tracker_export.hpp
+++ b/python_bindings/include/tracker_export.hpp
@@ -94,7 +94,7 @@ namespace bertini{
 				// Invariant backstop for multiprecision trackers: no mpc value entering the
 				// tracker may carry precision 0.  Refuse loudly rather than abort in libmpfr.
 				// (No precision concept for the fixed-double tracker, hence the constexpr gate.)
-				if constexpr (std::is_same_v<ComplexT, bertini::mpfr_complex>)
+				if constexpr (std::is_same_v<ComplexT, bertini::complex_mp>)
 				{
 					if (std::getenv("BERTINI_DIAG") != nullptr)
 					{
@@ -345,16 +345,16 @@ namespace bertini{
 			.def("precision_setup", &TrackerT::PrecisionSetup)
 			.def("precision_preservation", &TrackerT::PrecisionPreservation, "Turn on or off the preservation of precision.  That is, if this is on (true), then the precision of the final point will be the precision of the start point.  Generally, you want to let precision drift, methinks.")
 
-			.def("refine", return_Refine3_ptr<dbl>(),
+			.def("refine", return_Refine3_ptr<complex_dbl>(),
 				(arg("self"), arg("result"), arg("start_point"), arg("time")),
 				"refine a point using this tracker, from `start_point`, at fixed `time`.  returns a success code, computed refined point is in `result`.")
-			.def("refine", return_Refine3_ptr<mpfr_complex>(),
+			.def("refine", return_Refine3_ptr<complex_mp>(),
 				(arg("self"), arg("result"), arg("start_point"), arg("time")),
 				"refine a point using this tracker, from `start_point`, at fixed `time`.  returns a success code, computed refined point is in `result`.")
-			.def("refine", return_Refine4_ptr<dbl>(),
+			.def("refine", return_Refine4_ptr<complex_dbl>(),
 				(arg("self"), arg("result"), arg("start_point"), arg("time"), arg("tolerance"), arg("max_iterations")),
 				"refine a point using this tracker, from `start_point`, at fixed `time`.  returns a success code, computed refined point is in `result`.")
-			.def("refine", return_Refine4_ptr<mpfr_complex>(),
+			.def("refine", return_Refine4_ptr<complex_mp>(),
 				(arg("self"), arg("result"), arg("start_point"), arg("time"), arg("tolerance"), arg("max_iterations")),
 				"refine a point using this tracker, from `start_point`, at fixed `time`.  returns a success code, computed refined point is in `result`.")
 			;
@@ -366,11 +366,11 @@ namespace bertini{
 		void FixedDoubleTrackerVisitor<TrackerT>::visit(PyClass& cl) const
 		{
 			cl
-			.def("refine", return_Refine3_ptr<dbl>(),
+			.def("refine", return_Refine3_ptr<complex_dbl>(),
 				(arg("self"), arg("result"), arg("start_point"), arg("time")),
 				"refine a point using this tracker, from `start_point`, at fixed `time`.  returns a success code, computed refined point is in `result`.")
 
-			.def("refine", return_Refine4_ptr<dbl>(),
+			.def("refine", return_Refine4_ptr<complex_dbl>(),
 				(arg("self"), arg("result"), arg("start_point"), arg("time"), arg("tolerance"), arg("max_iterations")),
 				"refine a point using this tracker, from `start_point`, at fixed `time`.  returns a success code, computed refined point is in `result`.")
 			;
@@ -382,11 +382,11 @@ namespace bertini{
 		void FixedMultipleTrackerVisitor<TrackerT>::visit(PyClass& cl) const
 		{
 			cl
-			.def("refine", return_Refine3_ptr<mpfr_complex>(),
+			.def("refine", return_Refine3_ptr<complex_mp>(),
 				(arg("self"), arg("result"), arg("start_point"), arg("time")),
 				"refine a point using this tracker, from `start_point`, at fixed `time`.  returns a success code, computed refined point is in `result`.")
 
-			.def("refine", return_Refine4_ptr<mpfr_complex>(),
+			.def("refine", return_Refine4_ptr<complex_mp>(),
 				(arg("self"), arg("result"), arg("start_point"), arg("time"), arg("tolerance"), arg("max_iterations")),
 				"refine a point using this tracker, from `start_point`, at fixed `time`.  returns a success code, computed refined point is in `result`.")
 			;
@@ -398,26 +398,26 @@ namespace bertini{
 		void SteppingVisitor<T>::visit(PyClass& cl) const
 		{
 			// initial_step_size, max_step_size, step_size_success_factor, step_size_fail_factor are
-			// stored as mpq_rational (no MPFR precision state) but exposed to Python as mpfr_float
+			// stored as mpq_rational (no MPFR precision state) but exposed to Python as real_mp
 			// so the existing string/Float setter API is unchanged.  The round-trip is exact:
-			// every mpfr_float has an exact rational representation, and converting back recovers it.
+			// every real_mp has an exact rational representation, and converting back recovers it.
 			cl
 			.add_property("initial_step_size",
-				+[](tracking::SteppingConfig const& c) -> mpfr_float { return mpfr_float(c.initial_step_size); },
-				+[](tracking::SteppingConfig& c, mpfr_float const& v) { c.initial_step_size = mpq_rational(v); },
+				+[](tracking::SteppingConfig const& c) -> real_mp { return real_mp(c.initial_step_size); },
+				+[](tracking::SteppingConfig& c, real_mp const& v) { c.initial_step_size = mpq_rational(v); },
 				"The initial stepsize when tracking is started.  See also tracking.AMPTracker.reinitialize_initial_step_size")
 			.add_property("max_step_size",
-				+[](tracking::SteppingConfig const& c) -> mpfr_float { return mpfr_float(c.max_step_size); },
-				+[](tracking::SteppingConfig& c, mpfr_float const& v) { c.max_step_size = mpq_rational(v); },
+				+[](tracking::SteppingConfig const& c) -> real_mp { return real_mp(c.max_step_size); },
+				+[](tracking::SteppingConfig& c, real_mp const& v) { c.max_step_size = mpq_rational(v); },
 				"The maximum allowed stepsize during tracking.  See also min_num_steps")
 			.def_readwrite("min_step_size", &tracking::SteppingConfig::min_step_size,"The minimum stepsize the tracker is allowed to take.  See also max_step_size")
 			.add_property("step_size_success_factor",
-				+[](tracking::SteppingConfig const& c) -> mpfr_float { return mpfr_float(c.step_size_success_factor); },
-				+[](tracking::SteppingConfig& c, mpfr_float const& v) { c.step_size_success_factor = mpq_rational(v); },
+				+[](tracking::SteppingConfig const& c) -> real_mp { return real_mp(c.step_size_success_factor); },
+				+[](tracking::SteppingConfig& c, real_mp const& v) { c.step_size_success_factor = mpq_rational(v); },
 				"The scale factor for stepsize, after some consecutive steps.  See also consecutive_successful_steps_before_stepsize_increase")
 			.add_property("step_size_fail_factor",
-				+[](tracking::SteppingConfig const& c) -> mpfr_float { return mpfr_float(c.step_size_fail_factor); },
-				+[](tracking::SteppingConfig& c, mpfr_float const& v) { c.step_size_fail_factor = mpq_rational(v); },
+				+[](tracking::SteppingConfig const& c) -> real_mp { return real_mp(c.step_size_fail_factor); },
+				+[](tracking::SteppingConfig& c, real_mp const& v) { c.step_size_fail_factor = mpq_rational(v); },
 				"The scale factor for stepsize, after a fail happens.  See also step_size_success_factor")
 			.def_readwrite("consecutive_successful_steps_before_stepsize_increase", &tracking::SteppingConfig::consecutive_successful_steps_before_stepsize_increase,"This number of successful steps have to taken consecutively, and then the stepsize is permitted to increase")
 			.def_readwrite("min_num_steps", &tracking::SteppingConfig::min_num_steps, "The minimum number of steps the tracker can take between now and then.  This is useful if you are tracking closely between times, and want to guarantee some number of steps are taken.  Then again, this could be wasteful, too.")

--- a/python_bindings/include/zero_dim_export.hpp
+++ b/python_bindings/include/zero_dim_export.hpp
@@ -280,7 +280,7 @@ void ZDVisitor<AlgoT>::visit(PyClass& cl) const
 			using TrackerTraitsT = TrackerTraits<typename AlgoT::TrackerT>;
 			if (TrackerTraitsT::IsAdaptivePrec)
 				opt.mptype = 2;
-			else if (std::is_same<typename TrackerTraitsT::BaseComplexT, dbl>::value)
+			else if (std::is_same<typename TrackerTraitsT::BaseComplexT, complex_dbl>::value)
 				opt.mptype = 0;
 			else
 				opt.mptype = 1;
@@ -338,14 +338,14 @@ void ExportZeroDimSpecific(std::string const& class_name){
 // solve loop is re-implemented here -- this only registers the class + a constructor.
 
 // Build a start_system::User from a target system + a Python list of start-point vectors
-// (each element an mpfr_complex vector via eigenpy).  The returned User references `target`, and
+// (each element an complex_mp vector via eigenpy).  The returned User references `target`, and
 // RefToGiven references all three systems, so the friendly Python wrapper keeps them all alive.
 inline std::shared_ptr<start_system::User>
 MakeUserStartSystem(System const& target, boost::python::list const& start_points)
 {
-	SampCont<mpfr_complex> solns{
-		boost::python::stl_input_iterator<Vec<mpfr_complex>>(start_points),
-		boost::python::stl_input_iterator<Vec<mpfr_complex>>() };
+	SampCont<complex_mp> solns{
+		boost::python::stl_input_iterator<Vec<complex_mp>>(start_points),
+		boost::python::stl_input_iterator<Vec<complex_mp>>() };
 	return std::make_shared<start_system::User>(target, solns);
 }
 

--- a/python_bindings/src/containers.cpp
+++ b/python_bindings/src/containers.cpp
@@ -130,33 +130,33 @@ void ExportContainers()
 
 
 	// std::vector of Eigen::matrix
-	using T7 = std::vector<bertini::Vec<dbl_complex>>;
+	using T7 = std::vector<bertini::Vec<complex_dbl>>;
 	class_< T7 >("ListOfVectorComplexDoublePrecision")
 	.def(ListVisitor<T7>())
 	;
 
 	// std::vector of Eigen::matrix
-	using T8 = std::vector<bertini::Vec<mpfr_complex>>;
+	using T8 = std::vector<bertini::Vec<complex_mp>>;
 	class_< T8 >("ListOfVectorComplexVariablePrecision")
 	.def(ListVisitor<T8>())
 	;
 
-	using T9 = std::vector<bertini::algorithm::SolutionMetaData<dbl_complex>>;
+	using T9 = std::vector<bertini::algorithm::SolutionMetaData<complex_dbl>>;
 	class_< T9 >("ListOfSolutionMetaData_DoublePrec")
 	.def(ListVisitor<T9>())
 	;
 
-	using T10 = std::vector<bertini::algorithm::SolutionMetaData<mpfr_complex>>;
+	using T10 = std::vector<bertini::algorithm::SolutionMetaData<complex_mp>>;
 	class_< T10 >("ListOfSolutionMetaData_MultiPrec")
 	.def(ListVisitor<T10>())
 	;
 
-	using T11 = std::vector<bertini::algorithm::EGBoundaryMetaData<dbl_complex>>;
+	using T11 = std::vector<bertini::algorithm::EGBoundaryMetaData<complex_dbl>>;
 	class_< T11 >("ListOfEGBoundaryMetaData_DoublePrec")
 	.def(ListVisitor<T11>())
 	;
 
-	using T12 = std::vector<bertini::algorithm::EGBoundaryMetaData<mpfr_complex>>;
+	using T12 = std::vector<bertini::algorithm::EGBoundaryMetaData<complex_mp>>;
 	class_< T12 >("ListOfEGBoundaryMetaData_MultiPrec")
 	.def(ListVisitor<T12>())
 	;

--- a/python_bindings/src/function_tree.cpp
+++ b/python_bindings/src/function_tree.cpp
@@ -34,7 +34,7 @@
 
 using namespace boost::python;
 
-using dbl = std::complex<double>;
+using complex_dbl = std::complex<double>;
 using mpfr = bertini::complex;
 
 // BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(NodeEvalOverloadsMpfr, bertini::node::Node::template Eval<mpfr>, 0, 1);

--- a/python_bindings/src/mpfr_export.cpp
+++ b/python_bindings/src/mpfr_export.cpp
@@ -258,15 +258,15 @@ namespace bertini{
 			using boost::multiprecision::real;
 			using boost::multiprecision::imag;
 
-			mpfr_float (*reeeal)(const T&) = &boost::multiprecision::real;
-			mpfr_float (*imaaag)(const T&) = &boost::multiprecision::real;
+			real_mp (*reeeal)(const T&) = &boost::multiprecision::real;
+			real_mp (*imaaag)(const T&) = &boost::multiprecision::real;
 			def("real",reeeal, (arg("val")), "get the real part"); //,return_value_policy<copy_const_reference>()
 			def("imag",imaaag, (arg("val")), "get the imaginary part"); //,return_value_policy<copy_const_reference>()
 
 			// and then a few more free functions
 			// def("abs2",&T::abs2);
 
-			mpfr_complex (*pooolar)(const mpfr_float&,const mpfr_float&) = &boost::multiprecision::polar;
+			complex_mp (*pooolar)(const real_mp&,const real_mp&) = &boost::multiprecision::polar;
 
 			def("polar",pooolar, "construct from polar form");
 			// def("norm",&T::norm);
@@ -274,7 +274,7 @@ namespace bertini{
 			T (*conjjj)(const T&) = +[](const T& x) -> T { return boost::multiprecision::conj(x); };
 			def("conj",conjjj, "complex conjugate");
 
-			mpfr_float (*aaaarg)(const T&) = &boost::multiprecision::arg;
+			real_mp (*aaaarg)(const T&) = &boost::multiprecision::arg;
 			def("arg",aaaarg, "the argument, or the angle from 0.  beware the branch cut.");
 
 			// def("square",&square);
@@ -309,10 +309,10 @@ namespace bertini{
 			// Read the static default directly; fall back to 50 (Boost's library
 			// default) in case the getter itself delegates to the unset thread-local.
 			{
-				auto p = mpfr_float::default_precision();
+				auto p = real_mp::default_precision();
 				if (p == 0) p = 50;
-				mpfr_float::thread_default_precision(p);
-				mpfr_complex::thread_default_precision(p);
+				real_mp::thread_default_precision(p);
+				complex_mp::thread_default_precision(p);
 			}
 
 			def("default_precision", def_prec1, "get the default precision for variable-precision numbers.  is digits, not bits.");
@@ -406,7 +406,7 @@ namespace bertini{
 
 		void ExposeFloat()
 		{
-			using T = mpfr_float;
+			using T = real_mp;
 
 			class_<T>("Float", init<>("Default Construct a variable-precision float"))
 			.def_pickle(BoostArchivePickle<T>())
@@ -492,17 +492,17 @@ namespace bertini{
 		void ExposeComplex()
 		{
 
-			using T = bertini::mpfr_complex;
+			using T = bertini::complex_mp;
 
 			class_<T>("Complex", init<>())
 			.def_pickle(BoostArchivePickle<T>())
 			.def(init<double>((arg("self"),arg("real")),"Construct variable-precision complex number from a double, with 0 imaginary part. do this with caution, as 0.1 is not what you think it is -- there's noise at the end.")) // this should probably be made an explicit constructor rather than implicit
-			.def(init<mpfr_float>((arg("self"),arg("real")),"Construct variable-precision complex number from a variable-precision float, with 0 imaginary part"))
+			.def(init<real_mp>((arg("self"),arg("real")),"Construct variable-precision complex number from a variable-precision float, with 0 imaginary part"))
 			.def(init<std::string>((arg("self"),arg("real")),"Construct variable-precision complex number from a string, with 0 imaginary part"))
-			.def(init<mpfr_float,mpfr_float>((arg("self"),arg("real"),arg("imag")),"Construct variable-precision complex number from a pair of variable-precision floats"))
+			.def(init<real_mp,real_mp>((arg("self"),arg("real"),arg("imag")),"Construct variable-precision complex number from a pair of variable-precision floats"))
 			.def(init<double, double>((arg("self"),arg("real"),arg("imag")),"Construct variable-precision complex number from a pair of doubles.  do this with caution, as 0.1 is not what you think it is -- there's noise at the end.")) // this should probably be made an explicit constructor rather than implicit
-			.def(init<std::string, mpfr_float>((arg("self"),arg("real"),arg("imag")),"Construct variable-precision complex number from a string and a variable-precision float"))
-			.def(init<mpfr_float, std::string>((arg("self"),arg("real"),arg("imag")),"Construct variable-precision complex number from a variable-precision float and a string"))
+			.def(init<std::string, real_mp>((arg("self"),arg("real"),arg("imag")),"Construct variable-precision complex number from a string and a variable-precision float"))
+			.def(init<real_mp, std::string>((arg("self"),arg("real"),arg("imag")),"Construct variable-precision complex number from a variable-precision float and a string"))
 			.def(init<std::string, std::string>((arg("self"),arg("real"),arg("imag")),"Construct variable-precision complex number from a pair of strings.  the best way to construct one and be sure you have padded with zeros to the end, in the current working precision"))
 
 			.def(init<T>((arg("self"),arg("value")),"Construct variable-precision complex number from another one"))
@@ -522,20 +522,20 @@ namespace bertini{
 
 			.def(FieldVisitor<T, mpz_int>())
 			.def(FieldVisitor<T, mpq_rational>())
-			.def(FieldVisitor<T, mpfr_float>())
+			.def(FieldVisitor<T, real_mp>())
 
 			.def(FieldVisitor<T, int>())
 
 			.def(PowVisitor<T,T>())
 			.def(PowVisitor<T,int>())
-			.def(PowVisitor<T,mpfr_float>())
+			.def(PowVisitor<T,real_mp>())
 
 			.def(TranscendentalVisitor<T>())
 
 			.def(PrecisionVisitor<T>())
 
 			.def(EqualitySelfVisitor<T>())
-			.def(EqualityVisitor<T, mpfr_float>())
+			.def(EqualityVisitor<T, real_mp>())
 			.def(EqualityVisitor<T, int>())
 			;
 
@@ -562,14 +562,14 @@ namespace bertini{
 			eigenpy::registerCast<double,T>(false);
 
 			// it's ok to convert from variable precision Float to Complex, that's ok!
-			eigenpy::registerCast<mpfr_float,T>(true);
+			eigenpy::registerCast<real_mp,T>(true);
 
 			IMPLICITLY_CONVERTIBLE(int,T);
 			IMPLICITLY_CONVERTIBLE(long,T);
 			IMPLICITLY_CONVERTIBLE(int64_t,T);
 
 			// this is a general python conversion, not an eigenpy conversion.  it's ok to convert from reals to complexes.
-			IMPLICITLY_CONVERTIBLE(mpfr_float,T);
+			IMPLICITLY_CONVERTIBLE(real_mp,T);
 
 			// BUT!!
 			// do not allow implicit conversion, because it is a potential source of problems.
@@ -586,7 +586,7 @@ namespace bertini{
 			eigenpy::exposeType<T>();
 			eigenpy::exposeType<T, Eigen::RowMajor>();
 
-			boost::python::def("precision", &get_precision_vector<mpfr_complex>, "get the precision of a vector of complexes");
+			boost::python::def("precision", &get_precision_vector<complex_mp>, "get the precision of a vector of complexes");
 
 			boost::python::def("default_align_bytes", &get_default_align);
 

--- a/python_bindings/src/nid_datatypes_export.cpp
+++ b/python_bindings/src/nid_datatypes_export.cpp
@@ -11,7 +11,7 @@
 namespace bertini{
 	namespace python{
 
-		using dbl = std::complex<double>;
+		using complex_dbl = std::complex<double>;
 
 		// pickle via boost serialization -- so Slice / WitnessSet / NID result round-trip through
 		// pickle, copy, and deepcopy (and, in C++, through MPI / threads).  Mirrors the suites in
@@ -44,7 +44,7 @@ namespace bertini{
 		void ExportSlice(){
 			class_<Slice>("Slice", "A linear slice of affine/projective space: a stack of linear forms M [x ; 1].", init<>())
 			.def("from_coefficients",
-				+[](VariableGroup const& v, bertini::Mat<mpfr_complex> const& aug, bool homogeneous){
+				+[](VariableGroup const& v, bertini::Mat<complex_mp> const& aug, bool homogeneous){
 					return Slice::FromCoefficients(v, aug, homogeneous);
 				},
 				(arg("variables"), arg("coefficients"), arg("homogeneous")=false),
@@ -65,17 +65,17 @@ namespace bertini{
 				"A random real linear slice of `dim` dimensions (forms) on the given variables.")
 			.staticmethod("random_real")
 			.def("coefficients",
-				+[](Slice const& s){ return bertini::Mat<mpfr_complex>(s.Coefficients()); },
+				+[](Slice const& s){ return bertini::Mat<complex_mp>(s.Coefficients()); },
 				(arg("self")),
 				"The augmented coefficient matrix (one row per linear form, num_variables+1 columns; the trailing column is the constant term).  These rows are ready-made factors for a products-of-linears block.")
 			.def("dimension", &Slice::Dimension, (arg("self")), "the dimension of the slice -- the number of linear forms")
 			.def("num_variables", &Slice::NumVariables, (arg("self")), "the number of variables the slice is a function of")
 			.def("is_homogeneous", &Slice::IsHomogeneous, (arg("self")), "whether the slice was authored without constant terms")
 			.def("eval",
-				+[](Slice const& s, bertini::Vec<dbl> const& x){ return s.Eval(x); },
+				+[](Slice const& s, bertini::Vec<complex_dbl> const& x){ return s.Eval(x); },
 				(arg("self"), arg("x")), "evaluate the linear forms at x, in double precision")
 			.def("eval",
-				+[](Slice const& s, bertini::Vec<mpfr_complex> const& x){ return s.Eval(x); },
+				+[](Slice const& s, bertini::Vec<complex_mp> const& x){ return s.Eval(x); },
 				(arg("self"), arg("x")), "evaluate the linear forms at x, in multiple precision")
 			.def("add_to", &Slice::AddTo, (arg("self"), arg("system")), "add this slice's linear forms to a System as a linear-forms block")
 			.def("as_system", &Slice::AsSystem, (arg("self")), "a standalone System whose functions are exactly this slice's linear forms")
@@ -158,10 +158,10 @@ namespace bertini{
 
 		void ExportNIDDataTypes(){
 			ExportSlice();
-			ExportWitnessSet<dbl_complex>("WitnessSetDoublePrecision");
-			ExportWitnessSet<mpfr_complex>("WitnessSetMultiplePrecision");
-			ExportNIDResult<dbl_complex>("NumericalIrreducibleDecompositionDoublePrecision");
-			ExportNIDResult<mpfr_complex>("NumericalIrreducibleDecompositionMultiplePrecision");
+			ExportWitnessSet<complex_dbl>("WitnessSetDoublePrecision");
+			ExportWitnessSet<complex_mp>("WitnessSetMultiplePrecision");
+			ExportNIDResult<complex_dbl>("NumericalIrreducibleDecompositionDoublePrecision");
+			ExportNIDResult<complex_mp>("NumericalIrreducibleDecompositionMultiplePrecision");
 		}
 
 }} // namespaces

--- a/python_bindings/src/node_export.cpp
+++ b/python_bindings/src/node_export.cpp
@@ -202,22 +202,22 @@ namespace bertini{
 		
 		
 		// Interpret a single Python value (int, float, complex, or a multiprecision
-		// number) as an mpfr_complex.  Multiprecision inputs are taken as-is; native
+		// number) as an complex_mp.  Multiprecision inputs are taken as-is; native
 		// Python numbers are embedded at the current default precision (so a Python
 		// float carries only float64 worth of information --- the documented cap).
-		static mpfr_complex CoerceToMpfrComplex(object const& o)
+		static complex_mp CoerceToMpfrComplex(object const& o)
 		{
-			extract<mpfr_complex> as_mp(o);
+			extract<complex_mp> as_mp(o);
 			if (as_mp.check()) return as_mp();
 
 			extract<std::complex<double>> as_complex(o);
-			if (as_complex.check()) { auto c = as_complex(); return mpfr_complex(c.real(), c.imag()); }
+			if (as_complex.check()) { auto c = as_complex(); return complex_mp(c.real(), c.imag()); }
 
 			extract<double> as_double(o);
-			if (as_double.check()) return mpfr_complex(as_double());
+			if (as_double.check()) return complex_mp(as_double());
 
 			extract<long> as_long(o);
-			if (as_long.check()) return mpfr_complex(static_cast<double>(as_long()));
+			if (as_long.check()) return complex_mp(static_cast<double>(as_long()));
 
 			throw std::runtime_error("could not interpret a supplied value as a number in eval");
 		}
@@ -233,7 +233,7 @@ namespace bertini{
 
 			std::shared_ptr<Node> self = extract<std::shared_ptr<Node>>(args[0]);
 
-			std::map<std::string, mpfr_complex> values;
+			std::map<std::string, complex_mp> values;
 			list items = dict(kwargs).items();
 			for (long i = 0; i < len(items); ++i)
 			{
@@ -242,7 +242,7 @@ namespace bertini{
 				values[name] = CoerceToMpfrComplex(object(pair[1]));
 			}
 
-			return object(bertini::EvalExpression<mpfr_complex>(self, values));
+			return object(bertini::EvalExpression<complex_mp>(self, values));
 		}
 
 		// f.variables() --- the distinct variables appearing in this expression, sorted by name.

--- a/python_bindings/src/random_export.cpp
+++ b/python_bindings/src/random_export.cpp
@@ -21,7 +21,7 @@ void ExportRandom(){
 	def("complex_in_minus_one_to_one", bertini::multiprecision::rand,"Make a random complex number uniformly distributed in [-1,1]x[-1,1], in the current default precision");
 	def("complex_unit", bertini::multiprecision::rand_unit,"Make a random complex number of magnitude 1, in the current default precision");
 
-	mpfr_complex (*RandRealNoArgs)() = &bertini::multiprecision::RandomReal;
+	complex_mp (*RandRealNoArgs)() = &bertini::multiprecision::RandomReal;
 	def("real_as_complex", RandRealNoArgs, "Make a random real number in [-1,1], as a complex number with imaginary part 0, in the current default precision");
 
 	def("set_random_seed", &bertini::SetGlobalSeed, boost::python::arg("seed") = 0ul,

--- a/python_bindings/src/symbol_export.cpp
+++ b/python_bindings/src/symbol_export.cpp
@@ -124,10 +124,10 @@ namespace bertini{
 				"complex value (a real literal is just zero imaginary part).  Build it as Complex(real) "
 				"or Complex(real, imag) from exact strings/multiprec values; prefer Integer or Rational "
 				"for exact non-irrational coefficients.", no_init)
-			.def("__init__", make_constructor(&Complex::template Make<mpfr_float const&, mpfr_float const&>))
+			.def("__init__", make_constructor(&Complex::template Make<real_mp const&, real_mp const&>))
 			.def("__init__", make_constructor(&Complex::template Make<std::string const&>))
 			.def("__init__", make_constructor(&Complex::template Make<std::string const&, std::string const&>))
-			.def("__init__", make_constructor(&Complex::template Make<mpfr_complex const&>))
+			.def("__init__", make_constructor(&Complex::template Make<complex_mp const&>))
 			.def("value", &Complex::GetValue, return_value_policy<copy_const_reference>(), "the literal value this node represents, at its stored (highest) precision")
 			;
 			

--- a/python_bindings/src/system_export.cpp
+++ b/python_bindings/src/system_export.cpp
@@ -89,34 +89,34 @@ namespace bertini{
 				 arg("maxcrossedpathresolves") = 2u),
 				"Emit this system as a Bertini 1 classic input file (a CONFIG + INPUT string) so the same problem can be solved in Bertini 1 for cross-validation.  Every tracking knob that governs path resolution -- predictor, tolerances, and the FULL step-size cadence (maxstepsize / stepsuccessfactor / stepfailfactor / stepsforincrease) plus maxnewtonits -- is settable, so the emitted file is fully controlled against a Bertini 2 solve (defaults mirror Bertini 2's).  mptype: 0 double, 1 fixed-multiple, 2 adaptive.  odepredictor: 0 Euler, 2 RK4, 5 RKF45, 6 Cash-Karp.  AMP coeff/degree bounds are derived from the system.  Run `bertini1` on the result in a SCRATCH dir (it writes many files into its CWD).")
 
-			// Register mpfr overloads first so dbl overloads have highest priority
+			// Register mpfr overloads first so complex_dbl overloads have highest priority
 			// (boost::python resolves in LIFO order). Without this, a numpy int64
 			// array causes eigenpy to probe Vec<mpfr> construction first; with
 			// thread_default_precision=0 on Boost>=1.87 that aborts in mpfr_init2.
 			.def("eval", return_Eval0_ptr<mpfr>(), (arg("self")) ,"Evaluate the system in multiple precision, using already-set variable values.")
-			.def("eval", return_Eval0_ptr<dbl>(), (arg("self")) ,"Evaluate the system in double precision, using already-set variable values.")
+			.def("eval", return_Eval0_ptr<complex_dbl>(), (arg("self")) ,"Evaluate the system in double precision, using already-set variable values.")
 			.def("eval", return_Eval1_ptr<mpfr>(), (arg("self")) ,"Evaluate the system in multiple precision, using space variable values passed into this function.")
-			.def("eval", return_Eval1_ptr<dbl>(), (arg("self")) ,"Evaluate the system in double precision, using space variable values passed into this function.")
+			.def("eval", return_Eval1_ptr<complex_dbl>(), (arg("self")) ,"Evaluate the system in double precision, using space variable values passed into this function.")
 			.def("eval", return_Eval2_ptr<mpfr>(), (arg("self")) ,"Evaluate the system in multiple precision using space and time values passed into this function.  Throws if doesn't use a time variable")
-			.def("eval", return_Eval2_ptr<dbl>(), (arg("self")) ,"Evaluate the system in double precision using space and time values passed into this function.  Throws if doesn't use a time variable")
+			.def("eval", return_Eval2_ptr<complex_dbl>(), (arg("self")) ,"Evaluate the system in double precision using space and time values passed into this function.  Throws if doesn't use a time variable")
 			
 			// these two commented out because i don't need in-place Eigen::Ref wrapping here. 
 			// but if you did, you'd use two lines like this, ha.
 			// .def("eval", &eval_wrap_1<mpfr>)
-			// .def("eval", &eval_wrap_1<dbl>)
+			// .def("eval", &eval_wrap_1<complex_dbl>)
 
-			.def("eval_jacobian", return_Jac0_ptr<dbl>(), (arg("self")) ,"Evaluate the Jacobian (martix of partial derivatives) of the system, using already-set time and space value.")
+			.def("eval_jacobian", return_Jac0_ptr<complex_dbl>(), (arg("self")) ,"Evaluate the Jacobian (martix of partial derivatives) of the system, using already-set time and space value.")
 			.def("eval_jacobian", return_Jac0_ptr<mpfr>(), (arg("self")) ,"Evaluate the Jacobian (martix of partial derivatives) of the system, using already-set time and space value.")
-			.def("eval_jacobian", return_Jac1_ptr<dbl>(), (arg("self")) ,"Evaluate the Jacobian (martix of partial derivatives) of the system, using space values you pass in to this function")
+			.def("eval_jacobian", return_Jac1_ptr<complex_dbl>(), (arg("self")) ,"Evaluate the Jacobian (martix of partial derivatives) of the system, using space values you pass in to this function")
 			.def("eval_jacobian", return_Jac1_ptr<mpfr>(), (arg("self")) ,"Evaluate the Jacobian (martix of partial derivatives) of the system, using space values you pass in to this function")
-			.def("eval_jacobian", return_Jac2_ptr<dbl>(), (arg("self")) , "Evaluate the Jacobian (martix of partial derivatives) of the system, using time and space values passed into this function.  Throws if doesn't use a time variable")
+			.def("eval_jacobian", return_Jac2_ptr<complex_dbl>(), (arg("self")) , "Evaluate the Jacobian (martix of partial derivatives) of the system, using time and space values passed into this function.  Throws if doesn't use a time variable")
 			.def("eval_jacobian", return_Jac2_ptr<mpfr>(), (arg("self")) , "Evaluate the Jacobian (martix of partial derivatives) of the system, using time and space values passed into this function.  Throws if doesn't use a time variable")
 
 			.def("eval_time_derivative",
 				+[](SystemBaseT const& self, bertini::Vec<mpfr> const& v, mpfr const& t) { return self.TimeDerivative(v, t); },
 				(arg("self"), arg("space"), arg("time")), "Evaluate dH/dt (the time derivative) in multiple precision at the given space and time values.  Rows of t-independent blocks are zero.")
 			.def("eval_time_derivative",
-				+[](SystemBaseT const& self, bertini::Vec<dbl> const& v, dbl const& t) { return self.TimeDerivative(v, t); },
+				+[](SystemBaseT const& self, bertini::Vec<complex_dbl> const& v, complex_dbl const& t) { return self.TimeDerivative(v, t); },
 				(arg("self"), arg("space"), arg("time")), "Evaluate dH/dt (the time derivative) in double precision at the given space and time values.  Rows of t-independent blocks are zero.")
 
 			.def("homogenize", static_cast<void (SystemBaseT::*)()>(&SystemBaseT::Homogenize), (arg("self")),"Homogenize the system, adding new homogenizing variables if necessary.  This may change your polynomials; that is, it has side effects.")
@@ -133,11 +133,11 @@ namespace bertini{
 			// .def("num_parameters", &SystemBaseT::NumParameters,"Has no impact on anything.  The number of 'parameters' in the system.")
 			// .def("num_implicit_parameters", &SystemBaseT::NumImplicitParameters,"Has no impact on anything.  The number of 'implicit parameters' in the system.") // commented out until implemented
 			
-			.def("set_variables", &SystemBaseT::template SetVariables<dbl>, (arg("self"), arg("values")), "Set the values of the variables. Expects a vector of doubles")
+			.def("set_variables", &SystemBaseT::template SetVariables<complex_dbl>, (arg("self"), arg("values")), "Set the values of the variables. Expects a vector of doubles")
 			.def("set_variables", &SystemBaseT::template SetVariables<mpfr>, (arg("self"), arg("values")), "Set the values of the variables. Expects a vector of complex mpfr's")
-			.def("set_path_variable", &SystemBaseT::template SetPathVariable<dbl>, (arg("self"), arg("values")), "Set the value of the path variable.  This one's double-precision.  Throws if path variable not defined.")
+			.def("set_path_variable", &SystemBaseT::template SetPathVariable<complex_dbl>, (arg("self"), arg("values")), "Set the value of the path variable.  This one's double-precision.  Throws if path variable not defined.")
 			.def("set_path_variable", &SystemBaseT::template SetPathVariable<mpfr>, (arg("self"), arg("values")), "Set the value of the path variable.  This one's variable-precision.  Throws if path variable not defined.")
-			// .def("set_implicit_parameters", &SystemBaseT::template SetImplicitParameters<dbl>,"Doesn't do anything.  Sets the values of algebraically constrained parameters")
+			// .def("set_implicit_parameters", &SystemBaseT::template SetImplicitParameters<complex_dbl>,"Doesn't do anything.  Sets the values of algebraically constrained parameters")
 			// .def("set_implicit_parameters", &SystemBaseT::template SetImplicitParameters<mpfr>,"Doesn't do anything.  Sets the values of algebraically constrained parameters")
 			
 			.def("add_variable_group", &SystemBaseT::AddVariableGroup, (arg("self"), arg("group")), "Add a (affine) variable group to the System")
@@ -148,7 +148,7 @@ namespace bertini{
 					self.AddBlock(bertini::blocks::LinearFormsBlock(num_vars, coefficients));
 				},
 				(arg("self"), arg("num_vars"), arg("coefficients")),
-				"Add a block of affine linear forms f(x) = M [x;1] to the System, evaluated as a single matrix-vector product rather than as scalar expressions.  coefficients is an mpfr_complex matrix with one row per function and num_vars+1 columns; the trailing column carries each form's constant term.")
+				"Add a block of affine linear forms f(x) = M [x;1] to the System, evaluated as a single matrix-vector product rather than as scalar expressions.  coefficients is an complex_mp matrix with one row per function and num_vars+1 columns; the trailing column carries each form's constant term.")
 			.def("add_products_of_linears_block",
 				+[](SystemBaseT& self, std::size_t num_vars, boost::python::list const& factors) {
 					std::vector<bertini::Mat<mpfr>> v{
@@ -157,7 +157,7 @@ namespace bertini{
 					self.AddBlock(bertini::blocks::ProductsOfLinearsBlock(num_vars, std::move(v)));
 				},
 				(arg("self"), arg("num_vars"), arg("factors")),
-				"Add a block of products-of-linear-forms f_i(x) = prod_r ( c_{i,r} . [x;1] ) to the System, evaluated as matrix-multiplies-then-row-products rather than as scalar expressions.  factors is a list with one entry per function; entry i is an mpfr_complex matrix with one row per linear factor and num_vars+1 columns (the trailing column carries each factor's constant term).  Each function's degree is its number of factors.")
+				"Add a block of products-of-linear-forms f_i(x) = prod_r ( c_{i,r} . [x;1] ) to the System, evaluated as matrix-multiplies-then-row-products rather than as scalar expressions.  factors is a list with one entry per function; entry i is an complex_mp matrix with one row per linear factor and num_vars+1 columns (the trailing column carries each factor's constant term).  Each function's degree is its number of factors.")
 			// .def("add_ungrouped_variable", &SystemBaseT::AddUngroupedVariable,"Add an ungrouped variable to the system.  I honestly don't know why you'd do that.  This should be removed, and is a holdover from Bertini 1")
 			// .def("add_ungrouped_variables", &SystemBaseT::AddUngroupedVariables,"Add some ungrouped variables to the system.  I honestly don't know why you'd do that.  This should be removed, and is a holdover from Bertini 1")
 			// .def("add_implicit_parameter", &SystemBaseT::AddImplicitParameter)
@@ -190,7 +190,7 @@ namespace bertini{
 			.def("randomization_matrix",
 				+[](SystemBaseT const& self) { return self.RandomizationMatrix(); },
 				(arg("self")),
-				"The randomization matrix R (n x N, mpfr_complex) of a system produced by randomize().  Raises if the system has no randomization block.")
+				"The randomization matrix R (n x N, complex_mp) of a system produced by randomize().  Raises if the system has no randomization block.")
 			.def("reorder_functions_by_degree_decreasing", &SystemBaseT::ReorderFunctionsByDegreeDecreasing, (arg("self")),"Change the order of the functions to be in decreasing order")
 			.def("reorder_functions_by_degree_increasing", &SystemBaseT::ReorderFunctionsByDegreeIncreasing, (arg("self")),"Change the order of the functions to be in decreasing order")
 			.def("clear_variables", &SystemBaseT::ClearVariables, (arg("self")), "Remove the variable structure from the system")
@@ -201,18 +201,18 @@ namespace bertini{
 			.def("get_patch",&SystemBaseT::GetPatch, (arg("self")),"Get (a reference to) the patches from the system.")
 			.def("is_patched",&SystemBaseT::IsPatched, (arg("self")),"Check whether the system is patched.")
 
-			.def("rescale_point_to_fit_patch",&SystemBaseT::template RescalePointToFitPatch<dbl>,(arg("self"), arg("point")),"Return a rescaled version of the input point, which fits the patch for the system.")
+			.def("rescale_point_to_fit_patch",&SystemBaseT::template RescalePointToFitPatch<complex_dbl>,(arg("self"), arg("point")),"Return a rescaled version of the input point, which fits the patch for the system.")
 			.def("rescale_point_to_fit_patch",&SystemBaseT::template RescalePointToFitPatch<mpfr>,(arg("self"), arg("point")),"Return a rescaled version of the input point, which fits the patch for the system.")
 
-			.def("rescale_point_to_fit_patch_in_place",&SystemBaseT::template RescalePointToFitPatchInPlace<dbl>,(arg("self"), arg("point")),"Re-scale the input point, in place, to fit the patch for the system.  This assumes you have properly set the variable groups and auto-patched the system.")
+			.def("rescale_point_to_fit_patch_in_place",&SystemBaseT::template RescalePointToFitPatchInPlace<complex_dbl>,(arg("self"), arg("point")),"Re-scale the input point, in place, to fit the patch for the system.  This assumes you have properly set the variable groups and auto-patched the system.")
 
 			// .def("rescale_point_to_fit_patch_in_place",&SystemBaseT::template RescalePointToFitPatchInPlace<mpfr>,"Re-scale the input point, in place, to fit the patch for the system.  This assumes you have properly set the variable groups and auto-patched the system.")
 			.def("rescale_point_to_fit_patch_in_place",&rescale_wrap_inplace_mpfr,(arg("self"), arg("point")),"Re-scale the input point, in place, to fit the patch for the system.  This assumes you have properly set the variable groups and auto-patched the system.")
 
-			.def("dehomogenize_point",&SystemBaseT::template DehomogenizePoint<dbl>,(arg("self"), arg("point")), "Dehomogenize a vector of doubles (complex), using the variable structure in this System")
+			.def("dehomogenize_point",&SystemBaseT::template DehomogenizePoint<complex_dbl>,(arg("self"), arg("point")), "Dehomogenize a vector of doubles (complex), using the variable structure in this System")
 			.def("dehomogenize_point",&SystemBaseT::template DehomogenizePoint<mpfr>,(arg("self"), arg("point")), "Dehomogenize a vector of mpfr's (complex), using the variable structure in this System")
 
-			.def("homogenize_point",&SystemBaseT::template HomogenizePoint<dbl>,(arg("self"), arg("point")), "Take a point in user (dehomogenized) coordinates to this system's internal coordinates: inserts the homogenizing coordinate for each affine variable group, then rescales onto the system's patch if patched.  Inverse of dehomogenize_point.")
+			.def("homogenize_point",&SystemBaseT::template HomogenizePoint<complex_dbl>,(arg("self"), arg("point")), "Take a point in user (dehomogenized) coordinates to this system's internal coordinates: inserts the homogenizing coordinate for each affine variable group, then rescales onto the system's patch if patched.  Inverse of dehomogenize_point.")
 			.def("homogenize_point",&SystemBaseT::template HomogenizePoint<mpfr>,(arg("self"), arg("point")), "Take a point in user (dehomogenized) coordinates to this system's internal coordinates: inserts the homogenizing coordinate for each affine variable group, then rescales onto the system's patch if patched.  Inverse of dehomogenize_point.")
 
 			.def("variable_ordering",&SystemBaseT::VariableOrdering,(arg("self")), "The ordering of variables saying what each coordinate of a point in THIS system's coordinates means.  On your original system these are your variables; on a solver's target_system() the homogenizing variables appear too.")
@@ -241,7 +241,7 @@ namespace bertini{
 		{
 			cl
 			.def("num_start_points", &SystemBaseT::NumStartPoints,(arg("self")), "Get the number of start points that would be required by the system.  Non-negative, unsigned")
-			.def("start_point_d", return_GenStart_ptr<dbl>(),(arg("self"), arg("index")),"Get the k-th start point in double precision")
+			.def("start_point_d", return_GenStart_ptr<complex_dbl>(),(arg("self"), arg("index")),"Get the k-th start point in double precision")
 			.def("start_point_mp", return_GenStart_ptr<mpfr>(),(arg("self"), arg("index")),"Get the k-th start point in current multiple precision")
 			;
 
@@ -367,7 +367,7 @@ namespace bertini{
 		void ExportTotalDegree()
 		{
 			class_<start_system::TotalDegree, bases<start_system::StartSystem>, std::shared_ptr<start_system::TotalDegree> >("TotalDegree",init<System const&>())//,"Only constructor for a TotalDegree start system, requires a system.  You cannot construct one without.  If this is a problem, please contact the authors for help.")
-			.def("random_value", &start_system::TotalDegree::RandomValue<dbl>,(arg("self"), arg("index")), "Get the k-th random value, in double precision")
+			.def("random_value", &start_system::TotalDegree::RandomValue<complex_dbl>,(arg("self"), arg("index")), "Get the k-th random value, in double precision")
 			.def("random_value", &start_system::TotalDegree::RandomValue<mpfr>,(arg("self"), arg("index")), "Get the k-th random value, in current multiple precision")
 			.def("random_values", &start_system::TotalDegree::RandomValues,(arg("self")), return_value_policy<copy_const_reference>(), "Get (a reference to) the random values for the start system, as Nodes")
 			;

--- a/python_bindings/src/tracker_export.cpp
+++ b/python_bindings/src/tracker_export.cpp
@@ -63,7 +63,7 @@ namespace bertini{
 
 		void ExportAMPTracker()
 		{
-			class_<AMPTracker, std::shared_ptr<AMPTracker>, bases<bertini::Observable> >("AMPTracker", "The adaptive multiple precision (AMP) tracker.  Ambient numeric type is multiple-precision (mpfr_complex).  Contruct one by feeding it a system -- cannot be constructed without feeding it a system.  Adjust its settings via configs and the `setup` function.  Then, call method `track_path`.", init<const System&>())
+			class_<AMPTracker, std::shared_ptr<AMPTracker>, bases<bertini::Observable> >("AMPTracker", "The adaptive multiple precision (AMP) tracker.  Ambient numeric type is multiple-precision (complex_mp).  Contruct one by feeding it a system -- cannot be constructed without feeding it a system.  Adjust its settings via configs and the `setup` function.  Then, call method `track_path`.", init<const System&>())
 			.def(TrackerVisitor<AMPTracker>())
 			.def(AMPTrackerVisitor<AMPTracker>())
 			;
@@ -85,7 +85,7 @@ namespace bertini{
 
 		void ExportFixedMultipleTracker()
 		{
-			class_<MultiplePrecisionTracker, std::shared_ptr<MultiplePrecisionTracker>, bases<bertini::Observable> >("MultiplePrecisionTracker", "The fixed multiple precision tracker.  Ambient numeric type is multiple-precision (mpfr_complex).  Precision is the value of bertini.default_precision() at contruction.  Errors if you try to feed it things not at that precision.  Contruct one by feeding it a system -- cannot be constructed without feeding it a system.  Adjust its settings via configs and the `setup` function.  Then, call method `track_path`.", init<const System&>())
+			class_<MultiplePrecisionTracker, std::shared_ptr<MultiplePrecisionTracker>, bases<bertini::Observable> >("MultiplePrecisionTracker", "The fixed multiple precision tracker.  Ambient numeric type is multiple-precision (complex_mp).  Precision is the value of bertini.default_precision() at contruction.  Errors if you try to feed it things not at that precision.  Contruct one by feeding it a system -- cannot be constructed without feeding it a system.  Adjust its settings via configs and the `setup` function.  Then, call method `track_path`.", init<const System&>())
 			.def(TrackerVisitor<MultiplePrecisionTracker>())
 			.def(FixedMultipleTrackerVisitor<MultiplePrecisionTracker>())
 			;

--- a/python_bindings/src/zero_dim_configs_export.cpp
+++ b/python_bindings/src/zero_dim_configs_export.cpp
@@ -84,20 +84,20 @@ namespace bertini{
 			// One ZeroDimConfig for every precision model -- the homotopy times are stored precision-free
 			// (mpq_rational) and converted to the tracking type at use, so the config is no longer
 			// templated on the complex type.  The times are real (the solve tracks the real t-axis);
-			// they are exposed as mpfr_float and round-trip exactly, the same way SteppingConfig exposes
+			// they are exposed as real_mp and round-trip exactly, the same way SteppingConfig exposes
 			// its mpq_rational step sizes.
 			class_<ZeroDimConfig>("ZeroDimConfig", init<>())
 			.add_property("start_time",
-				+[](ZeroDimConfig const& c) -> mpfr_float { return mpfr_float(c.start_time); },
-				+[](ZeroDimConfig& c, mpfr_float const& v) { c.start_time = mpq_rational(v); },
+				+[](ZeroDimConfig const& c) -> real_mp { return real_mp(c.start_time); },
+				+[](ZeroDimConfig& c, real_mp const& v) { c.start_time = mpq_rational(v); },
 				"The time value at which the homotopy starts (where the start solutions live).")
 			.add_property("target_time",
-				+[](ZeroDimConfig const& c) -> mpfr_float { return mpfr_float(c.target_time); },
-				+[](ZeroDimConfig& c, mpfr_float const& v) { c.target_time = mpq_rational(v); },
+				+[](ZeroDimConfig const& c) -> real_mp { return real_mp(c.target_time); },
+				+[](ZeroDimConfig& c, real_mp const& v) { c.target_time = mpq_rational(v); },
 				"The time value the homotopy tracks to (where the solutions of interest live).")
 			.add_property("endgame_boundary",
-				+[](ZeroDimConfig const& c) -> mpfr_float { return mpfr_float(c.endgame_boundary); },
-				+[](ZeroDimConfig& c, mpfr_float const& v) { c.endgame_boundary = mpq_rational(v); },
+				+[](ZeroDimConfig const& c) -> real_mp { return real_mp(c.endgame_boundary); },
+				+[](ZeroDimConfig& c, real_mp const& v) { c.endgame_boundary = mpq_rational(v); },
 				"The time value at which tracking stops and the endgame takes over.")
 			.def_readwrite("max_num_crossed_path_resolve_attempts", &ZeroDimConfig::max_num_crossed_path_resolve_attempts,
 				"How many times to re-track crossed paths (with tightened settings) at the endgame "
@@ -118,11 +118,11 @@ namespace bertini{
 			.def_readwrite("elapsed_time",&AlgorithmMetaData::elapsed_time)
 			;
 
-			ExposeSolutionMetaData<mpfr_complex>("SolutionMetaDataMultiPrec");
-			ExposeSolutionMetaData<dbl_complex>("SolutionMetaDataDoublePrec");
+			ExposeSolutionMetaData<complex_mp>("SolutionMetaDataMultiPrec");
+			ExposeSolutionMetaData<complex_dbl>("SolutionMetaDataDoublePrec");
 
-			ExposeEndgameBoundaryMetaData<mpfr_complex>("EndgameBoundaryMetaDataMultiPrec");
-			ExposeEndgameBoundaryMetaData<dbl_complex>("EndgameBoundaryMetaDataDoublePrec");
+			ExposeEndgameBoundaryMetaData<complex_mp>("EndgameBoundaryMetaDataMultiPrec");
+			ExposeEndgameBoundaryMetaData<complex_dbl>("EndgameBoundaryMetaDataDoublePrec");
 
 			// Report from the path-crossing (midpath) check at the endgame boundary.
 			class_<MidpathCheckReport>("MidpathCheckReport", init<>())


### PR DESCRIPTION
Standardize the four scalar numeric types to lead with the math (real/complex), then the precision (dbl/mp), using **mp** for "multiprecision" rather than the **mpfr** library name:

| was | now |
|---|---|
| `dbl`, `dbl_complex` | `complex_dbl` (`std::complex<double>`) |
| `mpfr_complex` | `complex_mp` (mpc multiprecision complex) |
| `mpfr_float` | `real_mp` (mpfr multiprecision real) |
| *(new)* | `real_dbl` (= `double`; explicit alias so the real-double type lives in one place) |

C++-only sweep across `core/` + `python_bindings/`, done per-context to avoid over-matches (the Boost-qualified `boost::multiprecision::mpfr_float` library type stays, as do the `*_backend` names and the `mpfr_complex.hpp` filename/include paths). The Python value-type binding **names** (`multiprec.Float` / `.Complex`) are unchanged — only the C++ spellings moved.

This is the vocabulary the upcoming tiered-SLP-arithmetic work is written against, but it stands on its own as a clarity win and is landed separately so it's preserved regardless of how the tiered experiment turns out.

## Tests
All 10 C++ suites pass; full pytest green (541 passed); bindings import clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)