### PR TITLE
Tiered SLP arithmetic + allocation-free mp eval (~10x faster multiprecision)

### DIFF
--- a/core/include/bertini2/system/straight_line_program.hpp
+++ b/core/include/bertini2/system/straight_line_program.hpp
@@ -291,6 +291,20 @@ namespace bertini {
 		/// the corresponding number node's FreshEval exactly.  Definition + instantiations in the cpp.
 		template<typename NumT> NumT Produce() const;
 
+		/// Produce just the REAL value (for a slot inferred NumType::Real).  Only valid when IsReal().
+		template<typename RealT> RealT ProduceReal() const;
+
+		/// Whether this constant is real-valued: Integer/Pi/E always; a Rational/Complex literal iff its
+		/// imaginary part is exactly zero.  Drives NumType::Real inference for constant slots (ADR-0034).
+		bool IsReal() const {
+			switch (kind) {
+				case Kind::Integer: case Kind::Pi: case Kind::E: return true;
+				case Kind::Rational: return rat_imag == 0;
+				case Kind::Complex:  return float_value.imag() == 0;
+			}
+			return false;
+		}
+
 		friend class boost::serialization::access;
 		template <typename Archive>
 		void serialize(Archive& ar, const unsigned /*version*/) {
@@ -421,6 +435,11 @@ namespace bertini {
 		// Reorder `instructions_` into [frozen | live] and set `first_live_instruction_`.  Called once
 		// at the end of compilation, after `num_slots_` is set.
 		void PartitionInstructions();
+
+		// Fill slot_numtype_ by a forward pass over the (dependency-ordered) tape (ADR-0034): seed
+		// constant slots from ConstantRecipe::IsReal() and input slots as Complex, then propagate the
+		// NumType join through each instruction.  Called at the end of compilation.
+		void ComputeSlotNumTypes();
 
 
 		bool has_path_variable_ = false; //< Does this SLP have a path variable?
@@ -573,16 +592,33 @@ namespace bertini {
 		the function will NOT automatically resize your vector for you to be the correct size
 
 		 */
+		/// Number of slots the compiler inferred as NumType::Real (ADR-0034).  >0 means real-valued
+		/// subexpressions are being evaluated in the cheaper real banks; used by tests to confirm the
+		/// tier inference is live (not silently all-Complex).
+		size_t NumRealSlots() const {
+			size_t n = 0;
+			for (auto t : program_->slot_numtype_) if (t == NumType::Real) ++n;
+			return n;
+		}
+
+		// Read a slot's value as NumT (complex), pulling from the real or complex bank per its NumType
+		// (ADR-0034).  Used to copy outputs out, since a function/derivative slot could be Real-typed.
+		template<typename NumT>
+		NumT ReadSlotAsComplex(size_t slot) const {
+			using RealT = typename NumTraits<NumT>::Real;
+			if (program_->slot_numtype_[slot] == NumType::Real)
+				return NumT(memory_.template Get<RealT>()[slot]);
+			return memory_.template Get<NumT>()[slot];
+		}
+
 		template<typename NumT>
 		void GetFuncValsInPlace(Eigen::Ref<Vec<NumT>> result) const{
 			if (!memory_.is_evaluated_)
 				program_->Eval<NumT>(memory_);
 
-			auto& memory = memory_.Get<NumT>();
-
-			// copy content
+			// copy content (an output slot may be Real-typed; read from the bank its NumType selects)
 			for (size_t ii = 0; ii < program_->number_of_.Functions; ++ii) {
-				result(static_cast<Eigen::Index>(ii)) = memory[ii + program_->output_locations_.Functions];
+				result(static_cast<Eigen::Index>(ii)) = ReadSlotAsComplex<NumT>(ii + program_->output_locations_.Functions);
 			}
 		}
 
@@ -602,12 +638,10 @@ namespace bertini {
 			if (!memory_.is_evaluated_)
 				program_->Eval<NumT>(memory_);
 
-			auto& memory = memory_.Get<NumT>();
-
-			// copy content
+			// copy content (a derivative slot may be Real-typed; read from the bank its NumType selects)
 			for (size_t jj =0; jj < program_->number_of_.Variables; ++jj) {
 				for (size_t ii = 0; ii < program_->number_of_.Functions; ++ii) {
-					result(static_cast<Eigen::Index>(ii), static_cast<Eigen::Index>(jj)) = memory[ii+jj*program_->number_of_.Functions + program_->output_locations_.Jacobian];
+					result(static_cast<Eigen::Index>(ii), static_cast<Eigen::Index>(jj)) = ReadSlotAsComplex<NumT>(ii+jj*program_->number_of_.Functions + program_->output_locations_.Jacobian);
 				}
 			}
 		}
@@ -628,11 +662,9 @@ namespace bertini {
 			if (!memory_.is_evaluated_)
 				program_->Eval<NumT>(memory_);
 
-			auto& memory = memory_.Get<NumT>();
-			// 1. make container, size correctly.
-			// 2. copy content
+			// copy content (a time-derivative slot may be Real-typed; read from the right bank)
 			for (size_t ii = 0; ii < program_->number_of_.Functions; ++ii) {
-				result(static_cast<Eigen::Index>(ii)) = memory[ii + program_->output_locations_.TimeDeriv];
+				result(static_cast<Eigen::Index>(ii)) = ReadSlotAsComplex<NumT>(ii + program_->output_locations_.TimeDeriv);
 			}
 		}
 

--- a/core/include/bertini2/system/straight_line_program.hpp
+++ b/core/include/bertini2/system/straight_line_program.hpp
@@ -205,6 +205,16 @@ namespace bertini {
 
 	std::string OpcodeToString(Operation op);
 
+	// Compile-time bank selectors (ADR-0034).  After NumType inference, each instruction's opcode word
+	// gets these high bits set to record which bank (real or complex) each operand and the result live
+	// in, so the hot eval loop reads the banks inline from the instruction it has already loaded instead
+	// of looking up slot_numtype_[slot] per operand.  The base Operation occupies bits 0..16, so these
+	// sit well clear of it; masking with kOpcodeMask recovers the base op for the switch and for IsUnary.
+	constexpr size_t kOpcodeMask = (static_cast<size_t>(1) << 17) - 1;
+	constexpr size_t kArg0Real   =  static_cast<size_t>(1) << 20;  // first operand slot is NumType::Real
+	constexpr size_t kArg1Real   =  static_cast<size_t>(1) << 21;  // second operand slot is Real (binary, not IntPower)
+	constexpr size_t kOutReal    =  static_cast<size_t>(1) << 22;  // result slot is NumType::Real
+
 
 	/**
 	 \struct SLPOutputLocations
@@ -445,6 +455,12 @@ namespace bertini {
 		// constant slots from ConstantRecipe::IsReal() and input slots as Complex, then propagate the
 		// NumType join through each instruction.  Called at the end of compilation.
 		void ComputeSlotNumTypes();
+
+		// Pack each instruction's operand/result banks (from slot_numtype_) into its opcode word's high
+		// bits (kArg0Real/kArg1Real/kOutReal), so eval dispatches banks without per-slot lookups.  Runs
+		// after ComputeSlotNumTypes and PartitionInstructions (it only sets bits; order vs. partition
+		// doesn't matter as it rewrites instructions in place).
+		void SpecializeInstructions();
 
 
 		bool has_path_variable_ = false; //< Does this SLP have a path variable?

--- a/core/include/bertini2/system/straight_line_program.hpp
+++ b/core/include/bertini2/system/straight_line_program.hpp
@@ -388,6 +388,11 @@ namespace bertini {
 
 		SLPProgram() = default;
 
+		// ADR-0034 A/B switch: when false, ComputeSlotNumTypes leaves every slot Complex, reproducing
+		// the pre-tier all-complex evaluation.  Read at compile time (SLP construction).  Default true;
+		// the benchmark flips it to measure tiers-on vs tiers-off.  Not for production toggling.
+		static bool tiers_enabled_;
+
 		bool HavePathVariable() const { return has_path_variable_; }
 		inline unsigned NumFunctions() const{ return static_cast<unsigned>(number_of_.Functions);}
 		inline unsigned NumVariables() const{ return static_cast<unsigned>(number_of_.Variables);}

--- a/core/include/bertini2/system/straight_line_program.hpp
+++ b/core/include/bertini2/system/straight_line_program.hpp
@@ -155,6 +155,20 @@ namespace bertini {
 	class StraightLineProgram;
 
 
+	/**
+	\brief The numeric type a memory slot holds, orthogonal to working precision (ADR-0034).
+
+	Precision (double vs multiprecision) is the Eval<NumT> template parameter; this is the ℝ/ℂ
+	axis within a precision.  A slot tagged Real lives in the real register bank (real_dbl /
+	real_mp), Complex in the complex bank (complex_dbl / complex_mp).  The compiler infers each
+	slot's NumType from the function tree (a constant whose imaginary part is zero, an Integer, a
+	Rational with zero imaginary part, Pi/E are Real; variables and the path variable are Complex;
+	an operator's result is the join of its operands, escaping to Complex for ops that can leave ℝ).
+	Integer is reserved for a later stage; S1 uses {Real, Complex}.
+	*/
+	enum class NumType : uint8_t { Real = 0, Complex = 1 };  // Integer added in a later stage
+
+
 	enum Operation { // we'll start with the binary ones
 		Add=      1 << 0,
 		Subtract= 1 << 1,
@@ -308,9 +322,11 @@ namespace bertini {
 		template<typename NumT>
 		std::vector<NumT> const& Get() const { return std::get<std::vector<NumT>>(registers_); }
 
-		//< The register file.  Numbers and variables, plus temp results and output locations.  It's
-		//  all one block per number type.  That's why it's called a SLP!
-		mutable std::tuple< std::vector<complex_dbl>, std::vector<complex_mp> > registers_;
+		//< The register file (ADR-0034): one bank per (precision, NumType).  A slot lives in exactly
+		//  one bank, chosen by its NumType; the real banks are the real companions of the complex ones
+		//  (real_dbl for complex_dbl, real_mp for complex_mp).  Get<NumT>() selects a bank by type.
+		mutable std::tuple< std::vector<real_dbl>, std::vector<complex_dbl>,
+		                    std::vector<real_mp>,  std::vector<complex_mp> > registers_;
 
 		mutable unsigned precision_ = 16; //< The current working number of digits
 		mutable bool is_evaluated_ = false;
@@ -325,7 +341,9 @@ namespace bertini {
 
 		template <typename Archive>
 		void serialize(Archive& ar, const unsigned /*version*/) {
+			ar & std::get<std::vector<real_dbl>>(registers_);
 			ar & std::get<std::vector<complex_dbl>>(registers_);
+			ar & std::get<std::vector<real_mp>>(registers_);
 			ar & std::get<std::vector<complex_mp>>(registers_);
 			ar & precision_;
 			ar & is_evaluated_;
@@ -427,6 +445,11 @@ namespace bertini {
 
 		size_t num_slots_ = 0; //< Total number of memory slots the program needs (per number bank).
 
+		// The NumType of each slot (ADR-0034), indexed by global slot number; sized to num_slots_.
+		// Selects which register bank a slot lives in.  Default Complex (filled by the compiler);
+		// an all-Complex table reproduces the pre-tier behavior exactly.
+		std::vector<NumType> slot_numtype_;
+
 
 		friend class boost::serialization::access;
 
@@ -441,6 +464,7 @@ namespace bertini {
 			ar & constant_recipes_;
 			ar & first_live_instruction_;
 			ar & num_slots_;
+			ar & slot_numtype_;
 		}
 	};
 

--- a/core/src/function_tree/operators/arithmetic.cpp
+++ b/core/src/function_tree/operators/arithmetic.cpp
@@ -868,7 +868,16 @@ void PowerOperator::print(std::ostream & target) const
 
 std::shared_ptr<Node> PowerOperator::Differentiate(std::shared_ptr<Variable> const& v) const
 {
-	auto exp_minus_one = exponent_-1;
+	// d/dv (base^exp) = exp * base^(exp-1) * base'.  When the exponent is an integer literal, fold
+	// exp-1 to a literal Integer (e.g. 4 -> 3) instead of leaving a computed `exponent - 1` node --
+	// otherwise the derivative is base^(4-1), a power with a non-literal exponent, which the SLP
+	// compiler cannot lower to multiplications and must evaluate with a general (allocation-heavy)
+	// pow.  Non-integer exponents keep the symbolic exp-1.
+	std::shared_ptr<Node> exp_minus_one;
+	if (auto exp_as_int = std::dynamic_pointer_cast<Integer const>(exponent_))
+		exp_minus_one = Integer::Make(exp_as_int->GetValue() - 1);
+	else
+		exp_minus_one = exponent_-1;
 	return SimplifiedMult({
 		{base_->Differentiate(v), true},
 		{exponent_, true},

--- a/core/src/system/straight_line_program.cpp
+++ b/core/src/system/straight_line_program.cpp
@@ -147,8 +147,12 @@ namespace bertini{
 		// so the default-constructed slots are valid.
 		DefaultPrecision(memory_.precision_);
 
-		// adjust the sizes of the memory blocks to match the number expected via compilation
+		// adjust the sizes of the memory blocks to match the number expected via compilation.
+		// All four banks (real/complex x dbl/mp) are sized to the slot count; a slot lives in exactly
+		// one bank per its NumType, so the off-type banks hold default, never-read entries for now.
+		memory_.Get<real_dbl>().resize(program_->num_slots_);
 		memory_.Get<complex_dbl>().resize(program_->num_slots_);
+		memory_.Get<real_mp>().resize(program_->num_slots_);
 		memory_.Get<complex_mp>().resize(program_->num_slots_);
 
 		// downsample to get ready for evaluation
@@ -977,6 +981,11 @@ namespace bertini{
 
 		// the program's total slot count is the number of memory slots allocated during compilation
 		program_under_construction_.num_slots_ = next_available_complex_;
+
+		// NumType per slot (ADR-0034).  Stage-0/foundation: every slot is Complex, which makes the
+		// real banks unused and reproduces the pre-tier behavior exactly.  Tier inference (next
+		// increment) is what flips real-valued slots to NumType::Real.
+		program_under_construction_.slot_numtype_.assign(next_available_complex_, NumType::Complex);
 
 		// Split the tape into a frozen (constants-only) prologue and a live segment, so a
 		// point-only re-evaluation can skip recomputing the constants (ADR-0027).  This is a pure

--- a/core/src/system/straight_line_program.cpp
+++ b/core/src/system/straight_line_program.cpp
@@ -342,6 +342,25 @@ namespace bertini{
 		using std::sin;  using std::cos;  using std::tan;
 		using std::asin; using std::acos; using std::atan;
 
+		// The tier dispatch constructs complex temporaries during eval (promoting a real operand to
+		// complex in Power/sqrt/log/...).  Boost inits such a new mpc at the *thread default* precision,
+		// which is not guaranteed to be the working precision on this path -- if it is 0, mpc_init2
+		// aborts.  Pin the thread-local default to the working precision (thread-safe; no global write).
+		// (The old eval never constructed mp temporaries, so it didn't need this.)
+		if constexpr (!std::is_same<NumT,complex_dbl>::value)
+			SetThreadPrecision(mem.precision_);
+
+		// Re-tag a freshly written complex slot to the working precision.  Boost.Multiprecision has a
+		// bug in mixed mpfr_float/mpc_complex expression templates: `real_mp / complex_mp` computes the
+		// correct value but tags the result precision 0 (multiplication is unaffected), which later
+		// aborts when that slot is copied (mpc_init2 with precision 0).  Minimal bertini-free repro:
+		// two operands at precision 40, `out = r / z` gives out.precision()==0.  Re-tagging restores it.
+		// No-op for complex_dbl (std::complex has no precision tag), so the hot double path keeps native
+		// mixed arithmetic with zero overhead.
+		auto retag = [&](size_t o){
+			if constexpr (!std::is_same<NumT,complex_dbl>::value) Precision(cplx[o], mem.precision_);
+		};
+
 
 #ifndef BERTINI_DISABLE_PRECISION_CHECKS
 		if (! std::is_same<NumT,complex_dbl>::value && Precision(cplx[0])!=mem.precision_){
@@ -371,10 +390,13 @@ namespace bertini{
 		// (R+R, R-R, R*R, R/R), so we use the cheap real path; otherwise we use native mixed
 		// arithmetic (real * complex is ~half the work of complex * complex), promoting nothing.
 		auto binop = [&](size_t i1, size_t i2, size_t o, auto fn){
-			if (is_real(o))                          real[o] = fn(real[i1], real[i2]);
-			else if (is_real(i1) && !is_real(i2))    cplx[o] = fn(real[i1], cplx[i2]);
-			else if (!is_real(i1) && is_real(i2))    cplx[o] = fn(cplx[i1], real[i2]);
-			else                                     cplx[o] = fn(cplx[i1], cplx[i2]);
+			if (is_real(o))                          real[o] = fn(real[i1], real[i2]);  // all-real, cheap
+			else if (!is_real(i1) && !is_real(i2))   cplx[o] = fn(cplx[i1], cplx[i2]);  // pure complex, correctly tagged
+			else {  // mixed real/complex: native (the win), but re-tag the mis-reported mpc precision
+				if (is_real(i1)) cplx[o] = fn(real[i1], cplx[i2]);
+				else             cplx[o] = fn(cplx[i1], real[i2]);
+				retag(o);
+			}
 		};
 
 		// Type-preserving unary (result NumType == operand NumType): negate/copy/exp/sin/cos/tan/atan.
@@ -386,6 +408,7 @@ namespace bertini{
 		// sqrt/log/asin/acos, which can leave ℝ for some real inputs.
 		auto un_escape = [&](size_t i, size_t o, auto fn){
 			cplx[o] = is_real(i) ? fn(NumT(real[i])) : fn(cplx[i]);
+			retag(o);
 		};
 
 		for (size_t ii = loop_start; ii<instructions_.size();/*the increment is done at end of loop depending on arity */) {
@@ -402,10 +425,13 @@ namespace bertini{
 				case Divide:   binop(a, b, c, [](auto const& x, auto const& y){ return x / y; }); break;
 
 				case Power: {
-					// general a^b (slot exponent); result is Complex, so promote any real operand.
+					// general a^b (slot exponent); result is Complex, so promote any real operand to
+					// complex (a single converting construction at the working precision, not a mixed
+					// expression template), then a pure-complex pow -- so the result is tagged correctly.
 					const NumT base = is_real(a) ? NumT(real[a]) : cplx[a];
 					const NumT expo = is_real(b) ? NumT(real[b]) : cplx[b];
 					cplx[c] = pow(base, expo);
+					retag(c);
 					break;
 				}
 

--- a/core/src/system/straight_line_program.cpp
+++ b/core/src/system/straight_line_program.cpp
@@ -92,6 +92,33 @@ namespace bertini{
 		throw std::runtime_error("unrecognized ConstantRecipe kind in Produce<complex_mp>");
 	}
 
+	// Real companion of Produce (ADR-0034): the real value of a constant whose slot was inferred
+	// NumType::Real.  Only the real part is used; IsReal() guarantees the imaginary part is zero, so
+	// this matches the real part of Produce<complex>() bit-for-bit.
+	template<>
+	real_dbl ConstantRecipe::ProduceReal<real_dbl>() const {
+		switch (kind) {
+			case Kind::Integer:  return double(int_value);
+			case Kind::Rational: return double(rat_real);
+			case Kind::Complex:  return double(float_value.real());
+			case Kind::Pi:       return boost::math::constants::pi<double>();
+			case Kind::E:        return exp(1.0);
+		}
+		throw std::runtime_error("unrecognized ConstantRecipe kind in ProduceReal<real_dbl>");
+	}
+
+	template<>
+	real_mp ConstantRecipe::ProduceReal<real_mp>() const {
+		switch (kind) {
+			case Kind::Integer:  return real_mp(int_value, ThreadPrecision());
+			case Kind::Rational: return real_mp(rat_real, ThreadPrecision());
+			case Kind::Complex:  return real_mp(float_value.real(), ThreadPrecision());
+			case Kind::Pi:       return boost::math::constants::pi<real_mp>();
+			case Kind::E:        return real_mp(exp(real_mp(1)));
+		}
+		throw std::runtime_error("unrecognized ConstantRecipe kind in ProduceReal<real_mp>");
+	}
+
 
 	// the constructor
 	StraightLineProgram::StraightLineProgram(System const& sys){
@@ -106,14 +133,21 @@ namespace bertini{
 			return;
 		}
 		else{
-			auto& mem = memory_.Get<complex_mp>();
+			auto& cmem = memory_.Get<complex_mp>();
+			auto& rmem = memory_.Get<real_mp>();
 
-			// Refill the constants from their exact recipes (no node evaluation), then normalize
-			// every slot to the new precision.  (Matches the historical node-backed path.)
-			for (auto const& c : program_->constant_recipes_)
-				mem[c.slot] = c.Produce<complex_mp>();
+			// Refill the constants from their exact recipes (no node evaluation) into the bank their
+			// NumType selects, then normalize every slot of both banks to the new precision.
+			for (auto const& c : program_->constant_recipes_){
+				if (program_->slot_numtype_[c.slot] == NumType::Real)
+					rmem[c.slot] = c.ProduceReal<real_mp>();
+				else
+					cmem[c.slot] = c.Produce<complex_mp>();
+			}
 
-			for (auto& n : mem)
+			for (auto& n : cmem)
+				Precision(n, new_precision);
+			for (auto& n : rmem)
 				Precision(n, new_precision);
 
 			memory_.precision_ = new_precision;
@@ -127,10 +161,19 @@ namespace bertini{
 	template<typename NumT>
 	void StraightLineProgram::CopyNumbersIntoMemory() const
 	{
+		using RealT = typename NumTraits<NumT>::Real;
+		constexpr bool is_mp = std::is_same<NumT,complex_mp>::value;
 		for (auto const& c : program_->constant_recipes_){
-			memory_.Get<NumT>()[c.slot] = c.Produce<NumT>();
-			if (std::is_same<NumT,complex_mp>::value)
-				Precision(memory_.Get<NumT>()[c.slot], memory_.precision_);
+			if (program_->slot_numtype_[c.slot] == NumType::Real){
+				memory_.Get<RealT>()[c.slot] = c.ProduceReal<RealT>();
+				if constexpr (is_mp)
+					Precision(memory_.Get<RealT>()[c.slot], memory_.precision_);
+			}
+			else{
+				memory_.Get<NumT>()[c.slot] = c.Produce<NumT>();
+				if constexpr (is_mp)
+					Precision(memory_.Get<NumT>()[c.slot], memory_.precision_);
+			}
 		}
 	}
 
@@ -284,11 +327,24 @@ namespace bertini{
 	template<typename NumT>
 	void SLPProgram::Eval(SLPMemory& mem) const{
 
-		auto& memory =  mem.Get<NumT>();
+		// Two banks at this precision: the complex bank (NumT) and its real companion (ADR-0034).
+		// A slot's value lives in exactly one, selected by slot_numtype_.  An all-Complex program
+		// only ever touches `cplx`, so this is identical to the pre-tier path.
+		using RealT = typename NumTraits<NumT>::Real;
+		auto& cplx = mem.Get<NumT>();
+		auto& real = mem.Get<RealT>();
+
+		// Bring the std math functions into scope so the REAL (double) path resolves them: a plain
+		// double has no associated namespace, so unqualified sin/pow/... would otherwise bind to the
+		// function-tree node operators.  ADL still finds Boost's overloads for real_mp / complex_mp
+		// and std's for complex_dbl, so all four numeric types resolve correctly.
+		using std::pow;  using std::sqrt; using std::log;  using std::exp;
+		using std::sin;  using std::cos;  using std::tan;
+		using std::asin; using std::acos; using std::atan;
 
 
 #ifndef BERTINI_DISABLE_PRECISION_CHECKS
-		if (! std::is_same<NumT,complex_dbl>::value && Precision(memory[0])!=mem.precision_){
+		if (! std::is_same<NumT,complex_dbl>::value && Precision(cplx[0])!=mem.precision_){
 			throw std::runtime_error("memory and SLP are out-of-sync WRT precision");
 		}
 #endif
@@ -308,81 +364,69 @@ namespace bertini{
 
 		const size_t loop_start = frozen_valid ? first_live_instruction_ : 0;
 
+		auto is_real = [&](size_t s){ return slot_numtype_[s] == NumType::Real; };
+
+		// Binary arithmetic: read each operand from its NumType's bank and write the result to the
+		// result slot's bank.  When the result is Real, inference guarantees both operands are Real
+		// (R+R, R-R, R*R, R/R), so we use the cheap real path; otherwise we use native mixed
+		// arithmetic (real * complex is ~half the work of complex * complex), promoting nothing.
+		auto binop = [&](size_t i1, size_t i2, size_t o, auto fn){
+			if (is_real(o))                          real[o] = fn(real[i1], real[i2]);
+			else if (is_real(i1) && !is_real(i2))    cplx[o] = fn(real[i1], cplx[i2]);
+			else if (!is_real(i1) && is_real(i2))    cplx[o] = fn(cplx[i1], real[i2]);
+			else                                     cplx[o] = fn(cplx[i1], cplx[i2]);
+		};
+
+		// Type-preserving unary (result NumType == operand NumType): negate/copy/exp/sin/cos/tan/atan.
+		auto un_preserve = [&](size_t i, size_t o, auto fn){
+			if (is_real(o)) real[o] = fn(real[i]); else cplx[o] = fn(cplx[i]);
+		};
+
+		// Escape unary (result is Complex; a real operand is promoted so the complex branch is taken):
+		// sqrt/log/asin/acos, which can leave ℝ for some real inputs.
+		auto un_escape = [&](size_t i, size_t o, auto fn){
+			cplx[o] = is_real(i) ? fn(NumT(real[i])) : fn(cplx[i]);
+		};
+
 		for (size_t ii = loop_start; ii<instructions_.size();/*the increment is done at end of loop depending on arity */) {
 			//in the unary case the loop will increment by 3
 			//binary: by 4
 
+			const size_t a = instructions_[ii+1], b = instructions_[ii+2], c = instructions_[ii+3];
+
 			switch (instructions_[ii]) {
 
-				case Add:
-					memory[this->instructions_[ii+3]] = memory[instructions_[ii+1]] + memory[instructions_[ii+2]];
-					break;
+				case Add:      binop(a, b, c, [](auto const& x, auto const& y){ return x + y; }); break;
+				case Subtract: binop(a, b, c, [](auto const& x, auto const& y){ return x - y; }); break;
+				case Multiply: binop(a, b, c, [](auto const& x, auto const& y){ return x * y; }); break;
+				case Divide:   binop(a, b, c, [](auto const& x, auto const& y){ return x / y; }); break;
 
-				case Subtract:
-					memory[this->instructions_[ii+3]] = memory[instructions_[ii+1]] - memory[instructions_[ii+2]];
+				case Power: {
+					// general a^b (slot exponent); result is Complex, so promote any real operand.
+					const NumT base = is_real(a) ? NumT(real[a]) : cplx[a];
+					const NumT expo = is_real(b) ? NumT(real[b]) : cplx[b];
+					cplx[c] = pow(base, expo);
 					break;
-
-				case Multiply:
-					memory[this->instructions_[ii+3]] = memory[instructions_[ii+1]] * memory[instructions_[ii+2]];
-					break;
-
-				case Divide:
-					memory[this->instructions_[ii+3]] = memory[instructions_[ii+1]] / memory[instructions_[ii+2]];
-					break;
-
-				case Power:
-					memory[this->instructions_[ii+3]] = pow(memory[instructions_[ii+1]], memory[instructions_[ii+2]]);
-					break;
+				}
 
 				case IntPower:
-					{
-					memory[this->instructions_[ii+3]] = pow(memory[instructions_[ii+1]], this->integers_[instructions_[ii+2]]);
-					break;
-					}
-
-				case Assign:
-					memory[this->instructions_[ii+2]] = memory[instructions_[ii+1]];
+					// in2 (b) is an index into integers_, not a slot.  real^int -> real, complex^int -> complex.
+					if (is_real(c)) real[c] = pow(real[a], this->integers_[b]);
+					else            cplx[c] = pow(cplx[a], this->integers_[b]);
 					break;
 
-				case Negate:
-					memory[this->instructions_[ii+2]] = -(memory[instructions_[ii+1]]);
-					break;
+				case Assign:   un_preserve(a, b, [](auto const& x){ return x; }); break;
+				case Negate:   un_preserve(a, b, [](auto const& x){ return -x; }); break;
+				case Exp:      un_preserve(a, b, [](auto const& x){ return exp(x); }); break;
+				case Sin:      un_preserve(a, b, [](auto const& x){ return sin(x); }); break;
+				case Cos:      un_preserve(a, b, [](auto const& x){ return cos(x); }); break;
+				case Tan:      un_preserve(a, b, [](auto const& x){ return tan(x); }); break;
+				case Atan:     un_preserve(a, b, [](auto const& x){ return atan(x); }); break;
 
-				case Sqrt:
-					memory[this->instructions_[ii+2]] = sqrt(memory[instructions_[ii+1]]);
-					break;
-
-				case Log:
-					memory[this->instructions_[ii+2]] = log(memory[instructions_[ii+1]]);
-					break;
-
-				case Exp:
-					memory[this->instructions_[ii+2]] = exp(memory[instructions_[ii+1]]);
-					break;
-
-				case Sin:
-					memory[this->instructions_[ii+2]] = sin(memory[instructions_[ii+1]]);
-					break;
-
-				case Cos:
-					memory[this->instructions_[ii+2]] = cos(memory[instructions_[ii+1]]);
-					break;
-
-				case Tan:
-					memory[this->instructions_[ii+2]] = tan(memory[instructions_[ii+1]]);
-					break;
-
-				case Asin:
-					memory[this->instructions_[ii+2]] = asin(memory[instructions_[ii+1]]);
-					break;
-
-				case Acos:
-					memory[this->instructions_[ii+2]] = acos(memory[instructions_[ii+1]]);
-					break;
-
-				case Atan:
-					memory[this->instructions_[ii+2]] = atan(memory[instructions_[ii+1]]);
-					break;
+				case Sqrt:     un_escape(a, b, [](auto const& x){ return sqrt(x); }); break;
+				case Log:      un_escape(a, b, [](auto const& x){ return log(x); }); break;
+				case Asin:     un_escape(a, b, [](auto const& x){ return asin(x); }); break;
+				case Acos:     un_escape(a, b, [](auto const& x){ return acos(x); }); break;
 
 			} // switch for operation
 
@@ -411,6 +455,73 @@ namespace bertini{
 
 	template void SLPProgram::Eval<complex_dbl>(SLPMemory&) const;
 	template void SLPProgram::Eval<complex_mp>(SLPMemory&) const;
+
+
+	namespace {
+		// The NumType of a binary op's result given its operands' NumTypes (ADR-0034).  Real only when
+		// the result is GUARANTEED real for all inputs; otherwise Complex (the safe escape).  IntPower
+		// is handled separately (its exponent is an integer index, and result = base NumType).
+		NumType BinaryResultNumType(Operation op, NumType a, NumType b)
+		{
+			const bool both_real = (a == NumType::Real && b == NumType::Real);
+			switch (op)
+			{
+				// R+R, R-R, R*R are real; R/R is real (real/real stays in ℝ); any complex operand -> complex.
+				case Add: case Subtract: case Multiply: case Divide:
+					return both_real ? NumType::Real : NumType::Complex;
+				// general a^b (slot exponent): negative real base to a non-integer power leaves ℝ.
+				case Power:
+				default:
+					return NumType::Complex;
+			}
+		}
+
+		// The NumType of a unary op's result given its operand's NumType.
+		NumType UnaryResultNumType(Operation op, NumType a)
+		{
+			switch (op)
+			{
+				case Negate: case Assign:                          return a;          // sign/copy preserve
+				case Exp: case Sin: case Cos: case Tan: case Atan: return a;          // real-valued for real input
+				case Sqrt: case Log: case Asin: case Acos:         return NumType::Complex;  // can leave ℝ
+				default:                                           return NumType::Complex;
+			}
+		}
+	} // anonymous namespace
+
+	void SLPProgram::ComputeSlotNumTypes()
+	{
+		// Seed: constant slots from their recipe's real-ness; everything else (variables, the path
+		// variable, and as-yet-unwritten temporaries) starts Complex.  Then one forward pass over the
+		// dependency-ordered tape propagates the NumType of each instruction's result (same shape as
+		// PartitionInstructions' frozenness pass).
+		slot_numtype_.assign(num_slots_, NumType::Complex);
+		for (auto const& c : constant_recipes_)
+			slot_numtype_[c.slot] = c.IsReal() ? NumType::Real : NumType::Complex;
+
+		for (size_t ii = 0; ii < instructions_.size(); )
+		{
+			const auto op = static_cast<Operation>(instructions_[ii]);
+			if (IsUnary(op))
+			{
+				slot_numtype_[instructions_[ii + 2]] =
+					UnaryResultNumType(op, slot_numtype_[instructions_[ii + 1]]);
+				ii += 3;
+			}
+			else if (op == IntPower)
+			{
+				// in2 is an index into integers_, not a slot; real^int = real, complex^int = complex.
+				slot_numtype_[instructions_[ii + 3]] = slot_numtype_[instructions_[ii + 1]];
+				ii += 4;
+			}
+			else
+			{
+				slot_numtype_[instructions_[ii + 3]] =
+					BinaryResultNumType(op, slot_numtype_[instructions_[ii + 1]], slot_numtype_[instructions_[ii + 2]]);
+				ii += 4;
+			}
+		}
+	}
 
 
 	void SLPProgram::PartitionInstructions()
@@ -982,10 +1093,8 @@ namespace bertini{
 		// the program's total slot count is the number of memory slots allocated during compilation
 		program_under_construction_.num_slots_ = next_available_complex_;
 
-		// NumType per slot (ADR-0034).  Stage-0/foundation: every slot is Complex, which makes the
-		// real banks unused and reproduces the pre-tier behavior exactly.  Tier inference (next
-		// increment) is what flips real-valued slots to NumType::Real.
-		program_under_construction_.slot_numtype_.assign(next_available_complex_, NumType::Complex);
+		// NumType per slot (ADR-0034): infer which slots are real vs complex from the tree/tape.
+		program_under_construction_.ComputeSlotNumTypes();
 
 		// Split the tape into a frozen (constants-only) prologue and a live segment, so a
 		// point-only re-evaluation can skip recomputing the constants (ADR-0027).  This is a pure

--- a/core/src/system/straight_line_program.cpp
+++ b/core/src/system/straight_line_program.cpp
@@ -450,8 +450,10 @@ namespace bertini{
 					else    cplx[c] = pow(cplx[a], this->integers_[b]);
 					break;
 
-				case Assign:   un_preserve(a, b, ro, [](auto const& x){ return x; }); break;
-				case Negate:   un_preserve(a, b, ro, [](auto const& x){ return -x; }); break;
+				// Direct, in-place (no by-value lambda): `return x` / `return -x` would mint a temporary
+				// (an allocation per op at mp); a slot-to-slot copy / negate evaluates in place.
+				case Assign:   if (ro) real[b] = real[a];  else cplx[b] = cplx[a];   break;
+				case Negate:   if (ro) real[b] = -real[a]; else cplx[b] = -cplx[a];  break;
 				case Exp:      un_preserve(a, b, ro, [](auto const& x){ return exp(x); }); break;
 				case Sin:      un_preserve(a, b, ro, [](auto const& x){ return sin(x); }); break;
 				case Cos:      un_preserve(a, b, ro, [](auto const& x){ return cos(x); }); break;
@@ -906,19 +908,30 @@ namespace bertini{
 		else {
 			const unsigned m = expo < 0 ? static_cast<unsigned>(-static_cast<long long>(expo))
 			                            : static_cast<unsigned>(expo);
-			if (m == 1)
-				result_loc = base_loc;                       // x^1 = x (no instruction)
-			else {
-				// base^m by repeated multiplication.  Every multiply must have DISTINCT operands:
-				// mpc squaring (a*a, aliased) allocates a temporary, whereas a*b does not -- so we
-				// first copy the base into its own slot and always multiply against that copy.  The
-				// result is allocation-free (vs ~14 heap ops for boost's pow).
-				const size_t base_copy = next_available_complex_++;
-				program_under_construction_.AddInstruction(Assign, base_loc, base_copy);
-				size_t acc = base_loc;                       // acc = base^1
-				for (unsigned k = 2; k <= m; ++k) acc = emit_mul(acc, base_copy);  // acc *= base
-				result_loc = acc;                            // base^m
+			// base^m by exponentiation-by-squaring, emitted as multiplications: O(log m) multiplies
+			// instead of O(m) -- a large win at high degree / high precision, where each mpfr multiply
+			// is costly and pow(complex,complex) is far costlier still.  Allocation-free: a*a (aliased
+			// operands) allocates a temporary whereas a*b does not, so before each squaring we copy the
+			// running square into a distinct slot and only ever multiply distinct slots.  The loop also
+			// covers m==1 (yields base_loc, emitting nothing).
+			auto emit_copy = [&](size_t s) -> size_t {
+				const size_t out = next_available_complex_++;
+				program_under_construction_.AddInstruction(Assign, s, out);
+				return out;
+			};
+			size_t sq = base_loc;                            // sq = base^(2^bit)
+			size_t acc = 0; bool have = false;
+			for (unsigned mm = m; mm > 0; mm >>= 1u) {
+				if (mm & 1u) {                               // accumulate this set bit
+					if (have) acc = emit_mul(acc, sq);
+					else      { acc = sq; have = true; }
+				}
+				if (mm > 1u) {                               // more bits remain: sq = sq^2 (distinct ops)
+					const size_t copy = emit_copy(sq);
+					sq = emit_mul(sq, copy);
+				}
 			}
+			result_loc = acc;                                // base^m
 			if (expo < 0) {                                  // x^-k = 1 / x^k
 				const size_t recip = next_available_complex_++;
 				program_under_construction_.AddInstruction(Divide, one_loc(), result_loc, recip);

--- a/core/src/system/straight_line_program.cpp
+++ b/core/src/system/straight_line_program.cpp
@@ -266,7 +266,7 @@ namespace bertini{
 
 		out << std::endl << "instructions: " << std::endl;
 		for (size_t ii(0); ii<prog.instructions_.size(); /*it's in the loop at access time*/){
-			auto op = static_cast<Operation>(prog.instructions_[ii++]);
+			auto op = static_cast<Operation>(prog.instructions_[ii++] & kOpcodeMask);  // strip packed bank bits
 			out << OpcodeToString(op) << "(";
 			if (IsUnary(op)){
 				auto operand = prog.instructions_[ii++];
@@ -383,91 +383,89 @@ namespace bertini{
 
 		const size_t loop_start = frozen_valid ? first_live_instruction_ : 0;
 
-		auto is_real = [&](size_t s){ return slot_numtype_[s] == NumType::Real; };
+		// The operand/result banks are baked into each instruction's opcode word at compile time
+		// (SpecializeInstructions), so these take the decoded flags directly -- no slot_numtype_ lookup
+		// in the hot loop.  r0/r1 = operand-is-real, ro = result-is-real.
 
-		// Binary arithmetic: read each operand from its NumType's bank and write the result to the
-		// result slot's bank.  When the result is Real, inference guarantees both operands are Real
-		// (R+R, R-R, R*R, R/R), so we use the cheap real path; otherwise we use native mixed
-		// arithmetic (real * complex is ~half the work of complex * complex), promoting nothing.
-		// `is_div` marks Divide: only `real_mp / complex_mp` trips the Boost precision bug (and only
-		// when the complex value's imaginary part is 0, which is data-dependent), so we re-tag exactly
-		// that one branch -- the common mixed multiply/add/subtract need no fix-up.
-		auto binop = [&](size_t i1, size_t i2, size_t o, bool is_div, auto fn){
-			if (is_real(o))                          real[o] = fn(real[i1], real[i2]);  // all-real, cheap
-			else if (!is_real(i1) && !is_real(i2))   cplx[o] = fn(cplx[i1], cplx[i2]);  // pure complex
-			else if (is_real(i1)) {                                                     // real (op) complex
+		// Binary arithmetic.  When the result is Real, inference guarantees both operands are Real
+		// (R+R, R-R, R*R, R/R), so we use the cheap real path; otherwise native mixed arithmetic
+		// (real * complex is ~half the work of complex * complex), promoting nothing.  `is_div` marks
+		// Divide: only `real_mp / complex_mp` trips the Boost precision bug (and only when the complex
+		// value's imaginary part is 0), so we re-tag exactly that branch -- mixed +,-,* need no fix-up.
+		auto binop = [&](size_t i1, size_t i2, size_t o, bool r0, bool r1, bool ro, bool is_div, auto fn){
+			if (ro)               real[o] = fn(real[i1], real[i2]);  // all-real, cheap
+			else if (!r0 && !r1)  cplx[o] = fn(cplx[i1], cplx[i2]);  // pure complex
+			else if (r0) {                                           // real (op) complex
 				cplx[o] = fn(real[i1], cplx[i2]);
 				if (is_div) retag(o);
 			}
-			else                                     cplx[o] = fn(cplx[i1], real[i2]);  // complex (op) real
+			else                  cplx[o] = fn(cplx[i1], real[i2]);  // complex (op) real
 		};
 
 		// Type-preserving unary (result NumType == operand NumType): negate/copy/exp/sin/cos/tan/atan.
-		auto un_preserve = [&](size_t i, size_t o, auto fn){
-			if (is_real(o)) real[o] = fn(real[i]); else cplx[o] = fn(cplx[i]);
+		auto un_preserve = [&](size_t i, size_t o, bool ro, auto fn){
+			if (ro) real[o] = fn(real[i]); else cplx[o] = fn(cplx[i]);
 		};
 
-		// Escape unary (result is Complex; a real operand is promoted so the complex branch is taken):
-		// sqrt/log/asin/acos, which can leave ℝ for some real inputs.
-		auto un_escape = [&](size_t i, size_t o, auto fn){
-			// a real operand is promoted by a single converting construction (at the working precision),
-			// not a mixed expression template, so the result is tagged correctly -- no re-tag needed.
-			cplx[o] = is_real(i) ? fn(NumT(real[i])) : fn(cplx[i]);
+		// Escape unary (result is Complex; a real operand is promoted by a single converting
+		// construction at the working precision -- not a mixed expression template -- so it's tagged
+		// correctly): sqrt/log/asin/acos, which can leave ℝ for some real inputs.
+		auto un_escape = [&](size_t i, size_t o, bool ri, auto fn){
+			cplx[o] = ri ? fn(NumT(real[i])) : fn(cplx[i]);
 		};
 
 		for (size_t ii = loop_start; ii<instructions_.size();/*the increment is done at end of loop depending on arity */) {
 			//in the unary case the loop will increment by 3
 			//binary: by 4
 
+			const size_t opw = instructions_[ii];                        // opcode + packed bank bits
+			const Operation op = static_cast<Operation>(opw & kOpcodeMask);
+			const bool r0 = opw & kArg0Real;   // first operand in real bank
+			const bool r1 = opw & kArg1Real;   // second operand in real bank (binary, non-IntPower)
+			const bool ro = opw & kOutReal;    // result in real bank
 			const size_t a = instructions_[ii+1], b = instructions_[ii+2], c = instructions_[ii+3];
 
-			switch (instructions_[ii]) {
+			switch (op) {
 
-				case Add:      binop(a, b, c, false, [](auto const& x, auto const& y){ return x + y; }); break;
-				case Subtract: binop(a, b, c, false, [](auto const& x, auto const& y){ return x - y; }); break;
-				case Multiply: binop(a, b, c, false, [](auto const& x, auto const& y){ return x * y; }); break;
-				case Divide:   binop(a, b, c, true,  [](auto const& x, auto const& y){ return x / y; }); break;
+				case Add:      binop(a, b, c, r0, r1, ro, false, [](auto const& x, auto const& y){ return x + y; }); break;
+				case Subtract: binop(a, b, c, r0, r1, ro, false, [](auto const& x, auto const& y){ return x - y; }); break;
+				case Multiply: binop(a, b, c, r0, r1, ro, false, [](auto const& x, auto const& y){ return x * y; }); break;
+				case Divide:   binop(a, b, c, r0, r1, ro, true,  [](auto const& x, auto const& y){ return x / y; }); break;
 
 				case Power: {
 					// general a^b (slot exponent); result is Complex, so promote any real operand to
 					// complex (a single converting construction at the working precision, not a mixed
 					// expression template), then a pure-complex pow -- so the result is tagged correctly.
-					const NumT base = is_real(a) ? NumT(real[a]) : cplx[a];
-					const NumT expo = is_real(b) ? NumT(real[b]) : cplx[b];
+					const NumT base = r0 ? NumT(real[a]) : cplx[a];
+					const NumT expo = r1 ? NumT(real[b]) : cplx[b];
 					cplx[c] = pow(base, expo);
 					break;
 				}
 
 				case IntPower:
-					// in2 (b) is an index into integers_, not a slot.  real^int -> real, complex^int -> complex.
-					if (is_real(c)) real[c] = pow(real[a], this->integers_[b]);
-					else            cplx[c] = pow(cplx[a], this->integers_[b]);
+					// in2 (b) is an index into integers_, not a slot.  real^int -> real, complex^int -> complex
+					// (result bank == base bank, so `ro` selects both).
+					if (ro) real[c] = pow(real[a], this->integers_[b]);
+					else    cplx[c] = pow(cplx[a], this->integers_[b]);
 					break;
 
-				case Assign:   un_preserve(a, b, [](auto const& x){ return x; }); break;
-				case Negate:   un_preserve(a, b, [](auto const& x){ return -x; }); break;
-				case Exp:      un_preserve(a, b, [](auto const& x){ return exp(x); }); break;
-				case Sin:      un_preserve(a, b, [](auto const& x){ return sin(x); }); break;
-				case Cos:      un_preserve(a, b, [](auto const& x){ return cos(x); }); break;
-				case Tan:      un_preserve(a, b, [](auto const& x){ return tan(x); }); break;
-				case Atan:     un_preserve(a, b, [](auto const& x){ return atan(x); }); break;
+				case Assign:   un_preserve(a, b, ro, [](auto const& x){ return x; }); break;
+				case Negate:   un_preserve(a, b, ro, [](auto const& x){ return -x; }); break;
+				case Exp:      un_preserve(a, b, ro, [](auto const& x){ return exp(x); }); break;
+				case Sin:      un_preserve(a, b, ro, [](auto const& x){ return sin(x); }); break;
+				case Cos:      un_preserve(a, b, ro, [](auto const& x){ return cos(x); }); break;
+				case Tan:      un_preserve(a, b, ro, [](auto const& x){ return tan(x); }); break;
+				case Atan:     un_preserve(a, b, ro, [](auto const& x){ return atan(x); }); break;
 
-				case Sqrt:     un_escape(a, b, [](auto const& x){ return sqrt(x); }); break;
-				case Log:      un_escape(a, b, [](auto const& x){ return log(x); }); break;
-				case Asin:     un_escape(a, b, [](auto const& x){ return asin(x); }); break;
-				case Acos:     un_escape(a, b, [](auto const& x){ return acos(x); }); break;
+				case Sqrt:     un_escape(a, b, r0, [](auto const& x){ return sqrt(x); }); break;
+				case Log:      un_escape(a, b, r0, [](auto const& x){ return log(x); }); break;
+				case Asin:     un_escape(a, b, r0, [](auto const& x){ return asin(x); }); break;
+				case Acos:     un_escape(a, b, r0, [](auto const& x){ return acos(x); }); break;
 
 			} // switch for operation
 
 
-			if (IsUnary(static_cast<Operation>(instructions_[ii]))) {
-				ii = ii+3;
-
-			}
-			//in the binary case the loop will increment by 4
-			else {
-				ii = ii+4;
-			}
+			ii += IsUnary(op) ? 3 : 4;  // op is masked, so arity is read correctly
 		} // for loop around operations
 
 		// A full run (from instruction 0) has just refreshed the frozen prologue at this precision.
@@ -551,6 +549,35 @@ namespace bertini{
 			{
 				slot_numtype_[instructions_[ii + 3]] =
 					BinaryResultNumType(op, slot_numtype_[instructions_[ii + 1]], slot_numtype_[instructions_[ii + 2]]);
+				ii += 4;
+			}
+		}
+	}
+
+
+	void SLPProgram::SpecializeInstructions()
+	{
+		// Bake each instruction's operand/result banks into its opcode word (ADR-0034), so the eval
+		// loop reads them inline rather than looking up slot_numtype_ per slot.  Walk the still-clean
+		// tape; the base op (read before we OR in bits) drives arity, so the increment stays correct.
+		for (size_t ii = 0; ii < instructions_.size(); )
+		{
+			const auto op = static_cast<Operation>(instructions_[ii]);  // clean: bits not yet set here
+			size_t bits = 0;
+			if (IsUnary(op))
+			{
+				if (slot_numtype_[instructions_[ii + 1]] == NumType::Real) bits |= kArg0Real;
+				if (slot_numtype_[instructions_[ii + 2]] == NumType::Real) bits |= kOutReal;
+				instructions_[ii] |= bits;
+				ii += 3;
+			}
+			else
+			{
+				if (slot_numtype_[instructions_[ii + 1]] == NumType::Real) bits |= kArg0Real;
+				// IntPower's second word is an index into integers_, not a slot, so it gets no bank bit.
+				if (op != IntPower && slot_numtype_[instructions_[ii + 2]] == NumType::Real) bits |= kArg1Real;
+				if (slot_numtype_[instructions_[ii + 3]] == NumType::Real) bits |= kOutReal;
+				instructions_[ii] |= bits;
 				ii += 4;
 			}
 		}
@@ -1133,6 +1160,10 @@ namespace bertini{
 		// point-only re-evaluation can skip recomputing the constants (ADR-0027).  This is a pure
 		// program operation (no memory needed).
 		program_under_construction_.PartitionInstructions();
+
+		// Pack the per-instruction bank selectors into the opcode words (after the tape is final), so
+		// eval never touches slot_numtype_.  Must come last -- PartitionInstructions reads clean opcodes.
+		program_under_construction_.SpecializeInstructions();
 
 
 		// Wrap the now-immutable program in a facade and set up a per-thread memory for it.

--- a/core/src/system/straight_line_program.cpp
+++ b/core/src/system/straight_line_program.cpp
@@ -389,14 +389,17 @@ namespace bertini{
 		// result slot's bank.  When the result is Real, inference guarantees both operands are Real
 		// (R+R, R-R, R*R, R/R), so we use the cheap real path; otherwise we use native mixed
 		// arithmetic (real * complex is ~half the work of complex * complex), promoting nothing.
-		auto binop = [&](size_t i1, size_t i2, size_t o, auto fn){
+		// `is_div` marks Divide: only `real_mp / complex_mp` trips the Boost precision bug (and only
+		// when the complex value's imaginary part is 0, which is data-dependent), so we re-tag exactly
+		// that one branch -- the common mixed multiply/add/subtract need no fix-up.
+		auto binop = [&](size_t i1, size_t i2, size_t o, bool is_div, auto fn){
 			if (is_real(o))                          real[o] = fn(real[i1], real[i2]);  // all-real, cheap
-			else if (!is_real(i1) && !is_real(i2))   cplx[o] = fn(cplx[i1], cplx[i2]);  // pure complex, correctly tagged
-			else {  // mixed real/complex: native (the win), but re-tag the mis-reported mpc precision
-				if (is_real(i1)) cplx[o] = fn(real[i1], cplx[i2]);
-				else             cplx[o] = fn(cplx[i1], real[i2]);
-				retag(o);
+			else if (!is_real(i1) && !is_real(i2))   cplx[o] = fn(cplx[i1], cplx[i2]);  // pure complex
+			else if (is_real(i1)) {                                                     // real (op) complex
+				cplx[o] = fn(real[i1], cplx[i2]);
+				if (is_div) retag(o);
 			}
+			else                                     cplx[o] = fn(cplx[i1], real[i2]);  // complex (op) real
 		};
 
 		// Type-preserving unary (result NumType == operand NumType): negate/copy/exp/sin/cos/tan/atan.
@@ -407,8 +410,9 @@ namespace bertini{
 		// Escape unary (result is Complex; a real operand is promoted so the complex branch is taken):
 		// sqrt/log/asin/acos, which can leave ℝ for some real inputs.
 		auto un_escape = [&](size_t i, size_t o, auto fn){
+			// a real operand is promoted by a single converting construction (at the working precision),
+			// not a mixed expression template, so the result is tagged correctly -- no re-tag needed.
 			cplx[o] = is_real(i) ? fn(NumT(real[i])) : fn(cplx[i]);
-			retag(o);
 		};
 
 		for (size_t ii = loop_start; ii<instructions_.size();/*the increment is done at end of loop depending on arity */) {
@@ -419,10 +423,10 @@ namespace bertini{
 
 			switch (instructions_[ii]) {
 
-				case Add:      binop(a, b, c, [](auto const& x, auto const& y){ return x + y; }); break;
-				case Subtract: binop(a, b, c, [](auto const& x, auto const& y){ return x - y; }); break;
-				case Multiply: binop(a, b, c, [](auto const& x, auto const& y){ return x * y; }); break;
-				case Divide:   binop(a, b, c, [](auto const& x, auto const& y){ return x / y; }); break;
+				case Add:      binop(a, b, c, false, [](auto const& x, auto const& y){ return x + y; }); break;
+				case Subtract: binop(a, b, c, false, [](auto const& x, auto const& y){ return x - y; }); break;
+				case Multiply: binop(a, b, c, false, [](auto const& x, auto const& y){ return x * y; }); break;
+				case Divide:   binop(a, b, c, true,  [](auto const& x, auto const& y){ return x / y; }); break;
 
 				case Power: {
 					// general a^b (slot exponent); result is Complex, so promote any real operand to
@@ -431,7 +435,6 @@ namespace bertini{
 					const NumT base = is_real(a) ? NumT(real[a]) : cplx[a];
 					const NumT expo = is_real(b) ? NumT(real[b]) : cplx[b];
 					cplx[c] = pow(base, expo);
-					retag(c);
 					break;
 				}
 

--- a/core/src/system/straight_line_program.cpp
+++ b/core/src/system/straight_line_program.cpp
@@ -443,8 +443,9 @@ namespace bertini{
 				}
 
 				case IntPower:
-					// in2 (b) is an index into integers_, not a slot.  real^int -> real, complex^int -> complex
-					// (result bank == base bank, so `ro` selects both).
+					// Integer powers are lowered to Multiply instructions at COMPILE time now
+					// (Visit(IntegerPowerOperator) does exponentiation by squaring), so the hot loop
+					// only ever does allocation-free multiplies.  This case is a defensive fallback.
 					if (ro) real[c] = pow(real[a], this->integers_[b]);
 					else    cplx[c] = pow(cplx[a], this->integers_[b]);
 					break;
@@ -875,44 +876,81 @@ namespace bertini{
 	void SLPCompiler::Visit(node::IntegerPowerOperator const& n){
 		auto as_ptr = std::dynamic_pointer_cast<node::IntegerPowerOperator const>(n.shared_from_this());
 
-		IntT expo = n.exponent(); //integer
+		const IntT expo = n.exponent(); //integer
 
 		// ensure we have the location of the base of the power operation.  it's a node at this point.
 		auto operand = n.Operand();
 		if (this->locations_encountered_nodes_.find(operand) == this->locations_encountered_nodes_.end())
-		{
 			operand->Accept(*this);
+		const size_t base_loc = locations_encountered_nodes_[operand];
+
+		// Lower base^expo to multiplications at COMPILE time (exponentiation by squaring) instead of
+		// emitting an IntPower that calls boost's pow(mpc,int) -- which does ~14 heap allocations per
+		// call and is the dominant allocation churn in multiprecision eval.  A complex multiply into a
+		// preallocated slot is allocation-free, and the SLP's hash-consing already shares repeated
+		// powers across terms, so this is both faster and the right layer for a known exponent.
+		auto emit_mul = [&](size_t l, size_t r) -> size_t {
+			const size_t out = next_available_complex_++;
+			program_under_construction_.AddInstruction(Multiply, l, r, out);
+			return out;
+		};
+		auto one_loc = [&]() -> size_t {
+			auto one = Integer::Make(1);
+			this->RegisterConstant(one, RecipeFor(*one));
+			return locations_encountered_nodes_[one];
+		};
+
+		size_t result_loc;
+		if (expo == 0)
+			result_loc = one_loc();                         // x^0 = 1
+		else {
+			const unsigned m = expo < 0 ? static_cast<unsigned>(-static_cast<long long>(expo))
+			                            : static_cast<unsigned>(expo);
+			if (m == 1)
+				result_loc = base_loc;                       // x^1 = x (no instruction)
+			else {
+				// base^m by repeated multiplication.  Every multiply must have DISTINCT operands:
+				// mpc squaring (a*a, aliased) allocates a temporary, whereas a*b does not -- so we
+				// first copy the base into its own slot and always multiply against that copy.  The
+				// result is allocation-free (vs ~14 heap ops for boost's pow).
+				const size_t base_copy = next_available_complex_++;
+				program_under_construction_.AddInstruction(Assign, base_loc, base_copy);
+				size_t acc = base_loc;                       // acc = base^1
+				for (unsigned k = 2; k <= m; ++k) acc = emit_mul(acc, base_copy);  // acc *= base
+				result_loc = acc;                            // base^m
+			}
+			if (expo < 0) {                                  // x^-k = 1 / x^k
+				const size_t recip = next_available_complex_++;
+				program_under_construction_.AddInstruction(Divide, one_loc(), result_loc, recip);
+				result_loc = recip;
+			}
 		}
 
-		auto location_operand = locations_encountered_nodes_[operand];
-
-
-
-		if (this->locations_integers_.find(expo) == this->locations_integers_.end())
-		{
-			locations_integers_[expo] = program_under_construction_.integers_.size();
-			program_under_construction_.integers_.push_back(expo);
-		}
-
-
-		auto location_exponent  = locations_integers_[expo]; // this is a map lookup
-
-
-		this->locations_encountered_nodes_[as_ptr] = next_available_complex_;
-		program_under_construction_.AddInstruction(IntPower,location_operand,location_exponent, next_available_complex_++);
+		this->locations_encountered_nodes_[as_ptr] = result_loc;
 	}
 
 
 	void SLPCompiler::Visit(node::PowerOperator const& n){
 		auto as_ptr = std::dynamic_pointer_cast<node::PowerOperator const>(n.shared_from_this());
-		//get location of base and power then add instruction
 
 		const auto& base = n.GetBase();
 		const auto& exponent = n.GetExponent();
 
+		// If the exponent is a compile-time integer (e.g. parsed x^4), lower it to multiplications via
+		// the IntegerPowerOperator path instead of emitting a general Power -- pow(complex,complex) is
+		// the single most allocation-heavy op in mp eval (it goes through exp/log), whereas the lowered
+		// multiplies are allocation-free.
+		if (auto exp_int = std::dynamic_pointer_cast<node::Integer const>(exponent)) {
+			auto ipow = node::pow(base, exp_int->GetValue().convert_to<int>());  // makes an IntegerPowerOperator
+			if (this->locations_encountered_nodes_.find(ipow) == this->locations_encountered_nodes_.end())
+				ipow->Accept(*this);
+			this->locations_encountered_nodes_[as_ptr] = locations_encountered_nodes_[ipow];
+			return;
+		}
+
+		// general base^exponent (symbolic or non-integer exponent)
 		if (this->locations_encountered_nodes_.find(base) == this->locations_encountered_nodes_.end())
 			base->Accept(*this);
-
 		if (this->locations_encountered_nodes_.find(exponent) == this->locations_encountered_nodes_.end())
 			exponent->Accept(*this);
 
@@ -921,9 +959,6 @@ namespace bertini{
 
 		this->locations_encountered_nodes_[as_ptr] =  next_available_complex_;
 		program_under_construction_.AddInstruction(Power, loc_base, loc_exponent, next_available_complex_++);
-
-
-
 	}
 
 	void SLPCompiler::Visit(node::ExpOperator const& n){

--- a/core/src/system/straight_line_program.cpp
+++ b/core/src/system/straight_line_program.cpp
@@ -489,6 +489,8 @@ namespace bertini{
 		}
 	} // anonymous namespace
 
+	bool SLPProgram::tiers_enabled_ = true;
+
 	void SLPProgram::ComputeSlotNumTypes()
 	{
 		// Seed: constant slots from their recipe's real-ness; everything else (variables, the path
@@ -496,6 +498,8 @@ namespace bertini{
 		// dependency-ordered tape propagates the NumType of each instruction's result (same shape as
 		// PartitionInstructions' frozenness pass).
 		slot_numtype_.assign(num_slots_, NumType::Complex);
+		if (!tiers_enabled_)  // A/B baseline: force the pre-tier all-complex evaluation
+			return;
 		for (auto const& c : constant_recipes_)
 			slot_numtype_[c.slot] = c.IsReal() ? NumType::Real : NumType::Complex;
 

--- a/core/test/classes/slp_test.cpp
+++ b/core/test/classes/slp_test.cpp
@@ -6,6 +6,8 @@
 
 #include <set>
 #include <iostream>
+#include <chrono>
+#include <cstdlib>
 
 using Variable = bertini::node::Variable;
 
@@ -548,6 +550,66 @@ BOOST_AUTO_TEST_CASE(real_tier_mixed_eval_correct_mp)
 	slp.Eval(x);
 	auto f = slp.GetFuncVals<complex_mp>();
 	BOOST_CHECK(abs(f(0) - complex_mp(2, 6)) < 1e-40);
+}
+
+// Opt-in A/B speedup benchmark (ADR-0034 gate).  Skipped unless BERTINI_SLP_BENCH is set, so it adds
+// no time to normal runs.  Builds the SAME real-coefficient-heavy system twice -- once with tiers
+// forced off (all-complex baseline) and once on -- and times N evaluations of function + Jacobian at
+// high mpfr precision, where mpfr-complex arithmetic dominates.  Run with:
+//   BERTINI_SLP_BENCH=1 ./build/core/test_classes --run_test=SLP_tiered_numtype/tier_speedup_benchmark
+BOOST_AUTO_TEST_CASE(tier_speedup_benchmark)
+{
+	if (!std::getenv("BERTINI_SLP_BENCH")) { BOOST_CHECK(true); return; }
+
+	using real_mp = bertini::real_mp;
+	const std::string dense =
+		"function f1,f2,f3,f4; variable_group x,y,z,w; "
+		"f1 = 3*x^4 + 5*y^3 + 7*z^2 + 11*w^5 + 2*x*y*z - 13*z*w + 17*x - 19; "
+		"f2 = 23*y^4 + 29*z^3 + 31*x^2 + 37*w + 41*x*z*w - 43*x*y + 47; "
+		"f3 = 53*z^4 + 59*w^3 + 61*x^2 + 67*y^5 + 71*y*z*w - 73*x*w + 79; "
+		"f4 = 83*w^4 + 89*x^3 + 97*y^2 + 101*z^4 + 103*x*y*w - 107*y*z + 109;";
+
+	const char* penv = std::getenv("BERTINI_SLP_BENCH_PREC");
+	const char* nenv = std::getenv("BERTINI_SLP_BENCH_N");
+	const unsigned prec = penv ? static_cast<unsigned>(std::atoi(penv)) : 256;
+	const int N = nenv ? std::atoi(nenv) : 400;
+
+	auto run = [&](bool tiers) -> double {
+		bertini::SLPProgram::tiers_enabled_ = tiers;
+		bertini::DefaultPrecision(prec);
+		auto sys = ParseSLPSys(dense);
+		SLP slp(sys);
+		slp.precision(prec);
+
+		Vec<complex_mp> pt(4);
+		for (int j = 0; j < 4; ++j) pt(j) = complex_mp(real_mp(j + 2), real_mp(j + 1));
+		slp.Eval(pt); (void)slp.GetFuncVals<complex_mp>();  // warm the frozen prologue
+
+		complex_mp sink(0);
+		auto t0 = std::chrono::steady_clock::now();
+		for (int i = 0; i < N; ++i) {
+			pt(0) = complex_mp(real_mp(i % 7 + 2), real_mp(i % 5 + 1));
+			slp.Eval(pt);
+			auto f = slp.GetFuncVals<complex_mp>();
+			auto J = slp.GetJacobian<complex_mp>();
+			sink += f(0) + J(0,0);
+		}
+		auto t1 = std::chrono::steady_clock::now();
+		std::cout << "  [tiers=" << tiers << " real_slots=" << slp.NumRealSlots()
+		          << " sink=" << sink.real() << "]\n";
+		return std::chrono::duration<double>(t1 - t0).count();
+	};
+
+	const double off = run(false);
+	const double on  = run(true);
+	bertini::SLPProgram::tiers_enabled_ = true;  // restore default
+
+	std::cout << "\n=== SLP tier benchmark (prec=" << prec << " digits, N=" << N
+	          << " evals of f+J, 4 fns / 4 vars) ===\n"
+	          << "  tiers OFF (all-complex): " << off << " s\n"
+	          << "  tiers ON  (real tier):   " << on  << " s\n"
+	          << "  speedup: " << (off / on) << "x\n\n";
+	BOOST_CHECK(true);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // SLP_tiered_numtype

--- a/core/test/classes/slp_test.cpp
+++ b/core/test/classes/slp_test.cpp
@@ -495,3 +495,60 @@ BOOST_AUTO_TEST_CASE(precision_change_recomputes_constants)
 
 BOOST_AUTO_TEST_SUITE_END() // SLP_freeze_partition
 
+
+
+// ADR-0034: real-valued subexpressions evaluate in the cheaper real banks (NumType::Real), and the
+// result must equal the all-complex evaluation.  The rest of the C++ suite is the broad equivalence
+// gate (it solves/tracks integer- and rational-coefficient systems through the SLP); here we confirm
+// the inference is actually LIVE (not a silent all-Complex no-op) and that the mixed real-coefficient
+// x complex-variable path is numerically correct, at double and multiprecision.
+BOOST_AUTO_TEST_SUITE(SLP_tiered_numtype)
+
+using complex_mp = bertini::complex_mp;
+
+namespace {
+	bertini::System ParseSLPSys(std::string const& str){
+		bertini::System sys;
+		[[maybe_unused]] bool ok = bertini::parsing::classic::parse(str.begin(), str.end(), sys);
+		return sys;
+	}
+	// f = 3*x^2 + 2 : integer coefficients 3 and 2 are real, x is complex.
+	const std::string kRealCoeffSys = "function f; variable_group x; f = 3*x^2 + 2;";
+}
+
+// An integer-coefficient system must infer at least one Real slot -- otherwise the tier machinery
+// would be a silent no-op and there would be no speedup.
+BOOST_AUTO_TEST_CASE(integer_coeff_system_infers_real_slots)
+{
+	auto slp = SLP(ParseSLPSys(kRealCoeffSys));
+	BOOST_CHECK_GT(slp.NumRealSlots(), size_t(0));
+}
+
+// Evaluated at a genuinely complex point, the real-coefficient * complex-variable path must produce
+// the correct complex value (and Jacobian) -- i.e. the imaginary part propagates through the mixed
+// real*complex arithmetic.  x = 1+i:  3*(1+i)^2 + 2 = 3*(2i) + 2 = 2 + 6i;  df/dx = 6x = 6 + 6i.
+BOOST_AUTO_TEST_CASE(real_tier_mixed_eval_correct_double)
+{
+	auto slp = SLP(ParseSLPSys(kRealCoeffSys));
+	BOOST_REQUIRE_GT(slp.NumRealSlots(), size_t(0));
+
+	Vec<complex_dbl> x(1); x(0) = complex_dbl(1.0, 1.0);
+	slp.Eval(x);
+	auto f = slp.GetFuncVals<complex_dbl>();
+	auto J = slp.GetJacobian<complex_dbl>();
+	BOOST_CHECK_SMALL(abs(f(0)   - complex_dbl(2.0, 6.0)), 1e-13);
+	BOOST_CHECK_SMALL(abs(J(0,0) - complex_dbl(6.0, 6.0)), 1e-13);
+}
+
+// Same, at multiprecision: the real_mp bank carries the coefficients at the working precision.
+BOOST_AUTO_TEST_CASE(real_tier_mixed_eval_correct_mp)
+{
+	auto slp = SLP(ParseSLPSys(kRealCoeffSys));
+	Vec<complex_mp> x(1); x(0) = complex_mp(1, 1);
+	slp.Eval(x);
+	auto f = slp.GetFuncVals<complex_mp>();
+	BOOST_CHECK(abs(f(0) - complex_mp(2, 6)) < 1e-40);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // SLP_tiered_numtype
+

--- a/core/test/classes/slp_test.cpp
+++ b/core/test/classes/slp_test.cpp
@@ -562,12 +562,32 @@ BOOST_AUTO_TEST_CASE(tier_speedup_benchmark)
 	if (!std::getenv("BERTINI_SLP_BENCH")) { BOOST_CHECK(true); return; }
 
 	using real_mp = bertini::real_mp;
-	const std::string dense =
-		"function f1,f2,f3,f4; variable_group x,y,z,w; "
-		"f1 = 3*x^4 + 5*y^3 + 7*z^2 + 11*w^5 + 2*x*y*z - 13*z*w + 17*x - 19; "
-		"f2 = 23*y^4 + 29*z^3 + 31*x^2 + 37*w + 41*x*z*w - 43*x*y + 47; "
-		"f3 = 53*z^4 + 59*w^3 + 61*x^2 + 67*y^5 + 71*y*z*w - 73*x*w + 79; "
-		"f4 = 83*w^4 + 89*x^3 + 97*y^2 + 101*z^4 + 103*x*y*w - 107*y*z + 109;";
+	// Generate an nv-variable, nv-function dense integer-coefficient system (degree up to `deg`),
+	// so the benchmark can scale: bigger systems do more arithmetic per eval, shrinking the fixed
+	// per-eval overhead (allocations, output extraction) relative to the tiered arithmetic.
+	const char* nvenv = std::getenv("BERTINI_SLP_BENCH_NVARS");
+	const int nv  = nvenv ? std::atoi(nvenv) : 4;
+	const int deg = 5;
+	// zero-padded names (x00, x01, ...) so no name is a prefix of another (x1 vs x10 confuses the parser)
+	auto vn = [](int i){ char b[8]; std::snprintf(b, sizeof b, "x%03d", i); return std::string(b); };
+	auto fn = [](int i){ char b[8]; std::snprintf(b, sizeof b, "f%03d", i); return std::string(b); };
+	auto make_system = [&]() -> std::string {
+		std::string s = "function ";
+		for (int i = 0; i < nv; ++i) s += fn(i) + (i + 1 < nv ? "," : "; ");
+		s += "variable_group ";
+		for (int i = 0; i < nv; ++i) s += vn(i) + (i + 1 < nv ? "," : "; ");
+		int c = 2;
+		for (int i = 0; i < nv; ++i) {
+			s += fn(i) + " = ";
+			for (int j = 0; j < nv; ++j)  // one power term per variable
+				s += std::to_string(c++) + "*" + vn(j) + "^" + std::to_string((j % deg) + 2) + " + ";
+			for (int j = 0; j + 1 < nv; ++j)  // cross terms
+				s += std::to_string(c++) + "*" + vn(j) + "*" + vn(j + 1) + " + ";
+			s += std::to_string(c++) + "; ";
+		}
+		return s;
+	};
+	const std::string dense = make_system();
 
 	const char* penv = std::getenv("BERTINI_SLP_BENCH_PREC");
 	const char* nenv = std::getenv("BERTINI_SLP_BENCH_N");
@@ -581,8 +601,8 @@ BOOST_AUTO_TEST_CASE(tier_speedup_benchmark)
 		SLP slp(sys);
 		slp.precision(prec);
 
-		Vec<complex_mp> pt(4);
-		for (int j = 0; j < 4; ++j) pt(j) = complex_mp(real_mp(j + 2), real_mp(j + 1));
+		Vec<complex_mp> pt(nv);
+		for (int j = 0; j < nv; ++j) pt(j) = complex_mp(real_mp(j + 2), real_mp(j + 1));
 		slp.Eval(pt); (void)slp.GetFuncVals<complex_mp>();  // warm the frozen prologue
 
 		complex_mp sink(0);
@@ -608,8 +628,8 @@ BOOST_AUTO_TEST_CASE(tier_speedup_benchmark)
 		bertini::SLPProgram::tiers_enabled_ = tiers;
 		auto sys = ParseSLPSys(dense);
 		SLP slp(sys);
-		Vec<complex_dbl> pt(4);
-		for (int j = 0; j < 4; ++j) pt(j) = complex_dbl(j + 2, j + 1);
+		Vec<complex_dbl> pt(nv);
+		for (int j = 0; j < nv; ++j) pt(j) = complex_dbl(j + 2, j + 1);
 		slp.Eval(pt); (void)slp.GetFuncVals<complex_dbl>();
 
 		complex_dbl sink(0);
@@ -640,6 +660,47 @@ BOOST_AUTO_TEST_CASE(tier_speedup_benchmark)
 	          << "  MPFR prec=" << prec << " digits (N=" << N << " evals of f+J):\n"
 	          << "    tiers OFF: " << off << " s    tiers ON: " << on
 	          << " s    speedup: " << (off / on) << "x\n\n";
+	BOOST_CHECK(true);
+}
+
+// Probe the user's hypothesis: is real_mp * complex_mp actually cheaper than complex*complex, or
+// does Boost.Multiprecision promote the real operand to complex first (4 muls, no saving)?  And how
+// much of mpfr cost is the multiply vs. number management?  Opt-in via BERTINI_SLP_BENCH.
+BOOST_AUTO_TEST_CASE(mpfr_raw_op_microbench)
+{
+	if (!std::getenv("BERTINI_SLP_BENCH")) { BOOST_CHECK(true); return; }
+	using real_mp = bertini::real_mp;
+	const char* penv = std::getenv("BERTINI_SLP_BENCH_PREC");
+	const unsigned prec = penv ? static_cast<unsigned>(std::atoi(penv)) : 256;
+	const char* menv = std::getenv("BERTINI_SLP_BENCH_M");
+	const long M = menv ? std::atol(menv) : 1000000;
+	bertini::DefaultPrecision(prec);
+
+	complex_mp ac(real_mp("1.2345"), real_mp("5.6789"));
+	complex_mp bc(real_mp("9.8765"), real_mp("4.3210"));
+	complex_mp zc(0); bertini::Precision(zc, prec);
+	real_mp ar("3.14159"), br("2.71828"), zr(0);
+
+	complex_mp sink(0); bertini::Precision(sink, prec);
+	real_mp rsink(0);
+	auto timeit = [&](auto&& f){
+		auto t0 = std::chrono::steady_clock::now();
+		for (long i = 0; i < M; ++i) f();
+		return std::chrono::duration<double>(std::chrono::steady_clock::now() - t0).count();
+	};
+
+	const double t_cc = timeit([&]{ zc = ac * bc; sink += zc; });  // complex * complex
+	const double t_rc = timeit([&]{ zc = ar * bc; sink += zc; });  // real * complex (tier hot path)
+	const double t_rr = timeit([&]{ zr = ar * br; rsink += zr; }); // real * real
+
+	std::cout << "\n=== raw mpfr multiply microbench (prec=" << prec << ", M=" << M
+	          << ", sink=" << sink.real() << "/" << rsink << ") ===\n"
+	          << "  complex*complex: " << t_cc << " s\n"
+	          << "  real*complex:    " << t_rc << " s   (rc/cc = " << (t_rc / t_cc) << ")\n"
+	          << "  real*real:       " << t_rr << " s   (rr/cc = " << (t_rr / t_cc) << ")\n"
+	          << "  => " << (t_rc / t_cc < 0.8 ? "real*complex IS cheaper -- tier helps arithmetic"
+	                                           : "real*complex ~ complex*complex -- Boost promotes; no arithmetic win")
+	          << "\n\n";
 	BOOST_CHECK(true);
 }
 

--- a/core/test/classes/slp_test.cpp
+++ b/core/test/classes/slp_test.cpp
@@ -845,5 +845,35 @@ BOOST_AUTO_TEST_CASE(mpfr_alloc_per_raw_op)
 	BOOST_CHECK(true);
 }
 
+// Is the lowered O(n) repeated-multiply actually faster than the transcendental pow(complex,complex)?
+// Find the crossover exponent above which we should stop lowering and keep a general pow.  Opt-in.
+BOOST_AUTO_TEST_CASE(power_method_crossover)
+{
+	if (!std::getenv("BERTINI_SLP_BENCH")) { BOOST_CHECK(true); return; }
+	using real_mp = bertini::real_mp;
+	const char* penv = std::getenv("BERTINI_SLP_BENCH_PREC");
+	const unsigned prec = penv ? static_cast<unsigned>(std::atoi(penv)) : 256;
+	bertini::DefaultPrecision(prec);
+	complex_mp base(real_mp("1.3"), real_mp("0.7")), basec(0), acc(0), tmp(0), result(0);
+	for (auto* p : {&base, &basec, &acc, &tmp, &result}) bertini::Precision(*p, prec);
+	basec = base;
+	const long M = 5000;
+	auto timeit = [&](auto&& f){ auto t0 = std::chrono::steady_clock::now();
+		for (long i = 0; i < M; ++i) f();
+		return std::chrono::duration<double>(std::chrono::steady_clock::now() - t0).count() / M * 1e6; };  // us/op
+
+	std::cout << "\n=== power method crossover (prec=" << prec << " digits, us per op) ===\n";
+	std::cout << "   n | repeated-mul | pow(c,int) | pow(c,complex) | mul faster than pow(c,c)?\n";
+	for (int n : {2, 3, 4, 6, 8, 12, 16, 24, 32, 48, 64, 96}) {
+		complex_mp en(n); bertini::Precision(en, prec);
+		const double t_mul = timeit([&]{ acc = base; for (int k = 2; k <= n; ++k) { tmp = acc * basec; acc.swap(tmp); } result.swap(acc); });
+		const double t_pi  = timeit([&]{ result = pow(base, n); });
+		const double t_pc  = timeit([&]{ result = pow(base, en); });
+		std::cout << "  " << (n<10?" ":"") << n << " | " << t_mul << "      | " << t_pi
+		          << "    | " << t_pc << "      | " << (t_mul < t_pc ? "yes" : "NO -- pow wins") << "\n";
+	}
+	BOOST_CHECK(true);
+}
+
 BOOST_AUTO_TEST_SUITE_END() // SLP_tiered_numtype
 

--- a/core/test/classes/slp_test.cpp
+++ b/core/test/classes/slp_test.cpp
@@ -8,6 +8,8 @@
 #include <iostream>
 #include <chrono>
 #include <cstdlib>
+#include <atomic>
+#include <gmp.h>
 
 using Variable = bertini::node::Variable;
 
@@ -730,6 +732,116 @@ BOOST_AUTO_TEST_CASE(mpfr_raw_op_microbench)
 	          << "  => " << (t_rc / t_cc < 0.8 ? "real*complex IS cheaper -- tier helps arithmetic"
 	                                           : "real*complex ~ complex*complex -- Boost promotes; no arithmetic win")
 	          << "\n\n";
+	BOOST_CHECK(true);
+}
+
+namespace {
+	// A counting GMP allocator: delegates to std malloc/realloc/free (so blocks stay interchangeable
+	// with the default GMP allocator) while tallying calls.  Used to quantify mpfr churn per eval.
+	std::atomic<long> g_alloc{0}, g_realloc{0}, g_free{0}, g_bytes{0};
+	void* counting_alloc(size_t n)                       { ++g_alloc;  g_bytes += static_cast<long>(n); return std::malloc(n); }
+	void* counting_realloc(void* p, size_t /*o*/, size_t n){ ++g_realloc; return std::realloc(p, n); }
+	void  counting_free(void* p, size_t /*n*/)           { ++g_free;   std::free(p); }
+}
+
+// Quantify the mpfr allocation churn of the live eval segment (the user's hypothesis: alloc/dealloc,
+// not op-count, is the mp performance limit).  Counts malloc/realloc/free per eval of f+J at mp
+// precision.  Opt-in via BERTINI_SLP_BENCH.
+BOOST_AUTO_TEST_CASE(mpfr_alloc_churn_per_eval)
+{
+	if (!std::getenv("BERTINI_SLP_BENCH")) { BOOST_CHECK(true); return; }
+	using real_mp = bertini::real_mp;
+	const char* penv = std::getenv("BERTINI_SLP_BENCH_PREC");
+	const unsigned prec = penv ? static_cast<unsigned>(std::atoi(penv)) : 256;
+	bertini::DefaultPrecision(prec);
+
+	const char* sysenv = std::getenv("BERTINI_SLP_BENCH_SYS");
+	auto sys_for_slp = ParseSLPSys(sysenv ? sysenv :
+		"function f0,f1,f2,f3; variable_group x0,x1,x2,x3; "
+		"f0 = 3*x0^4 + 5*x1^3 + 7*x2^2 + 11*x3^5 + 2*x0*x1*x2 - 13*x2*x3 + 17*x0 - 19; "
+		"f1 = 23*x1^4 + 29*x2^3 + 31*x0^2 + 37*x3 + 41*x0*x2*x3 - 43*x0*x1 + 47; "
+		"f2 = 53*x2^4 + 59*x3^3 + 61*x0^2 + 67*x1^5 + 71*x1*x2*x3 - 73*x0*x3 + 79; "
+		"f3 = 83*x3^4 + 89*x0^3 + 97*x1^2 + 101*x2^4 + 103*x0*x1*x3 - 107*x1*x2 + 109;");
+	auto slp = SLP(sys_for_slp);
+	if (std::getenv("BERTINI_SLP_DUMP")) std::cout << "\n----- SLP -----\n" << slp << "\n---------------\n";
+	slp.precision(prec);
+	const int nvars = static_cast<int>(slp.NumVariables());
+	Vec<complex_mp> pt(nvars);
+	for (int j = 0; j < nvars; ++j) pt(j) = complex_mp(real_mp(j + 2), real_mp(j + 1));
+	slp.Eval(pt); (void)slp.GetFuncVals<complex_mp>(); (void)slp.GetJacobian<complex_mp>();  // warm prologue
+
+	// install the counting allocator (blocks stay malloc/free-compatible, so mixing is safe)
+	void* (*oa)(size_t); void* (*ora)(void*, size_t, size_t); void (*ofr)(void*, size_t);
+	mp_get_memory_functions(&oa, &ora, &ofr);
+	mp_set_memory_functions(counting_alloc, counting_realloc, counting_free);
+
+	const int N = 200;
+	// Pre-build the varying inputs OUTSIDE the counted region -- constructing complex_mp/real_mp
+	// allocates, and we must not attribute that to eval.  Assigning a prebuilt value is alloc-free.
+	std::vector<complex_mp> inputs;
+	for (int i = 0; i < N; ++i) inputs.push_back(complex_mp(real_mp(i % 7 + 2), real_mp(i % 5 + 1)));
+
+	// (a) eval live segment only
+	g_alloc = g_realloc = g_free = 0;
+	for (int i = 0; i < N; ++i) { pt(0) = inputs[i]; slp.Eval(pt); }
+	const double e_malloc = double(g_alloc)/N, e_realloc = double(g_realloc)/N, e_free = double(g_free)/N;
+	// (b) eval + output extraction (GetFuncVals + GetJacobian build Eigen Vec/Mat<mpc>)
+	g_alloc = g_realloc = g_free = 0;
+	for (int i = 0; i < N; ++i) {
+		pt(0) = inputs[i];
+		slp.Eval(pt); (void)slp.GetFuncVals<complex_mp>(); (void)slp.GetJacobian<complex_mp>();
+	}
+	const double t_malloc = double(g_alloc)/N, t_realloc = double(g_realloc)/N, t_free = double(g_free)/N;
+	mp_set_memory_functions(oa, ora, ofr);         // restore
+
+	std::cout << "\n=== mpfr alloc churn (prec=" << prec << ", N=" << N << ", 4 fns/4 vars) ===\n"
+	          << "  eval only        : malloc=" << e_malloc << " realloc=" << e_realloc << " free=" << e_free << "\n"
+	          << "  eval + extraction: malloc=" << t_malloc << " realloc=" << t_realloc << " free=" << t_free << "\n"
+	          << "  extraction adds  : malloc=" << (t_malloc-e_malloc) << " realloc=" << (t_realloc-e_realloc) << "\n\n";
+	BOOST_CHECK(true);
+}
+
+// How many heap ops does a single raw mpc/mpfr op cost?  Tells us how much of the eval churn is
+// Boost's per-op INTERNAL scratch (which only a pooling allocator can fix) vs our own temporaries.
+BOOST_AUTO_TEST_CASE(mpfr_alloc_per_raw_op)
+{
+	if (!std::getenv("BERTINI_SLP_BENCH")) { BOOST_CHECK(true); return; }
+	using real_mp = bertini::real_mp;
+	const char* penv = std::getenv("BERTINI_SLP_BENCH_PREC");
+	const unsigned prec = penv ? static_cast<unsigned>(std::atoi(penv)) : 256;
+	bertini::DefaultPrecision(prec);
+	const long M = 5000;
+
+	complex_mp a(real_mp("1.5"), real_mp("2.5")), b(real_mp("3.5"), real_mp("4.5")), c(0);
+	bertini::Precision(c, prec);
+
+	void* (*oa)(size_t); void* (*ora)(void*, size_t, size_t); void (*ofr)(void*, size_t);
+	mp_get_memory_functions(&oa, &ora, &ofr);
+	auto measure = [&](const char* label, auto&& op){
+		mp_set_memory_functions(counting_alloc, counting_realloc, counting_free);
+		g_alloc = g_realloc = g_free = 0;
+		for (long i = 0; i < M; ++i) op();
+		mp_set_memory_functions(oa, ora, ofr);
+		std::cout << "  " << label << ": malloc=" << double(g_alloc)/M
+		          << " realloc=" << double(g_realloc)/M << " free=" << double(g_free)/M << "\n";
+	};
+	std::cout << "\n=== heap ops per raw op (prec=" << prec << ", into a preallocated dest) ===\n";
+	real_mp r("2.5"); bertini::Precision(r, prec);
+	measure("c = a * b   (complex*complex)    ", [&]{ c = a * b; });
+	measure("c = a * a   (SQUARING, aliased)  ", [&]{ c = a * a; });
+	measure("c = a + b   (complex+complex)    ", [&]{ c = a + b; });
+	measure("c = r * a   (real*complex MIXED) ", [&]{ c = r * a; });
+	measure("c = r + a   (real+complex MIXED) ", [&]{ c = r + a; });
+	measure("c = a * r   (complex*real MIXED) ", [&]{ c = a * r; });
+	measure("c = a       (copy / Assign)      ", [&]{ c = a; });
+	measure("c = mul-lambda(a,b) (eval binop) ", [&]{ c = [](auto const& x, auto const& y){ return x*y; }(a, b); });
+	measure("c = (-x)-lambda(a)  (eval Negate)", [&]{ c = [](auto const& x){ return -x; }(a); });
+	measure("c = pow(a,4)(IntPower)           ", [&]{ c = pow(a, 4); });
+	// in-place exponentiation by squaring with one reused scratch -- the proposed IntPower replacement
+	measure("c = a^4 by squaring (1 scratch)  ", [&]{
+		static thread_local complex_mp base; bertini::Precision(base, prec);
+		base = a; c = a; for (int k = 1; k < 4; ++k) c *= base;   // simple repeated multiply (alloc-free?)
+	});
 	BOOST_CHECK(true);
 }
 

--- a/core/test/classes/slp_test.cpp
+++ b/core/test/classes/slp_test.cpp
@@ -600,15 +600,46 @@ BOOST_AUTO_TEST_CASE(tier_speedup_benchmark)
 		return std::chrono::duration<double>(t1 - t0).count();
 	};
 
+	// DOUBLE precision -- where the AMP tracker spends most of its time, and the worst case for
+	// per-op dispatch overhead (cheap hardware arithmetic, so the slot_numtype_ branches dominate).
+	const char* ndenv = std::getenv("BERTINI_SLP_BENCH_NDBL");
+	const int Nd = ndenv ? std::atoi(ndenv) : 100000;
+	auto run_dbl = [&](bool tiers) -> double {
+		bertini::SLPProgram::tiers_enabled_ = tiers;
+		auto sys = ParseSLPSys(dense);
+		SLP slp(sys);
+		Vec<complex_dbl> pt(4);
+		for (int j = 0; j < 4; ++j) pt(j) = complex_dbl(j + 2, j + 1);
+		slp.Eval(pt); (void)slp.GetFuncVals<complex_dbl>();
+
+		complex_dbl sink(0);
+		auto t0 = std::chrono::steady_clock::now();
+		for (int i = 0; i < Nd; ++i) {
+			pt(0) = complex_dbl(i % 7 + 2, i % 5 + 1);
+			slp.Eval(pt);
+			auto f = slp.GetFuncVals<complex_dbl>();
+			auto J = slp.GetJacobian<complex_dbl>();
+			sink += f(0) + J(0,0);
+		}
+		auto t1 = std::chrono::steady_clock::now();
+		std::cout << "  [dbl tiers=" << tiers << " real_slots=" << slp.NumRealSlots()
+		          << " sink=" << sink.real() << "]\n";
+		return std::chrono::duration<double>(t1 - t0).count();
+	};
+	const double d_off = run_dbl(false);
+	const double d_on  = run_dbl(true);
+
 	const double off = run(false);
 	const double on  = run(true);
 	bertini::SLPProgram::tiers_enabled_ = true;  // restore default
 
-	std::cout << "\n=== SLP tier benchmark (prec=" << prec << " digits, N=" << N
-	          << " evals of f+J, 4 fns / 4 vars) ===\n"
-	          << "  tiers OFF (all-complex): " << off << " s\n"
-	          << "  tiers ON  (real tier):   " << on  << " s\n"
-	          << "  speedup: " << (off / on) << "x\n\n";
+	std::cout << "\n=== SLP tier benchmark (4 fns / 4 vars) ===\n"
+	          << "  DOUBLE  (N=" << Nd << " evals of f+J):\n"
+	          << "    tiers OFF: " << d_off << " s    tiers ON: " << d_on
+	          << " s    speedup: " << (d_off / d_on) << "x\n"
+	          << "  MPFR prec=" << prec << " digits (N=" << N << " evals of f+J):\n"
+	          << "    tiers OFF: " << off << " s    tiers ON: " << on
+	          << " s    speedup: " << (off / on) << "x\n\n";
 	BOOST_CHECK(true);
 }
 

--- a/core/test/classes/slp_test.cpp
+++ b/core/test/classes/slp_test.cpp
@@ -552,6 +552,35 @@ BOOST_AUTO_TEST_CASE(real_tier_mixed_eval_correct_mp)
 	BOOST_CHECK(abs(f(0) - complex_mp(2, 6)) < 1e-40);
 }
 
+// Regression: the tier dispatch builds complex temporaries when promoting a real operand to complex
+// (Power/sqrt/log/...).  Boost inits a fresh mpc at the thread-default precision, which on the eval
+// path is not guaranteed to be the working precision -- if it is 0, mpc_init2 aborts.  Eval pins the
+// thread precision to the working precision first.  Exercises the promotion paths at mp precision:
+// x/y's Jacobian (-x/y^2) promotes a real exponent constant, and sqrt/log/x^3 are the escape ops.
+BOOST_AUTO_TEST_CASE(mp_promotion_paths_evaluate_correctly)
+{
+	bertini::DefaultPrecision(40);
+	auto slp = SLP(ParseSLPSys("function f; variable_group x, y; f = x/y;"));
+	slp.precision(40);
+
+	Vec<complex_mp> pt(2);
+	pt(0) = complex_mp(6); pt(1) = complex_mp(2);
+	slp.Eval(pt);
+	auto f = slp.GetFuncVals<complex_mp>();
+	auto J = slp.GetJacobian<complex_mp>();         // -x/y^2 promotes a real exponent constant
+
+	BOOST_CHECK(abs(f(0)   - complex_mp(3)) < 1e-30);             // 6/2 = 3
+	BOOST_CHECK(abs(J(0,0) - complex_mp(1) / complex_mp(2)) < 1e-30); // d(x/y)/dx = 1/y = 1/2
+
+	auto g = SLP(ParseSLPSys("function f; variable_group x; f = sqrt(x) + log(x) + x^3;"));
+	g.precision(40);
+	Vec<complex_mp> q(1); q(0) = complex_mp(4);
+	g.Eval(q);
+	auto gf = g.GetFuncVals<complex_mp>();
+	using std::sqrt; using std::log;
+	BOOST_CHECK(abs(gf(0) - (sqrt(complex_mp(4)) + log(complex_mp(4)) + complex_mp(64))) < 1e-30);
+}
+
 // Opt-in A/B speedup benchmark (ADR-0034 gate).  Skipped unless BERTINI_SLP_BENCH is set, so it adds
 // no time to normal runs.  Builds the SAME real-coefficient-heavy system twice -- once with tiers
 // forced off (all-complex baseline) and once on -- and times N evaluations of function + Jacobian at

--- a/docs/adr/0034-tiered-slp-arithmetic.md
+++ b/docs/adr/0034-tiered-slp-arithmetic.md
@@ -3,9 +3,32 @@
 **Status:** Accepted (design; implementation staged and measurement-gated)
 **Date:** 2026-06-27
 
-> **Implementation status (2026-06-27):** design only. No tier code yet. Foundation in flight:
-> the `Float`→`Complex` node rename (PR #37) makes the literal node honestly "complex" and frees
-> the name `Real`. Stages below land behind equivalence tests and a benchmark gate.
+> **Implementation status (2026-06-27):** **Stage 1 (real tier) implemented and landed.** The
+> `Float`→`Complex` node rename (PR #37) and the scalar-name standardization (PR #38) are the
+> foundation. Stage 2 (integer tier) is **deferred** — see the measured outcome below. JIT (the lever
+> for competing with HomotopyContinuation.jl) is captured separately and deferred unless it proves
+> straightforward.
+
+## Measured outcome (Stage 1)
+
+The real tier is correct (tiered eval is bit-identical to all-complex; verified by the full C++ suite
+plus `SLP_tiered_numtype`) and a **modest, no-regression win**: ~10% at mpfr (256 digits) and ~8% at
+double, with no fully-complex regression even at 4096 digits.
+
+A raw-op probe (`mpfr_raw_op_microbench`) settles *why* the win is only modest — and rules out two
+suspected culprits:
+- Boost does **not** promote: `real_mp * complex_mp` costs 0.33–0.45× a complex×complex multiply, and
+  `real_mp * real_mp` 0.14–0.21×. So the tier genuinely makes the ops it touches 2–3× cheaper.
+- The hot loop is **not** allocation-bound: the register banks are pre-allocated and expression
+  templates evaluate into the destination slot.
+
+The ceiling is **structural**: in a polynomial over *complex* variables, the monomial arithmetic
+(`x⁵`, `x·y·z`) is irreducibly complex and dominates per-eval cost, while the real-valued coefficients
+are frozen constants computed once in the prologue. Only the coefficient×monomial multiplies (~1 in
+`degree`) go cheap, so the aggregate per-eval win is bounded. The genuine "much faster" levers are
+therefore **reducing the count of complex multiplies** (Horner / stronger CSE) and **JIT** (removing
+interpreter overhead, biggest at double) — not more tiers. Hence Stage 2 (integer tier, expected to
+hit the same ceiling for even less of the work) is deferred.
 
 ## Context
 

--- a/docs/adr/0034-tiered-slp-arithmetic.md
+++ b/docs/adr/0034-tiered-slp-arithmetic.md
@@ -1,0 +1,89 @@
+# ADR-0034: Tiered numeric arithmetic in the SLP (integer / real / complex)
+
+**Status:** Accepted (design; implementation staged and measurement-gated)
+**Date:** 2026-06-27
+
+> **Implementation status (2026-06-27):** design only. No tier code yet. Foundation in flight:
+> the `Float`→`Complex` node rename (PR #37) makes the literal node honestly "complex" and frees
+> the name `Real`. Stages below land behind equivalence tests and a benchmark gate.
+
+## Context
+
+The SLP is the sole evaluator of polynomial systems (ADR-0027). It evaluates **everything in
+complex**: the register file is `tuple<vector<dbl_complex>, vector<mpfr_complex>>` — one bank per
+precision, both complex — and even an integer or rational coefficient is widened to a complex slot
+(`ConstantRecipe::Produce`) before any arithmetic touches it.
+
+`mpfr_complex` arithmetic is the most expensive thing the library does: a complex multiply is ~4 real
+multiplies + 2 adds, each an arbitrary-precision mpfr operation. Yet polynomial systems are full of
+cheaper structure — integer/rational/real coefficients, and coefficient×variable products where one
+operand is narrow. Evaluating those in the **narrowest sufficient numeric type** and widening to
+complex only when an operation demands it should be a large speedup at high precision, where the
+`mpfr_complex` cost dominates everything else.
+
+There is precedent: the existing **`IntPower`** opcode reads its exponent from a separate `integers_`
+bank and dispatches to integer-power `pow` — a cross-tier operation, which this design generalizes.
+
+The counter-risk, raised explicitly: a mixed-type tape adds register banks and per-operation tier
+dispatch, which can **thrash cache and lose locality**, potentially eating the arithmetic savings.
+So this is **measured, not assumed** — every tier must demonstrate a net speedup before it ships.
+
+## Decision
+
+Introduce a **tier lattice** `Integer ⊂ Real ⊂ Complex`, **orthogonal to precision**.
+
+- **Precision stays the `Eval<NumT>` template parameter** (double vs mpfr), preserving the AMP
+  template invariant: the numeric type is not smeared into runtime state. **Tier is a per-slot
+  runtime property *within* a precision.** So `Eval<mpfr_complex>` works over mpfr banks
+  `{mpz_int, mpfr_float, mpfr_complex}` and `Eval<dbl_complex>` over `{int, double, dbl_complex}`.
+
+1. **Per-slot tier + per-tier banks.** The single complex bank becomes three banks per precision
+   (integer/real/complex). Every slot carries a tier tag; slots are allocated per-tier in the
+   compiler.
+
+2. **Compile-time tier inference** in `SLPCompiler`. A subexpression's tier is the *join* of its
+   operands' tiers, with op-specific escapes:
+   - `+ - *` → join(operands).
+   - `/` → escapes to at least real (integer/integer is not integer).
+   - `sqrt, log, ^non-integer` → complex unless the operand is provably non-negative real (default
+     complex, to stay correct on negative reals).
+   - `IntPower` → base tier. `exp, trig` → operand tier.
+   Leaves seed the lattice: `Kind::Integer→Integer`; `Rational→Real` (Integer if unit denominator);
+   `Complex→Real` when `imag==0` else `Complex`; `Pi/E→Real`; variables and the path variable →
+   `Complex` (homotopy unknowns are complex).
+
+3. **Explicit promotion (widening) instructions.** Where an operation needs an operand at a higher
+   tier than its slot, the compiler emits a `Promote` instruction (int→real, real→complex) into a
+   target-tier slot. Widening is explicit and cheap, so eval stays branch-simple.
+
+4. **Tier-aware eval dispatch.** `Add/Subtract/Multiply/Divide` carry their operand+result tiers,
+   compactly encoded so the combinatorial blow-up stays bounded; the hot mixed case (narrow×complex)
+   gets a dedicated fast path (`real*complex` = 2 real muls, not 4). The pure-complex path is kept
+   byte-identical to today, so a fully-complex system never regresses.
+
+5. **`IntPower` is folded in** as the Integer-tier-operand special case it already is.
+
+## Staging (each stage gated by tests + benchmark)
+
+- **Stage 0 — this ADR + scalar-name standardization.** One real + one complex type per precision,
+  with an explicit `using` for the double real type (changeable in one place); the vocabulary the
+  banks and inference are written against.
+- **Stage 1 — Real tier.** Real bank, real↔complex promotion, tier-aware `+ - * /` for `{real,
+  complex}`. The common, high-value, lowest-combinatorial case. **Gate:** equivalence holds and the
+  benchmark shows a net mpfr speedup with no fully-complex regression.
+- **Stage 2 — Integer tier.** Integer bank, int→real/complex promotion, integer fast paths, `IntPower`
+  folded in. **Same gate.** If a tier does not pay off in measurement, it does not ship.
+
+## Consequences
+
+- **Speedup** on integer/rational/real-coefficient systems at high precision (the goal).
+- **Correctness invariant:** tiered eval must equal all-complex eval to rounding — verified by a
+  battery of systems at double and several mpfr precisions, for functions and Jacobian (the analogue
+  of "threaded == serial").
+- **Serialization format bump:** the tape and memory layout change; the SLP archive version is bumped
+  and old dev archives will not load (acceptable pre-release; consistent with the node rename).
+- **Complexity cost:** a larger eval switch and per-slot tier bookkeeping. Mitigated by keeping the
+  complex path unchanged, by explicit (not implicit) promotion, and by the measurement gate — a tier
+  that loses to cache effects is dropped rather than shipped.
+- **Builds on** ADR-0027 (immutable Program + per-thread Memory; the freeze-set prologue) and the
+  `Float`→`Complex` rename; precedent from the existing `IntPower` cross-tier op.

--- a/docs/adr/0035-slp-eval-is-allocation-free.md
+++ b/docs/adr/0035-slp-eval-is-allocation-free.md
@@ -1,0 +1,76 @@
+# ADR-0035: The SLP eval loop is allocation-free (lower integer powers to multiplies; no by-value temporaries)
+
+**Status:** Accepted
+**Date:** 2026-06-27
+
+## Context
+
+The straight-line program (SLP) is the sole evaluator of polynomial systems (ADR-0027), and its
+inner `Eval<NumT>` loop is the hottest code in the library — it runs once per Newton step, per path,
+per homotopy. At multiprecision the cost is dominated by `mpfr`/`mpc` arithmetic, and for years the
+working assumption was that the arithmetic itself was the floor.
+
+It was not. A counting GMP allocator (`mp_set_memory_functions`) over the eval loop showed the real
+cost was **heap allocation churn**: a *single* evaluation of function + Jacobian for a tiny dense
+4-variable, degree-≤5 system did **~1132 `malloc`/`free` pairs** at 256 digits (and ~2874 at 1024),
+with `malloc` exactly balanced by `free` — pure churn. Per-operation probes isolated three sources,
+none of them the arithmetic:
+
+1. **`pow` for integer powers.** `pow(mpc, int)` heap-allocates ~14 temporaries per call; worse, the
+   parser builds `x^k` as a general `PowerOperator`, so it was emitting `pow(mpc, mpc)` — the
+   *transcendental* `exp(k·log x)` — at ~40 µs/call at 256 digits (and ~720 µs at 1600). A complex
+   multiply into a preallocated slot, by contrast, is **0 allocations**.
+2. **A differentiation bug.** `PowerOperator::Differentiate` built the new exponent as an
+   *unevaluated* `exponent - 1` node, so `d(x^4)/dx` was `4·x^(4-1)` — a power with a *computed*
+   exponent that the SLP could not recognize as integer, falling back to the allocation-heavy general
+   `pow`. Jacobians were the worst offenders.
+3. **By-value temporaries in the hot loop.** The eval's `Assign` and `Negate` were implemented with a
+   by-value `return x` / `return -x` lambda, which materializes a fresh `mpc` temporary (an
+   allocation) instead of writing in place. (Arithmetic `+ - * /` were already allocation-free via
+   Boost expression templates evaluating into the destination slot.)
+
+A further trap was measured and must be remembered: **aliased multiplication allocates.** `c = a*a`
+(same operand twice) costs ~6 heap ops because `mpc` defensively allocates a temporary for the
+squaring, whereas `c = a*b` (distinct operands) is 0.
+
+## Decision
+
+**The SLP eval loop must perform zero heap allocations.** Concretely:
+
+1. **Lower integer powers to multiplications at compile time.** `Visit(IntegerPowerOperator)` and
+   `Visit(PowerOperator)`-with-integer-exponent emit a chain of `Multiply` instructions using
+   **exponentiation by squaring** (O(log n) multiplies). The squarings are kept allocation-free by
+   copying the running square into a distinct slot before each square, so every multiply has distinct
+   operands. The SLP's hash-consing shares repeated powers across terms. No `IntPower`/`Power`
+   instruction is emitted for an integer exponent; the general `Power` opcode remains only for
+   genuinely symbolic/non-integer exponents.
+2. **Differentiation folds constant integer exponents to literals.** `PowerOperator::Differentiate`
+   emits `n·x^(n-1)` with `n-1` a literal `Integer` when the exponent is an integer literal, so
+   derivatives lower like any other integer power.
+3. **No by-value temporaries in eval.** Results are written in place into the preallocated register
+   slots: arithmetic uses expression templates; `Assign`/`Negate` are direct slot operations
+   (`cplx[o] = cplx[i]` / `-cplx[i]`), not a value-returning lambda. Promotions and the rare
+   transcendentals are the only remaining temporary constructions, and they must construct at the
+   working precision (see ADR-0034's thread-precision pin).
+
+No transcendental fallback for large exponents is warranted: the crossover sweep (30–1600 digits)
+shows `pow(complex,complex)` always loses to the lowered multiplies, and by a wider margin at higher
+precision (transcendentals scale worse than multiplies).
+
+## Consequences
+
+- **~10× faster multiprecision eval**, and **0 allocations per eval at ≤256 digits** (1132 → 0).
+  This is what makes b2's evaluation competitive at high precision.
+- **A standing invariant to defend.** The three traps — calling `pow`, multiplying aliased operands
+  (`a*a`), and returning mpc/mpfr *by value* — each silently reintroduce per-op allocation. New eval
+  code and new function-tree → SLP lowerings must avoid them. The probes that caught this live in
+  `core/test/classes/slp_test.cpp` (`mpfr_alloc_churn_per_eval`, `mpfr_alloc_per_raw_op`,
+  `power_method_crossover`, opt-in via `BERTINI_SLP_BENCH`).
+- **Residual at extreme precision.** At ~1024+ digits some `realloc`/`malloc` remains (≈198/eval at
+  1024) from `mpfr` limb growth; a pooling GMP allocator would mop that up but is process-global and
+  thread-/wheel-sensitive, so it is deferred.
+- **Follow-ups:** `Assign` *elision* (copy propagation / slot coalescing) would cut instruction count
+  further (the lowering and output wiring emit copies). JIT (ADR-0034 / task) removes the interpreter
+  entirely.
+- **Builds on** ADR-0027 (immutable Program + preallocated per-thread Memory) and ADR-0034 (tiered
+  arithmetic; the thread-precision pin and the per-slot bank dispatch).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -51,3 +51,4 @@ Each ADR follows the template:
 | [0031](0031-eigenpy-vec-index-returns-aliasing-view-copy-before-storing.md) | Indexing an eigenpy Vec returns an aliasing view — copy values before storing them (fixes #259) | Python bindings |
 | [0032](0032-slice-is-a-thin-wrapper-over-linear-forms-block.md) | A witness set's Slice is a thin wrapper over LinearFormsBlock; LinearSlice retired | Core / nag_datatypes |
 | [0033](0033-slice-shape-contract-we-own-dimensionality.md) | Slice shape is OUR accessors' contract, not eigenpy's: coefficients() always 2-D, slice[i] a form vector, slice[i:j] a sub-Slice | Python bindings |
+| [0034](0034-tiered-slp-arithmetic.md) | SLP evaluates in the narrowest sufficient numeric tier (integer<real<complex), orthogonal to precision; widen only when an op demands it; measurement-gated | Core / SLP |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -52,3 +52,4 @@ Each ADR follows the template:
 | [0032](0032-slice-is-a-thin-wrapper-over-linear-forms-block.md) | A witness set's Slice is a thin wrapper over LinearFormsBlock; LinearSlice retired | Core / nag_datatypes |
 | [0033](0033-slice-shape-contract-we-own-dimensionality.md) | Slice shape is OUR accessors' contract, not eigenpy's: coefficients() always 2-D, slice[i] a form vector, slice[i:j] a sub-Slice | Python bindings |
 | [0034](0034-tiered-slp-arithmetic.md) | SLP evaluates in the narrowest sufficient numeric tier (integer<real<complex), orthogonal to precision; widen only when an op demands it; measurement-gated | Core / SLP |
+| [0035](0035-slp-eval-is-allocation-free.md) | The SLP eval loop is allocation-free — lower integer powers to multiplies (exp-by-squaring), fold differentiated exponents to literals, no by-value temporaries; ~10x faster mp eval, 0 allocs/eval ≤256 digits | Core / SLP / performance |


### PR DESCRIPTION
The tiered-SLP-arithmetic sprint (ADR-0034) and, the headline, the **elimination of MPFR allocation churn in SLP eval** (ADR-0035): multiprecision evaluation is now **allocation-free at ≤256 digits and ~10× faster**.

## What's here

**S1 — real tier (ADR-0034):** per-slot `NumType`, real/complex register banks, compile-time inference, `NumType`-aware dispatch with native mixed `real_mp * complex_mp`, and a compile-time fold of the operand/result bank selection into the opcode word (no `slot_numtype_` lookup in the hot loop). Double eval ~+10-16%.

**The big one — allocation-free eval (ADR-0035):** an mpfr-allocation probe showed eval was dominated by **heap churn, not arithmetic** (~1132 malloc/eval for a tiny system at 256 digits). Three causes, all fixed:
- integer powers went through `pow` (parser emitted `pow(complex,complex)`, ~40µs/op) → **lowered to multiplies at compile time** via exp-by-squaring, kept alloc-free (aliased `a*a` allocates; distinct `a*b` does not);
- a **differentiation bug**: `d(x^4)` produced `x^(4-1)` (computed exponent) that fell back to general `pow` → **fold `n-1` to a literal**;
- eval's `Assign`/`Negate` minted temporaries via by-value lambdas → **direct in-place ops**.

Result: **1132 → 0 malloc/eval** at 256 digits.

| precision | malloc/eval before | after |
|---|---|---|
| 64 | 910 | **0** |
| 256 | 1132 | **0** |
| 1024 | 2874 | 198 (limb growth) |

## ⚠️ Contains a Boost.Multiprecision bug workaround — commit `a00a8877`

While building the real tier we hit a genuine **Boost.Multiprecision bug**, minimally reproduced with no bertini: `real_mp / complex_mp` mis-tags the result precision to **0** when the divisor's imaginary part is 0 (`*`, `+`, `-`, `complex/real`, and nonzero-imaginary division are all fine), which SIGABRTs on a later copy. **Commit `a00a8877`** is the workaround (a narrow re-tag on exactly that branch) and the C++ regression `mp_promotion_paths_evaluate_correctly`. To be reported upstream; report drafted in local `z_notes/`.

## Notes
- Overlaps PR #38 (scalar-name standardization, split out so the naming is preserved regardless); after #38 merges this rebases onto develop to dedupe that commit.
- ADRs: 0034 (tiered arithmetic), 0035 (allocation-free eval).

## Tests
All 10 C++ suites + full pytest (541 passed) green. Allocation/crossover probes added (opt-in `BERTINI_SLP_BENCH`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)