### PR TITLE
fix(endgame): Cauchy SecurityLevel guard was inverted — truncate diverging paths

### DIFF
--- a/core/include/bertini2/endgames/cauchy.hpp
+++ b/core/include/bertini2/endgames/cauchy.hpp
@@ -1134,7 +1134,7 @@ public:
 				return SuccessCode::Success;
 			}
 
-			if (this->SecuritySettings().level)
+			if (this->SecuritySettings().level <= 0)
 			{//we are too large, break out of loop to return error.
 				norm_of_dehom_latest = this->GetSystem().InfinityNormOfDehomogenized(latest_approx);
 

--- a/core/test/nag_algorithms/zero_dim.cpp
+++ b/core/test/nag_algorithms/zero_dim.cpp
@@ -573,6 +573,12 @@ BOOST_AUTO_TEST_CASE(infinite_solutions_at_infinity)
 
 	auto zd = algorithm::ZeroDim<TrackerT, endgame::EndgameSelector<TrackerT>::Cauchy, System, start_system::TotalDegree>(sys);
 	zd.DefaultSetup();
+	// SecurityLevel <= 0 truncates paths heading to infinity as failures (SecurityMaxNormReached);
+	// this test wants the at-infinity path actually computed, so raise the level to keep tracking it
+	// to its (infinite) endpoint, where it is classified as a divergence.
+	endgame::SecurityConfig sec;
+	sec.level = 1;
+	zd.GetEndgame().Set(sec);
 	zd.Solve();
 
 	auto r = zd.Report();

--- a/docs/adr/0037-cauchy-endgame-securitylevel-guard-inverted.md
+++ b/docs/adr/0037-cauchy-endgame-securitylevel-guard-inverted.md
@@ -1,0 +1,53 @@
+# ADR-0037: The Cauchy endgame's SecurityLevel guard was inverted (diverging paths ground at escalating precision)
+
+**Status:** Accepted
+
+## Context
+
+Benchmarking the b2 CLI against Bertini 1.7 on zero-dim solves (cyclic5, adaptive precision)
+showed b2 ~100× slower. An instrumented investigation found:
+
+- The over-escalation to multiprecision is **entirely in the endgame** (≈89% of corrector
+  criterion checks, ≈97% of the multiprecision arithmetic cost); main-path tracking runs in double
+  and already matches b1.
+- The escalation is driven solely by AMP **Criterion C**, responding to a Jacobian that is
+  **genuinely near-singular**: an independent full-inverse norm matched the random-probe estimate of
+  `‖J⁻¹‖` to within ~6%, reaching `~10²⁰`. (So the condition probe is faithful; the matrix really is
+  near-singular.)
+- The near-singular points belong to paths whose **homogenizing coordinate `x[0] → 0`** — i.e.
+  paths **diverging to infinity**. As `x[0]` collapses, the homogenized Jacobian degenerates, so
+  Criterion C correctly demands ever more precision — but it is *wasted* work on doomed paths.
+
+Bertini 1 truncates such paths cheaply (it reported "Truncated infinite paths: 50 — set
+SecurityLevel to 1"). b2 was *not* truncating them. Root cause: in `endgames/cauchy.hpp` the
+SecurityMaxNorm divergence check was guarded by `if (SecuritySettings().level)` — i.e. it only ran
+when `level != 0`. But the **default is `level = 0`**, and the PowerSeries endgame guards the same
+check with `if (level <= 0)`. An in-code NOTE already flagged the two as "appear inconsistent."
+Bertini 1 semantics (authoritative): **SecurityLevel ≤ 0 ⇒ truncate paths going to infinity**
+(the safe default); **level ≥ 1 ⇒ keep tracking them** so the at-infinity endpoints are computed.
+So b2's Cauchy guard was inverted: at the default level it never truncated, and ground every
+diverging path through the full Cauchy endgame at escalating precision.
+
+## Decision
+
+1. Fix the guard in `endgames/cauchy.hpp` to `if (this->SecuritySettings().level <= 0)`, matching
+   the PowerSeries endgame and Bertini 1. At the default SecurityLevel 0, diverging paths are now
+   truncated (returning `SuccessCode::SecurityMaxNormReached`).
+2. Keep `SecurityMaxNormReached` classified as a **path failure**, not an infinite endpoint — a
+   truncation is "we gave up on this path", not a computed at-infinity solution (this mirrors
+   Bertini 1, which lists them as truncated and tells you to raise SecurityLevel to compute them).
+   `ZeroDim::Report()` therefore continues to count only `GoingToInfinity` as a divergence.
+3. To *compute* infinite endpoints, set `SecurityConfig::level >= 1` so paths are tracked to their
+   (infinite) endpoint and classified `GoingToInfinity`. The `infinite_solutions_at_infinity` test
+   now sets `level = 1` to exercise that path.
+
+## Consequences
+
+- cyclic5 (serial, mptype 2): **25.3s → 11.1s** (~2.3×), with all 70 finite solutions unchanged
+  and matching Bertini 1 to <1e-8. The remaining gap vs b1 (~0.2s) is the per-step double-precision
+  machinery overhead, tracked separately.
+- Default behavior is now b1-faithful: diverging paths are truncated cheaply instead of ground
+  through the MP endgame. Users who want at-infinity endpoints raise SecurityLevel (as in b1).
+- Note left for follow-up: `SecurityConfig::max_norm`'s default (`1e4`) carries a "wrong default
+  value" comment; and `InfiniteSolutions()` still lists `SecurityMaxNormReached` points — both are
+  pre-existing and out of scope for this fix.


### PR DESCRIPTION
## What

The Cauchy endgame guarded its SecurityMaxNorm divergence check with `if (SecuritySettings().level)` — so it only truncated paths going to infinity when `level != 0`. But the **default is `level = 0`**, and the PowerSeries endgame uses `if (level <= 0)` for the same check (an in-code NOTE already flagged the inconsistency). **Bertini 1 is authoritative**: SecurityLevel ≤ 0 truncates paths going to infinity (safe default); level ≥ 1 keeps tracking them so at-infinity endpoints are computed.

So at the default level, b2 never truncated diverging paths and ground every one through the full Cauchy endgame at escalating multiprecision: the homogenizing coordinate `x[0] → 0` makes the homogenized Jacobian genuinely near-singular (`‖J⁻¹‖ ~ 1e20`), so AMP Criterion C correctly demanded ever more precision — all wasted on doomed paths. b1 truncates them cheaply ("Truncated infinite paths: N").

## Fix
- `cauchy.hpp`: guard with `level <= 0`, matching PowerSeries and b1.
- `SecurityMaxNormReached` stays a path **failure** (a truncation, not a computed infinite endpoint); `ZeroDim::Report()` continues to count only `GoingToInfinity` as a divergence.
- To compute at-infinity endpoints, raise `SecurityLevel >= 1`; the `infinite_solutions_at_infinity` test now does so.

## Impact
cyclic5 (serial, mptype 2): **25.3s → 11.1s (~2.3×)**; 70 finite solutions unchanged, matching Bertini 1 to <1e-8. Full ctest green. See **ADR-0037**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)