### PR TITLE
feat(blackbox): emit Bertini 1.7-compatible solution files + external-solver benchmark

### DIFF
--- a/benchmark/comparison/.gitignore
+++ b/benchmark/comparison/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+# default per-run snapshot CSV (history.csv IS committed; this transient one is not)
+comparison_results.csv

--- a/benchmark/comparison/README.md
+++ b/benchmark/comparison/README.md
@@ -1,0 +1,182 @@
+# Bertini 2 vs other solvers — serial & MPI comparison benchmark
+
+This benchmark measures how fast the **bertini2 CLI** solves zero-dimensional polynomial systems
+compared with other numerical-algebraic-geometry solvers, under **identical settings**, and at the
+same time checks that the solvers **agree on the answer**.
+
+Today the only other solver wired up is **Bertini 1**. The design is solver-agnostic: a future
+phase will add [HomotopyContinuation.jl](https://www.juliahomotopycontinuation.org/) simply by
+adding one more adapter in `solvers.py` — nothing else changes.
+
+These numbers are intended to be reproducible and citable in a paper, so the methodology below is
+spelled out in full.
+
+---
+
+## Why this is a fair comparison
+
+Each test system is built once in Python with pybertini and emitted to a **single classic Bertini
+input file** via `System.to_classic_input(...)`. That one file — same equations, same precision
+mode, same predictor, same tolerances, same step-size cadence — is handed to *every* solver. So
+"same settings in both" is not a promise we have to police; it is true by construction. (The
+emitter is exercised by `python/test/classes/classic_writer_test.py` and round-trip fidelity is
+pinned in C++ by `classic_parsing_test::classic_writer_round_trips_a_system`.)
+
+Two phases:
+
+1. **Serial** — one process, one thread. The MPI-built binaries are simply run directly (a single
+   MPI process), which is the serial baseline.
+2. **MPI, single thread** — `mpirun -n N` with `OMP_NUM_THREADS=1`, sweeping `--ranks`.
+
+## Correctness/agreement comes for free — and is *not* part of the timing
+
+Because all solvers read the same input, every solver should return the **same number of
+solutions**, equal to the system's known count. The driver reports this as a `matches_expected`
+column and flags any disagreement.
+
+Both solvers are parsed with **one** parser: the Bertini 2 CLI now writes Bertini 1.7-compatible
+machine-readable solution files (`finite_solutions`, `real_finite_solutions`,
+`nonsingular_solutions`, `singular_solutions`, `raw_solutions` — each count-led; see ADR-0034), so
+the count comes from `finite_solutions` for both. Byte-for-byte equality with Bertini 1 is *not*
+expected (different implementations and RNG); only the file format and the solution *count* match.
+
+This check is performed **after** the timed region, by reading each solver's output files. The
+stopwatch (`time.perf_counter()`) brackets **only** the solve subprocess; parsing solution counts
+and comparing them adds nothing to any reported wall time.
+
+---
+
+## Prerequisites
+
+- An **MPI-built `bertini2`** (`cmake -DENABLE_MPI=ON ...`; target `bertini2_exe`, binary
+  `./build/core/bertini2`).
+- For the Bertini 1 column, an **MPI-built Bertini 1** binary (you supply it; it is not part of
+  this repo). Point `--bertini1` at it.
+- `mpirun` on `PATH` for any `--ranks` greater than 1.
+- `pybertini` importable (the `bertini` Python package, matching your built `_pybertini`).
+
+> Both Bertini 1 and the bertini2 CLI write their output files (`main_data`, `raw_data`, `output`,
+> `failed_paths`, …) into the current directory. The driver runs **every** invocation in its own
+> fresh temp directory and deletes it afterward, so runs never collide and nothing is left behind.
+
+---
+
+## How to run
+
+Serial only, bertini2 vs Bertini 1, on the default system subset:
+
+```bash
+python benchmark/comparison/run_comparison.py \
+    --bertini2 ./build/core/bertini2 \
+    --bertini1 /path/to/bertini \
+    --output comparison_results.csv
+```
+
+Pick systems explicitly and add an MPI single-thread sweep:
+
+```bash
+python benchmark/comparison/run_comparison.py \
+    --bertini2 ./build/core/bertini2 \
+    --bertini1 /path/to/bertini \
+    --systems cyclic6 cyclic7 katsura5 \
+    --ranks 1 2 4 8
+```
+
+bertini2 only (no Bertini 1 installed) — still times and checks counts:
+
+```bash
+python benchmark/comparison/run_comparison.py --bertini2 ./build/core/bertini2 --systems all
+```
+
+Key options: `--systems NAME ... | all`, `--ranks N ...`, `--repeats N` (keep fastest),
+`--timeout SECS`, `--mptype {0,1,2}`, `--predictor {0,2,5}`, `--mpirun`, `--mpirun-args`,
+`--output FILE`. Run with `-h` for the full list.
+
+For publishable numbers: use a quiet, non-throttling machine and `--repeats 3` or more (the fastest
+time is kept).
+
+---
+
+## Historical data (tracking b2's performance over time)
+
+Every run **appends** one row per measurement to a committed history file (default
+`benchmark/comparison/history.csv`; `--history FILE` to redirect, `--no-history` to skip). Each row
+records full provenance so results stay interpretable years later:
+
+```
+timestamp, host, cpu, os, b2_commit, mptype, predictor,
+solver, solver_version, system, ranks, threads,
+wall_time_s, solutions_found, expected_count, matches_expected, note
+```
+
+Commit this file. As you improve Bertini 2, new rows accumulate and you can plot wall time for a
+given `(system, solver, ranks)` over `b2_commit`/`timestamp` to *see* the speedups land. Use
+`--note` to tag a row (e.g. `--note "after SLP rework"`).
+
+**Wall-times are only comparable within the same machine.** `host`+`cpu` are recorded precisely so
+you filter to one machine before comparing across time; a `b2_commit` ending in `-dirty` means the
+working tree had uncommitted changes (not a clean, citable point). Bertini 1 will likely never move,
+but HomotopyContinuation.jl is actively developed, so its `solver_version` matters too.
+
+---
+
+## Test bed
+
+All systems are genuinely zero-dimensional, so the solution count is a fixed known value used as
+the correctness ground truth. Generators live in `systems.py`; add a family by registering a
+builder in the `SYSTEMS` dict.
+
+| Name(s)            | Family    | Vars | Solutions | Notes |
+|--------------------|-----------|------|-----------|-------|
+| `diag3/5/6`        | diagonal  | 3/5/6 | 27/243/729 | `xᵢ³ − cᵢ`; trivial warmup/sanity tier |
+| `cyclic5`          | cyclic-n  | 5    | 70        | |
+| `cyclic6`          | cyclic-n  | 6    | 156       | |
+| `cyclic7`          | cyclic-n  | 7    | 924       | |
+| `katsura3..6`      | Katsura-n | 4..7 | 2ⁿ (8..64)| |
+
+**cyclic-n caveat:** cyclic-n is zero-dimensional only when *n* is squarefree (Backelin). The
+squarefree small cases are n ∈ {5, 6, 7, 10, 11}; n ∈ {4, 8, 9, 12, …} have positive-dimensional
+components and are **not** valid zero-dim test cases, so they are not registered. The `cyclic(n)`
+generator accepts any n, but only register squarefree ones.
+
+---
+
+## Results
+
+Fill these in from your runs (machine, date, and `bertini2`/Bertini 1 versions matter — record
+them). `b1/b2` is the wall-time ratio (>1 means bertini2 was faster).
+
+### Serial (ranks=1, threads=1)
+
+| System  | bertini2 (s) | bertini1 (s) | b1/b2 | counts agree |
+|---------|--------------|--------------|-------|--------------|
+| cyclic6 |              |              |       |              |
+| cyclic7 |              |              |       |              |
+| katsura5|              |              |       |              |
+
+### MPI, single thread (sweep ranks)
+
+| System  | ranks | bertini2 (s) | bertini1 (s) | b1/b2 |
+|---------|-------|--------------|--------------|-------|
+| cyclic7 | 1     |              |              |       |
+| cyclic7 | 2     |              |              |       |
+| cyclic7 | 4     |              |              |       |
+
+Environment to record alongside results: CPU model, core count, OS, `bertini2` version/commit, the
+Bertini 1 version, MPI implementation, and the `--mptype`/`--predictor` used.
+
+---
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `run_comparison.py` | Driver: emit shared input, run each solver, time, parse, tabulate, write CSV |
+| `systems.py`        | Python generators for the test bed (cyclic-n, Katsura-n, diagonal) |
+| `solvers.py`        | Solver adapters (`bertini2`, `bertini1`) behind one `run() -> RunResult` interface |
+
+## Future work
+
+Add a HomotopyContinuation.jl adapter to `solvers.py` (and an entry to `ADAPTERS`). It writes its
+own problem from the same system rather than the classic input, so the "same settings" guarantee
+will need an equivalent mapping of tracking knobs — note that explicitly when added.

--- a/benchmark/comparison/run_comparison.py
+++ b/benchmark/comparison/run_comparison.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Benchmark the bertini2 CLI against other zero-dim solvers (Bertini 1 today) on the same systems.
+
+Each test system is built in Python with pybertini and emitted ONCE to a classic Bertini-1 input
+file (System.to_classic_input). That single file is fed to every solver, so the problem and all
+tracking settings (precision mode, predictor, tolerances, step cadence) are identical across
+solvers by construction. Two phases:
+
+  * serial            -- one process, one thread, every system through every solver;
+  * MPI single-thread -- sweep --ranks with OMP_NUM_THREADS=1, each solver under `mpirun -n N`.
+
+We get a correctness/agreement check for free: every solver should report the same solution count,
+equal to the system's known expected count. That check is done AFTER timing, from output files, and
+is NEVER part of any reported wall time.
+
+Usage:
+    python benchmark/comparison/run_comparison.py \
+        --bertini2 ./build/core/bertini2 \
+        --bertini1 /path/to/bertini \
+        --systems cyclic6 katsura5 \
+        --ranks 1 2 4 \
+        --output comparison_results.csv
+
+Requirements:
+    - an MPI-built bertini2 and (for the bertini1 column) an MPI-built Bertini 1
+    - mpirun on PATH for the rank sweep (--ranks beyond 1)
+    - pybertini importable (the `bertini` package)
+"""
+
+import argparse
+import csv
+import datetime
+import math
+import os
+import platform
+import shutil
+import subprocess
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.dirname(os.path.dirname(HERE))           # benchmark/comparison -> repo root
+DEFAULT_HISTORY = os.path.join(HERE, "history.csv")          # committed, append-only
+
+sys.path.insert(0, HERE)
+import solvers          # noqa: E402
+import systems          # noqa: E402
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description="Compare bertini2 vs other solvers on the same systems")
+    p.add_argument("--bertini2", default="./build/core/bertini2",
+                   help="Path to the bertini2 executable (default: ./build/core/bertini2)")
+    p.add_argument("--bertini1", default=None,
+                   help="Path to a Bertini 1 executable. If omitted, only bertini2 is run.")
+    p.add_argument("--systems", nargs="+", default=systems.DEFAULT_SYSTEMS,
+                   help=f"System names, or 'all' (default: {' '.join(systems.DEFAULT_SYSTEMS)}). "
+                        f"Known: {', '.join(sorted(systems.SYSTEMS))}")
+    p.add_argument("--ranks", nargs="+", type=int, default=[1],
+                   help="MPI rank counts (single-thread) to sweep (default: 1 = serial only)")
+    p.add_argument("--repeats", type=int, default=1,
+                   help="Timed repeats per (system, solver, ranks); the fastest is kept (default: 1)")
+    p.add_argument("--timeout", type=float, default=600.0, help="Per-run timeout, seconds (default: 600)")
+    p.add_argument("--mpirun", default="mpirun", help="MPI launcher for rank sweeps (default: mpirun)")
+    p.add_argument("--mpirun-args", default="--bind-to none",
+                   help="Extra flags before -n, one quoted string (default: '--bind-to none')")
+    p.add_argument("--output", default="comparison_results.csv",
+                   help="Per-run snapshot CSV (overwritten each run)")
+    p.add_argument("--history", default=DEFAULT_HISTORY,
+                   help=f"Append-only history CSV, committed to the repo so performance can be "
+                        f"tracked over time (default: {os.path.relpath(DEFAULT_HISTORY, REPO_ROOT)})")
+    p.add_argument("--no-history", action="store_true",
+                   help="Do not append to the history file (just write the per-run --output CSV)")
+    p.add_argument("--note", default="",
+                   help="Free-text note recorded with each history row (e.g. 'after SLP rework')")
+    # Tracking knobs, emitted into the shared classic input (identical for every solver).
+    p.add_argument("--mptype", type=int, default=2, help="0 double, 1 fixed-multiple, 2 adaptive (default 2)")
+    p.add_argument("--predictor", type=int, default=5, help="odepredictor: 0 Euler, 2 RK4, 5 RKF45 (default 5)")
+    return p.parse_args()
+
+
+def _git_commit():
+    """Short b2 commit hash, with a -dirty suffix if the working tree has uncommitted changes."""
+    try:
+        commit = subprocess.run(["git", "-C", REPO_ROOT, "rev-parse", "--short", "HEAD"],
+                                capture_output=True, text=True).stdout.strip()
+        dirty = subprocess.run(["git", "-C", REPO_ROOT, "status", "--porcelain"],
+                               capture_output=True, text=True).stdout.strip()
+        return (commit or "unknown") + ("-dirty" if dirty else "")
+    except OSError:
+        return "unknown"
+
+
+def _cpu_brand():
+    """Human-readable CPU model -- timings are only comparable across rows with the same CPU."""
+    try:
+        if platform.system() == "Darwin":
+            return subprocess.run(["sysctl", "-n", "machdep.cpu.brand_string"],
+                                  capture_output=True, text=True).stdout.strip() or "unknown"
+        if platform.system() == "Linux":
+            with open("/proc/cpuinfo") as f:
+                for line in f:
+                    if line.startswith("model name"):
+                        return line.split(":", 1)[1].strip()
+    except OSError:
+        pass
+    return platform.processor() or "unknown"
+
+
+def _solver_version(exe):
+    """First line of `<solver> --version`; 'unknown' if it doesn't support the flag."""
+    try:
+        out = subprocess.run([os.path.abspath(exe), "--version"],
+                             capture_output=True, text=True, timeout=15)
+        text = (out.stdout + out.stderr).strip()
+        return text.splitlines()[0][:120] if text else "unknown"
+    except (OSError, subprocess.SubprocessError):
+        return "unknown"
+
+
+def build_metadata(solver_cols, mptype, predictor, note):
+    """Per-invocation provenance recorded on every history row (machine, date, versions, settings)."""
+    return {
+        "timestamp": datetime.datetime.now().astimezone().isoformat(timespec="seconds"),
+        "host": platform.node(),
+        "cpu": _cpu_brand(),
+        "os": platform.platform(),
+        "b2_commit": _git_commit(),
+        "mptype": mptype,
+        "predictor": predictor,
+        "note": note,
+        "_versions": {name: _solver_version(exe) for name, exe in solver_cols},
+    }
+
+
+HISTORY_FIELDS = ["timestamp", "host", "cpu", "os", "b2_commit", "mptype", "predictor",
+                  "solver", "solver_version", "system", "ranks", "threads",
+                  "wall_time_s", "solutions_found", "expected_count", "matches_expected", "note"]
+
+
+def append_history(path, rows, meta):
+    """Append one history row per measurement; write the header if the file is new."""
+    is_new = not os.path.exists(path)
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    with open(path, "a", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=HISTORY_FIELDS)
+        if is_new:
+            w.writeheader()
+        for r in rows:
+            w.writerow({
+                "timestamp": meta["timestamp"], "host": meta["host"], "cpu": meta["cpu"],
+                "os": meta["os"], "b2_commit": meta["b2_commit"],
+                "mptype": meta["mptype"], "predictor": meta["predictor"], "note": meta["note"],
+                "solver": r["solver"], "solver_version": meta["_versions"].get(r["solver"], ""),
+                "system": r["system"], "ranks": r["ranks"], "threads": r["threads"],
+                "wall_time_s": r["wall_time_s"], "solutions_found": r["solutions_found"],
+                "expected_count": r["expected_count"], "matches_expected": r["matches_expected"],
+            })
+
+
+def emit_input(system, mptype, predictor):
+    """Build the single classic-Bertini input string shared by all solvers for this system."""
+    return system.to_classic_input(mptype=mptype, odepredictor=predictor)
+
+
+def timed(adapter, exe, input_text, ranks, mpirun, mpirun_args, timeout, repeats):
+    """Run one (solver, system, ranks) cell `repeats` times; keep the fastest valid time.
+
+    Solution count comes from the runs (it is constant across repeats); timing is the minimum.
+    """
+    best_time = float("nan")
+    solutions = -1
+    detail = ""
+    for _ in range(repeats):
+        r = adapter(exe, input_text, ranks=ranks, threads=1,
+                    mpirun=mpirun, mpirun_args=mpirun_args, timeout=timeout)
+        detail = r.detail
+        if r.ok:
+            solutions = r.solutions_found
+            if math.isnan(best_time) or r.wall_time_s < best_time:
+                best_time = r.wall_time_s
+    return best_time, solutions, detail
+
+
+def main():
+    args = parse_args()
+
+    names = sorted(systems.SYSTEMS) if args.systems == ["all"] else args.systems
+    for n in names:
+        if n not in systems.SYSTEMS:
+            sys.exit(f"Error: unknown system {n!r}. Known: {', '.join(sorted(systems.SYSTEMS))}")
+    def resolve(exe):
+        """Accept either a path to an executable or a bare command resolved on PATH."""
+        return exe if os.path.isfile(exe) else shutil.which(exe)
+
+    bertini2 = resolve(args.bertini2)
+    if not bertini2:
+        sys.exit(f"Error: bertini2 not found: {args.bertini2}")
+
+    if args.bertini1:
+        bertini1 = resolve(args.bertini1)
+        if not bertini1:
+            sys.exit(f"Error: bertini1 not found: {args.bertini1}")
+    else:
+        # Auto-detect Bertini 1, conventionally installed as `bertini` on PATH.
+        bertini1 = shutil.which("bertini")
+        if bertini1:
+            print(f"Auto-detected Bertini 1 on PATH: {bertini1}  (use --bertini1 to override)")
+
+    ranks_list = sorted(set(args.ranks) | {1})              # always include the serial baseline
+    needs_mpi = any(r > 1 for r in ranks_list)
+    if needs_mpi and shutil.which(args.mpirun) is None:
+        sys.exit(f"Error: {args.mpirun!r} not on PATH but --ranks includes >1")
+    if bertini1 is None:
+        print("NOTE: no Bertini 1 found; running bertini2 only (no cross-solver comparison).\n")
+
+    solver_cols = [("bertini2", bertini2)]
+    if bertini1:
+        solver_cols.append(("bertini1", bertini1))
+
+    print(f"systems:   {names}")
+    print(f"solvers:   {[s for s, _ in solver_cols]}")
+    print(f"ranks:     {ranks_list}   (threads fixed at 1)")
+    print(f"settings:  mptype={args.mptype}, odepredictor={args.predictor}  (identical for all solvers)")
+    print(f"repeats:   {args.repeats}\n")
+
+    rows = []
+    for name in names:
+        system, expected = systems.build(name)
+        input_text = emit_input(system, args.mptype, args.predictor)
+
+        for ranks in ranks_list:
+            for solver_name, exe in solver_cols:
+                adapter = solvers.ADAPTERS[solver_name]
+                label = f"{name:10s} {solver_name:9s} ranks={ranks}"
+                print(f"Running {label} ... ", end="", flush=True)
+                t, found, detail = timed(adapter, exe, input_text, ranks,
+                                         args.mpirun, args.mpirun_args, args.timeout, args.repeats)
+                match = "yes" if (found == expected) else "NO"
+                if math.isnan(t):
+                    print(f"failed ({detail})")
+                else:
+                    flag = "" if match == "yes" else f"  <-- count {found} != expected {expected}"
+                    print(f"{t:8.3f}s  ({found} solutions){flag}")
+                rows.append({
+                    "system": name, "solver": solver_name, "ranks": ranks, "threads": 1,
+                    "wall_time_s": f"{t:.4f}" if not math.isnan(t) else "nan",
+                    "solutions_found": found, "expected_count": expected,
+                    "matches_expected": match, "detail": detail,
+                })
+
+    fieldnames = ["system", "solver", "ranks", "threads", "wall_time_s",
+                  "solutions_found", "expected_count", "matches_expected", "detail"]
+    with open(args.output, "w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=fieldnames)
+        w.writeheader()
+        w.writerows(rows)
+
+    if not args.no_history:
+        meta = build_metadata(solver_cols, args.mptype, args.predictor, args.note)
+        append_history(args.history, rows, meta)
+
+    _print_summary(rows, names, ranks_list, solver_cols)
+    print(f"\nPer-run results written to: {args.output}")
+    if not args.no_history:
+        print(f"Appended {len(rows)} row(s) to history:  {args.history}  "
+              f"(commit this file to track performance over time)")
+
+    # Correctness gate is reported, not timed: did everything that ran match its expected count?
+    bad = [r for r in rows if r["wall_time_s"] != "nan" and r["matches_expected"] != "yes"]
+    if bad:
+        print(f"\nWARNING: {len(bad)} run(s) did not match the expected solution count "
+              f"(see matches_expected column).")
+
+
+def _print_summary(rows, names, ranks_list, solver_cols):
+    """Side-by-side timing table per system & rank, plus the bertini2/bertini1 speed ratio."""
+    solver_names = [s for s, _ in solver_cols]
+    print()
+    header = f"{'system':10s} {'ranks':>5s} " + "".join(f"{s+'(s)':>13s}" for s in solver_names)
+    if {"bertini2", "bertini1"} <= set(solver_names):
+        header += f"{'b1/b2':>9s}"
+    print(header)
+    print("-" * len(header))
+    by_key = {(r["system"], r["solver"], r["ranks"]): r for r in rows}
+    for name in names:
+        for ranks in ranks_list:
+            line = f"{name:10s} {ranks:5d} "
+            times = {}
+            for s in solver_names:
+                r = by_key.get((name, s, ranks))
+                t = r["wall_time_s"] if r else "nan"
+                times[s] = t
+                line += f"{t:>13s}"
+            if {"bertini2", "bertini1"} <= set(solver_names):
+                try:
+                    ratio = float(times["bertini1"]) / float(times["bertini2"])
+                    line += f"{ratio:>9.2f}"
+                except (ValueError, ZeroDivisionError):
+                    line += f"{'-':>9s}"
+            print(line)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/comparison/solvers.py
+++ b/benchmark/comparison/solvers.py
@@ -1,0 +1,137 @@
+"""Solver adapters for the external-solver comparison benchmark.
+
+Each adapter runs one CLI solver on a given classic-Bertini input *string*, in its own fresh
+scratch directory (both Bertini 1 and the bertini2 CLI pollute their CWD with main_data,
+raw_data, output, failed_paths, ... -- isolation keeps runs from colliding and keeps the repo
+clean), times only the subprocess, and -- separately, after timing -- parses the solution count
+from the files the run wrote.
+
+Adding HomotopyContinuation.jl later is just a new adapter with the same ``run(...) -> RunResult``
+shape; nothing else in the suite needs to change.
+
+IMPORTANT: timing measures ONLY the solve subprocess (perf_counter brackets subprocess.run).
+Parsing the solution count and checking agreement happen afterwards, from already-written output
+files, and are never included in any reported wall time.
+"""
+
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import tempfile
+import time
+from collections import namedtuple
+
+# wall_time_s: float (nan on failure); solutions_found: int (-1 if unparseable);
+# ok: did the process exit 0 and produce a parseable count; detail: short human note.
+RunResult = namedtuple("RunResult", ["wall_time_s", "solutions_found", "ok", "detail"])
+
+
+def _launch(exe, ranks, mpirun, mpirun_args):
+    """Build the argv to launch a solver: direct for serial, under mpirun for an MPI rank sweep."""
+    exe = os.path.abspath(exe)
+    if ranks <= 1:
+        # Serial: invoke the binary directly. An MPI-built binary run without mpirun is a single
+        # MPI process, which is exactly the serial baseline we want.
+        return [exe]
+    return [mpirun, *shlex.split(mpirun_args), "-n", str(ranks), exe]
+
+
+def _time_run(argv, input_text, threads, timeout):
+    """Run argv in a fresh scratch dir with the given input; time ONLY the subprocess.
+
+    Returns (wall_time_s, returncode, scratch_dir, stderr_tail).  Caller parses output files in
+    scratch_dir, then removes it.  wall_time_s is nan on timeout.
+    """
+    scratch = tempfile.mkdtemp(prefix="b2_cmp_")
+    with open(os.path.join(scratch, "input"), "w") as f:   # both solvers read a file named "input"
+        f.write(input_text)
+
+    env = os.environ.copy()
+    env["OMP_NUM_THREADS"] = str(threads)                  # single-thread for this benchmark phase
+
+    t0 = time.perf_counter()
+    try:
+        # stdin=DEVNULL is essential: the solvers read no input, but if stdin is an inherited
+        # pipe/tty they can block forever waiting on it (observed as a hang under capture).
+        proc = subprocess.run(argv, cwd=scratch, env=env, stdin=subprocess.DEVNULL,
+                              capture_output=True, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        return float("nan"), None, scratch, "timeout"
+    t1 = time.perf_counter()
+    stderr_tail = proc.stderr.decode(errors="replace")[-500:]
+    return t1 - t0, proc.returncode, scratch, stderr_tail
+
+
+def _count_from_first_int_line(path):
+    """A classic Bertini solution file begins with an integer count on its first line."""
+    try:
+        with open(path) as f:
+            return int(f.readline().strip())
+    except (OSError, ValueError):
+        return -1
+
+
+# --------------------------------------------------------------------------------------------
+# Adapters
+# --------------------------------------------------------------------------------------------
+
+def _run_classic(exe, input_text, ranks, threads, mpirun, mpirun_args, timeout):
+    """Run a solver that writes Bertini 1.7 classic output files; return a RunResult.
+
+    Both Bertini 1 and (as of the classic-output work) the Bertini 2 CLI write the count-led
+    `finite_solutions` file, so a single parser serves both.
+    """
+    argv = _launch(exe, ranks, mpirun, mpirun_args)
+    wall, rc, scratch, err = _time_run(argv, input_text, threads, timeout)
+    try:
+        if wall != wall:                                   # nan -> timeout
+            return RunResult(float("nan"), -1, False, "timeout")
+        if rc != 0:
+            return RunResult(float("nan"), -1, False, f"exit {rc}: {err}")
+        count = _finite_solution_count(scratch)
+        return RunResult(wall, count, count >= 0, "ok" if count >= 0 else "unparseable output")
+    finally:
+        shutil.rmtree(scratch, ignore_errors=True)
+
+
+def _finite_solution_count(scratch):
+    """Solution count from the classic count-led solution files (first line is the count).
+
+    `finite_solutions` is the apples-to-apples cross-solver count; fall back to the other
+    count-led files, then a regex scrape of main_data as a last resort.
+    """
+    for name in ("finite_solutions", "nonsingular_solutions", "real_finite_solutions",
+                 "raw_solutions"):
+        c = _count_from_first_int_line(os.path.join(scratch, name))
+        if c >= 0:
+            return c
+    try:
+        with open(os.path.join(scratch, "main_data")) as f:
+            text = f.read()
+        m = re.search(r"(\d+)\s+(?:finite\s+)?solutions", text, re.IGNORECASE)
+        if m:
+            return int(m.group(1))
+    except OSError:
+        pass
+    return -1
+
+
+def run_bertini2(exe, input_text, *, ranks=1, threads=1,
+                 mpirun="mpirun", mpirun_args="--bind-to none", timeout=600.0):
+    """Run the bertini2 CLI (writes Bertini 1.7-compatible solution files)."""
+    return _run_classic(exe, input_text, ranks, threads, mpirun, mpirun_args, timeout)
+
+
+def run_bertini1(exe, input_text, *, ranks=1, threads=1,
+                 mpirun="mpirun", mpirun_args="--bind-to none", timeout=600.0):
+    """Run Bertini 1.7 (assumed MPI-built)."""
+    return _run_classic(exe, input_text, ranks, threads, mpirun, mpirun_args, timeout)
+
+
+# Registry of available solver adapters, keyed by the column name used in output.
+ADAPTERS = {
+    "bertini2": run_bertini2,
+    "bertini1": run_bertini1,
+}

--- a/benchmark/comparison/systems.py
+++ b/benchmark/comparison/systems.py
@@ -1,0 +1,126 @@
+"""Test-bed polynomial systems for the external-solver comparison benchmark.
+
+Every system is built in Python with pybertini and is genuinely zero-dimensional, so the
+solution count is a known constant we can use as a correctness check (see ``expected_count``).
+The driver emits each system *once* to a classic Bertini-1 input file via
+``System.to_classic_input(...)`` and feeds that single file to every solver, so the problem and
+all tracking settings are identical across solvers by construction.
+
+Add a new family by writing a generator that returns a built ``bertini.System`` and registering
+it in ``SYSTEMS``.  Keep generators free of any solver- or timing-specific concerns.
+"""
+
+import functools
+import operator
+
+import bertini as pb
+
+
+def _product(factors):
+    """Symbolic product of a non-empty list of nodes."""
+    return functools.reduce(operator.mul, factors)
+
+
+def _sum(terms):
+    """Symbolic sum of a non-empty list of nodes."""
+    return functools.reduce(operator.add, terms)
+
+
+# --------------------------------------------------------------------------------------------
+# Families
+# --------------------------------------------------------------------------------------------
+
+def cyclic(n):
+    """The cyclic-n roots system in n variables.
+
+    Equations: for k = 1 .. n-1 the sum of all length-k cyclic products of the variables, plus
+    the closing relation (product of all variables) - 1.
+
+    cyclic-n is zero-dimensional only when n is squarefree (Backelin); n in {5, 6, 7, 10, 11}
+    are the small squarefree cases.  n in {4, 8, 9, 12, ...} have positive-dimensional
+    components and are NOT valid zero-dim test cases -- don't register them.
+    """
+    x = pb.variables('x', n)               # x0 .. x_{n-1}
+    sys = pb.System()
+    sys.add_variable_group(pb.VariableGroup(x))
+
+    for k in range(1, n):
+        terms = [_product([x[(i + j) % n] for j in range(k)]) for i in range(n)]
+        sys.add_function(_sum(terms))
+    sys.add_function(_product(x) - 1)
+    return sys
+
+
+def katsura(n):
+    """The Katsura-n system in n+1 variables (x0 .. xn), with 2**n solutions.
+
+    Uses the symmetric-index convention: x_{-i} = x_i, and x_i = 0 for |i| > n.  For
+    m = 0 .. n-1 the convolution  sum_j x_{|j|} x_{|m-j|} - x_m = 0, plus the normalization
+    x0 + 2*(x1 + ... + xn) - 1 = 0.
+    """
+    x = pb.variables('x', n + 1)           # x0 .. xn
+    sys = pb.System()
+    sys.add_variable_group(pb.VariableGroup(x))
+
+    for m in range(n):
+        terms = []
+        for j in range(-n, n + 1):
+            a, b = abs(j), abs(m - j)
+            if a <= n and b <= n:
+                terms.append(x[a] * x[b])
+        sys.add_function(_sum(terms) - x[m])
+    sys.add_function(x[0] + 2 * _sum(x[1:]) - 1)
+    return sys
+
+
+def diagonal(n, degree=3):
+    """The diagonal warmup family x_i**degree - c_i, with degree**n solutions.
+
+    Trivially zero-dimensional with analytically known roots -- a fast sanity tier mirroring the
+    existing benchmark/inputs/*.b2 systems.  The c_i are distinct small primes.
+    """
+    primes = [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37]
+    if n > len(primes):
+        raise ValueError(f"diagonal: need {n} distinct constants, have {len(primes)} primes")
+    x = pb.variables('x', n)
+    sys = pb.System()
+    sys.add_variable_group(pb.VariableGroup(x))
+    for i in range(n):
+        sys.add_function(x[i] ** degree - primes[i])
+    return sys
+
+
+# --------------------------------------------------------------------------------------------
+# Registry: name -> (builder, expected solution count)
+# --------------------------------------------------------------------------------------------
+# expected_count is the number of isolated complex solutions of the (zero-dimensional) system;
+# it is the ground truth for the correctness / agreement check, never part of any timing.
+
+SYSTEMS = {
+    # diagonal warmup tier (fast sanity)
+    "diag3":    (lambda: diagonal(3), 27),
+    "diag5":    (lambda: diagonal(5), 243),
+    "diag6":    (lambda: diagonal(6), 729),
+
+    # cyclic-n (squarefree n only: genuinely zero-dimensional)
+    "cyclic5":  (lambda: cyclic(5), 70),
+    "cyclic6":  (lambda: cyclic(6), 156),
+    "cyclic7":  (lambda: cyclic(7), 924),
+
+    # Katsura-n (2**n solutions)
+    "katsura3": (lambda: katsura(3), 8),
+    "katsura4": (lambda: katsura(4), 16),
+    "katsura5": (lambda: katsura(5), 32),
+    "katsura6": (lambda: katsura(6), 64),
+}
+
+# Sensible default subset for a quick run: one of each family, mid-sized.
+DEFAULT_SYSTEMS = ["diag5", "cyclic6", "katsura5"]
+
+
+def build(name):
+    """Return (system, expected_count) for a registered name."""
+    if name not in SYSTEMS:
+        raise KeyError(f"unknown system {name!r}; known: {', '.join(sorted(SYSTEMS))}")
+    builder, expected = SYSTEMS[name]
+    return builder(), expected

--- a/core/include/bertini2/nag_algorithms/output.hpp
+++ b/core/include/bertini2/nag_algorithms/output.hpp
@@ -114,8 +114,68 @@ struct Classic <ZeroDim<A,B,C,D,E>>
 	}
 
 
+	// --- Bertini 1.7 machine-readable solution files -------------------------------------
+	//
+	// These mirror the classic solution-file format so that tooling written against Bertini 1.7
+	// reads Bertini 2's output unchanged: the first line is the solution count, then each
+	// solution is a block of NumVariables coordinate lines ("re im", scientific), blocks
+	// separated by a blank line.  Byte-for-byte equality with Bertini 1 is neither sought nor
+	// possible (different implementations and RNG); the contract is *machine-readable* parity.
+	// Coordinates are in user (dehomogenized) coordinates, as Bertini 1 reports them.
+
+	// Write a count-led list of solution points (each a Vec): "<count>\n\n" then, per point,
+	// the coordinate lines followed by a blank-line separator.
+	template <typename OutT, typename SolListT>
+	static void SolutionList(OutT & out, SolListT const& sols)
+	{
+		out << sols.size() << "\n\n";
+		for (auto const& v : sols)
+		{
+			generators::Classic::generate(boost::spirit::ostream_iterator(out), v);
+			out << "\n";
+		}
+	}
+
 	template <typename OutT>
-	static 
+	static void FiniteSolutions(OutT & out, ZDT const& zd)      { SolutionList(out, zd.FiniteSolutions()); }
+
+	template <typename OutT>
+	static void RealFiniteSolutions(OutT & out, ZDT const& zd)  { SolutionList(out, zd.RealSolutions()); }
+
+	template <typename OutT>
+	static void NonsingularSolutions(OutT & out, ZDT const& zd) { SolutionList(out, zd.NonsingularSolutions()); }
+
+	template <typename OutT>
+	static void SingularSolutions(OutT & out, ZDT const& zd)    { SolutionList(out, zd.SingularSolutions()); }
+
+	// raw_solutions: every successful endpoint, each preceded by its path number (Bertini 1 lists
+	// the raw endpoints before finite/infinite classification, tagged by path).
+	template <typename OutT>
+	static void RawSolutions(OutT & out, ZDT const& zd)
+	{
+		auto const& md   = zd.FinalSolutionMetadata();
+		auto const& sols = zd.SolutionsUserCoords();
+		const auto m = std::min(md.size(), sols.size());
+
+		std::size_t count{0};
+		for (std::size_t ii{0}; ii<m; ++ii)
+			if (md[ii].endgame_success == SuccessCode::Success)
+				++count;
+
+		out << count << "\n\n";
+		for (std::size_t ii{0}; ii<m; ++ii)
+		{
+			if (md[ii].endgame_success != SuccessCode::Success)
+				continue;
+			out << md[ii].path_index << "\n";
+			generators::Classic::generate(boost::spirit::ostream_iterator(out), sols[ii]);
+			out << "\n";
+		}
+	}
+
+
+	template <typename OutT>
+	static
 	void NumVariables(OutT & out, ZDT const& zd, std::string const& additional = "\n")
 	{
 		const auto& sys = zd.TargetSystem();

--- a/core/include/bertini2/nag_algorithms/zero_dim_solve.hpp
+++ b/core/include/bertini2/nag_algorithms/zero_dim_solve.hpp
@@ -90,6 +90,12 @@ struct AnyZeroDim : public virtual AnyAlgorithm
 {
 	virtual void WriteMainData(std::ostream& out) const = 0;
 	virtual void WriteRawData(std::ostream& out)  const = 0;
+	// Bertini 1.7-compatible machine-readable solution files (count-led coordinate blocks).
+	virtual void WriteFiniteSolutions(std::ostream& out)      const = 0;
+	virtual void WriteRealFiniteSolutions(std::ostream& out)  const = 0;
+	virtual void WriteNonsingularSolutions(std::ostream& out) const = 0;
+	virtual void WriteSingularSolutions(std::ostream& out)    const = 0;
+	virtual void WriteRawSolutions(std::ostream& out)         const = 0;
 	virtual void ApplyParsedConfigs(std::string const& config_str) = 0;
 	virtual ~AnyZeroDim() = default;
 };
@@ -682,6 +688,11 @@ std::ostream& operator<<(std::ostream & out, const SolveReport & r)
 			// output.hpp is included (avoiding a circular-include chicken-and-egg).
 			void WriteMainData(std::ostream& out) const override;
 			void WriteRawData(std::ostream& out)  const override;
+			void WriteFiniteSolutions(std::ostream& out)      const override;
+			void WriteRealFiniteSolutions(std::ostream& out)  const override;
+			void WriteNonsingularSolutions(std::ostream& out) const override;
+			void WriteSingularSolutions(std::ostream& out)    const override;
+			void WriteRawSolutions(std::ostream& out)         const override;
 			void ApplyParsedConfigs(std::string const& config_str) override;
 
 			virtual ~ZeroDim() = default;
@@ -1883,6 +1894,51 @@ inline void
 ZeroDim<TrackerType,EndgameType,SystemType,StartSystemType,SystemManagementP>::WriteRawData(std::ostream& out) const
 {
 	output::Classic<ZeroDim>::RawData(out, *this);
+}
+
+template<typename TrackerType, typename EndgameType,
+         typename SystemType, typename StartSystemType,
+         template<typename,typename> class SystemManagementP>
+inline void
+ZeroDim<TrackerType,EndgameType,SystemType,StartSystemType,SystemManagementP>::WriteFiniteSolutions(std::ostream& out) const
+{
+	output::Classic<ZeroDim>::FiniteSolutions(out, *this);
+}
+
+template<typename TrackerType, typename EndgameType,
+         typename SystemType, typename StartSystemType,
+         template<typename,typename> class SystemManagementP>
+inline void
+ZeroDim<TrackerType,EndgameType,SystemType,StartSystemType,SystemManagementP>::WriteRealFiniteSolutions(std::ostream& out) const
+{
+	output::Classic<ZeroDim>::RealFiniteSolutions(out, *this);
+}
+
+template<typename TrackerType, typename EndgameType,
+         typename SystemType, typename StartSystemType,
+         template<typename,typename> class SystemManagementP>
+inline void
+ZeroDim<TrackerType,EndgameType,SystemType,StartSystemType,SystemManagementP>::WriteNonsingularSolutions(std::ostream& out) const
+{
+	output::Classic<ZeroDim>::NonsingularSolutions(out, *this);
+}
+
+template<typename TrackerType, typename EndgameType,
+         typename SystemType, typename StartSystemType,
+         template<typename,typename> class SystemManagementP>
+inline void
+ZeroDim<TrackerType,EndgameType,SystemType,StartSystemType,SystemManagementP>::WriteSingularSolutions(std::ostream& out) const
+{
+	output::Classic<ZeroDim>::SingularSolutions(out, *this);
+}
+
+template<typename TrackerType, typename EndgameType,
+         typename SystemType, typename StartSystemType,
+         template<typename,typename> class SystemManagementP>
+inline void
+ZeroDim<TrackerType,EndgameType,SystemType,StartSystemType,SystemManagementP>::WriteRawSolutions(std::ostream& out) const
+{
+	output::Classic<ZeroDim>::RawSolutions(out, *this);
 }
 
 } // ns algorithm

--- a/core/src/blackbox/main_mode_switch.cpp
+++ b/core/src/blackbox/main_mode_switch.cpp
@@ -94,7 +94,29 @@ int RunZeroDim(std::string const& config_str, std::string const& input_str)
 			std::ofstream raw_data{"raw_data"};
 			alg->WriteRawData(raw_data);
 		}
-		std::cout << "bertini: wrote main_data and raw_data\n";
+		// Bertini 1.7-compatible machine-readable solution files (count-led coordinate blocks),
+		// so tooling that parses Bertini 1 output reads these unchanged.
+		{
+			std::ofstream f{"finite_solutions"};
+			alg->WriteFiniteSolutions(f);
+		}
+		{
+			std::ofstream f{"real_finite_solutions"};
+			alg->WriteRealFiniteSolutions(f);
+		}
+		{
+			std::ofstream f{"nonsingular_solutions"};
+			alg->WriteNonsingularSolutions(f);
+		}
+		{
+			std::ofstream f{"singular_solutions"};
+			alg->WriteSingularSolutions(f);
+		}
+		{
+			std::ofstream f{"raw_solutions"};
+			alg->WriteRawSolutions(f);
+		}
+		std::cout << "bertini: wrote main_data, raw_data, and solution files\n";
 	}
 	return 0;
 }

--- a/core/test/nag_algorithms/zero_dim.cpp
+++ b/core/test/nag_algorithms/zero_dim.cpp
@@ -508,6 +508,55 @@ BOOST_AUTO_TEST_CASE(filtered_solution_accessors)
 	BOOST_CHECK_EQUAL(zd.FiniteSolutions(false).size(), zd.FiniteSolutions(true).size());
 }
 
+// The Bertini 1.7-compatible solution-file writers (output::Classic): each file is count-led and
+// machine-readable -- first line is the solution count, then one block of NumVariables "re im"
+// coordinate lines per solution.  On x^2-1, y^2-1 the four roots (+-1,+-1) are all finite, real,
+// and nonsingular.
+BOOST_AUTO_TEST_CASE(classic_solution_file_output)
+{
+	using namespace bertini;
+	namespace out = bertini::algorithm::output;
+
+	auto x = node::Variable::Make("x");
+	auto y = node::Variable::Make("y");
+	System sys;
+	sys.AddFunction(pow(x, 2) - 1);
+	sys.AddFunction(pow(y, 2) - 1);
+	sys.AddVariableGroup(VariableGroup{x, y});
+
+	auto zd = algorithm::ZeroDim<TrackerT, endgame::EndgameSelector<TrackerT>::Cauchy, System, start_system::TotalDegree>(sys);
+	zd.DefaultSetup();
+	zd.Solve();
+
+	// first whitespace-delimited token is the solution count
+	auto first_count = [](std::string const& s){ std::istringstream iss(s); long n=-1; iss >> n; return n; };
+	// "re im" coordinate lines contain a space; count lines, path-index lines, and blanks do not
+	auto coord_lines = [](std::string const& s){
+		std::istringstream iss(s); std::string line; std::size_t c=0;
+		while (std::getline(iss, line)) if (line.find(' ') != std::string::npos) ++c;
+		return c; };
+
+	std::ostringstream fin, real, nonsing, sing, raw;
+	out::Classic<decltype(zd)>::FiniteSolutions(fin, zd);
+	out::Classic<decltype(zd)>::RealFiniteSolutions(real, zd);
+	out::Classic<decltype(zd)>::NonsingularSolutions(nonsing, zd);
+	out::Classic<decltype(zd)>::SingularSolutions(sing, zd);
+	out::Classic<decltype(zd)>::RawSolutions(raw, zd);
+
+	BOOST_CHECK_EQUAL(first_count(fin.str()),     4);
+	BOOST_CHECK_EQUAL(first_count(real.str()),    4);
+	BOOST_CHECK_EQUAL(first_count(nonsing.str()), 4);
+	BOOST_CHECK_EQUAL(first_count(sing.str()),    0);
+	BOOST_CHECK_EQUAL(first_count(raw.str()),     4);
+
+	// the count in the file agrees with the corresponding accessor
+	BOOST_CHECK_EQUAL(first_count(fin.str()),  static_cast<long>(zd.FiniteSolutions().size()));
+	BOOST_CHECK_EQUAL(first_count(sing.str()), static_cast<long>(zd.SingularSolutions().size()));
+
+	// exactly one coordinate block (NumVariables lines) per finite solution
+	BOOST_CHECK_EQUAL(coord_lines(fin.str()), sys.NumVariables() * 4u);
+}
+
 // InfiniteSolutions: the at-infinity complement of FiniteSolutions.  The system {x*y - 1, x - 1}
 // has Bezout number 2 but exactly one affine solution (1,1); the second total-degree path must
 // diverge -- so there is one finite endpoint and one at infinity.

--- a/docs/adr/0034-cli-emits-bertini1-compatible-solution-files.md
+++ b/docs/adr/0034-cli-emits-bertini1-compatible-solution-files.md
@@ -1,0 +1,56 @@
+# ADR-0034: The CLI emits Bertini 1.7-compatible machine-readable solution files
+
+**Status:** Accepted
+**Date:** 2026-06-27
+
+## Context
+
+Bertini 2 already produces Bertini 1.7-compatible *input* (`System::to_classic_input`, the
+classic writer) so the same problem can be solved in either tool. The *output* side had no such
+parity: the CLI (`core/src/blackbox/main_mode_switch.cpp`) wrote only `main_data` and `raw_data`,
+in a Bertini-2-specific layout. Neither carries a solution-count header, neither uses Bertini 1's
+`-1` raw terminator, and **none** of Bertini 1's companion solution files were written at all.
+
+That broke backwards compatibility for any tool (or person, or benchmark) that consumes Bertini 1
+output: there was no `finite_solutions` to read, and `main_data`'s first line is the *variable*
+count, not the solution count — a silent trap (the old `benchmark/run_benchmark.py` parsed it as a
+solution count and got the wrong number).
+
+Backwards compatibility was the whole point of the classic writer; the reading side should match.
+Note: **byte-for-byte** equality with Bertini 1 is impossible and is explicitly *not* a goal — the
+implementations differ, and even the random gamma/seed differ, so the actual solution *values* and
+ordering will never coincide. The contract is **machine-readable parity**: same file names, same
+count-led block format, so a parser written for Bertini 1.7 reads Bertini 2 unchanged.
+
+## Decision
+
+The zero-dim CLI additionally writes the Bertini 1.7 solution files, in the classic format
+(first line = count, then one block of `NumVariables` `"re im"` coordinate lines per solution, in
+user/dehomogenized coordinates, blocks blank-separated):
+
+- `finite_solutions`, `real_finite_solutions`, `nonsingular_solutions`, `singular_solutions`
+- `raw_solutions` (each successful endpoint preceded by its path number)
+
+Implementation is additive and reuses what already exists:
+
+- `output::Classic<ZeroDim>` (`core/include/bertini2/nag_algorithms/output.hpp`) gains the writers,
+  built on the existing classified accessors (`FiniteSolutions()`, `RealSolutions()`,
+  `NonsingularSolutions()`, `SingularSolutions()`, `FinalSolutionMetadata()`; see ADR-0015 for the
+  classification thresholds) and the existing `generators::Classic` number formatter.
+- `AnyZeroDim` (`zero_dim_solve.hpp`) gains five pure-virtual `Write*Solutions` methods; `ZeroDim`
+  is the only implementer, so this does not affect any other type.
+- The CLI opens and writes the five files after `main_data`/`raw_data`.
+
+`main_data` and `raw_data` are left as-is: they are informational, and chasing byte-compatibility
+there has no payoff given the no-byte-equality reality above.
+
+## Consequences
+
+- Tools and scripts that parse Bertini 1.7 solution files now read Bertini 2 CLI output unchanged.
+- A single parser serves both solvers — used by `benchmark/comparison/` to time Bertini 2 against
+  Bertini 1 on the same emitted input and cross-check that they agree on the solution count.
+- Verified: on cyclic-5 the CLI writes 70 finite solutions whose *set* matches the trusted
+  Bertini 1.7 oracle (`python/test/zero_dim/data/cyclic5_finite_solutions.txt`) to ~2.5e-12. A C++
+  test (`core/test/nag_algorithms/zero_dim.cpp::classic_solution_file_output`) pins the file format
+  and counts.
+- The five extra files are written only by the manager rank, alongside the existing output writes.


### PR DESCRIPTION
  ## What & why

  Bertini 2 already produces Bertini 1.7-compatible *input* (`System::to_classic_input`), so the
  same problem can be solved in either tool. The *output* side had no such parity: the CLI wrote
  only its own `main_data`/`raw_data` — with no solution-count header and **none** of Bertini 1's
  companion solution files. Anything that parses Bertini 1 output (tools, scripts, a benchmark)
  couldn't read it, and `main_data`'s first line is the *variable* count, not the solution count
  (a silent trap the old `benchmark/run_benchmark.py` fell into).

  Backwards compatibility was the whole point of the classic *writer*; this makes the reading side
  match. **Byte-for-byte equality with Bertini 1 is impossible and not a goal** (different
  implementations, different RNG) — the contract is **machine-readable parity**: same file names,
  
  ## Core change (ADR-0034)
  
  The zero-dim CLI now also writes the Bertini 1.7 solution files in classic count-led format
  (first line = count, then one block of `NumVariables` `"re im"` coordinate lines per solution, in
  user/dehomogenized coordinates):
  
  - `finite_solutions`, `real_finite_solutions`, `nonsingular_solutions`, `singular_solutions`, `raw_solutions`
  
  Additive and reuses existing machinery — the classified accessors (`FiniteSolutions()`,
  `RealSolutions()`, `NonsingularSolutions()`, `SingularSolutions()`; thresholds per ADR-0015) and
  the `generators::Classic` number formatter. `main_data`/`raw_data` are unchanged.
  
  - `output.hpp` — the writers
  - `zero_dim_solve.hpp` — `AnyZeroDim` virtuals + `ZeroDim` overrides (only implementer)
  - `main_mode_switch.cpp` — write the five files (manager rank)
  - `core/test/nag_algorithms/zero_dim.cpp::classic_solution_file_output` — pins format + counts
  
  ## Benchmark (`benchmark/comparison/`)
  
  Serial then MPI-single-thread comparison of the bertini2 CLI against other zero-dim solvers
  (Bertini 1 today; HomotopyContinuation.jl later via one more adapter). Systems are built in Python
  and emitted once to a classic input fed to **every** solver, so settings are identical by
  construction; a single parser (`finite_solutions`) serves both. Correctness/agreement is a free
  by-product — checked *after* timing, never inside it. Each run appends provenance rows
  (host/cpu/commit/version/settings) to a committed `history.csv` to track performance over time.
  
  ## Verification
  
  - `test_nag_algorithms` suite green; core lib, CLI, and `_pybertini` bindings all rebuild clean.
  - Validated against **real Bertini 1.7** — b2 and b1 agree on the actual solution *set*, not just counts:
  
    | System  | b2 count | b1 count | max set distance (bidirectional) |
    |---------|----------|----------|----------------------------------|
    | diag3   | 27       | 27       | 4.86e-12                         |
    | cyclic5 | 70       | 70       | 1.02e-11                         |
    
    (Ordering differs by design — different homotopy/RNG — but the variety points coincide to
    tracking tolerance.) cyclic-5's b2 set also matches the checked-in trusted oracle to ~2.5e-12.