### PR TITLE
De-template ZeroDim on the start system; add linear-product TotalDegree

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -174,12 +174,25 @@ jobs:
           CCACHE_DIR: ${{ github.workspace }}/.ccache
         run: ccache -s || true
 
-      - name: Test
+      # Run the suite under BOTH thread settings.  OMP_NUM_THREADS overrides the requested per-solve
+      # thread count (parallel::EffectiveThreadCount), so the serial and threaded code paths genuinely
+      # differ; running both on every platform catches threading bugs (e.g. clone-per-thread) that a
+      # single setting would hide.  `--parallel` is ctest's *process* parallelism (independent of the
+      # per-solve OMP count), so each leg still runs the test executables concurrently.
+      - name: Test (threaded + OMP_NUM_THREADS=1)
         working-directory: build
         env:
           LD_LIBRARY_PATH: /tmp/boost-base/lib:/tmp/boost-base/lib64
           DYLD_LIBRARY_PATH: /tmp/boost-base/lib
-        run: ctest --output-on-failure --timeout 600 --parallel $(nproc 2>/dev/null || sysctl -n hw.ncpu)
+        run: |
+          set -e
+          jobs=$(nproc 2>/dev/null || sysctl -n hw.ncpu)
+          echo "::group::ctest with OMP_NUM_THREADS unset (per-solve threading on)"
+          env -u OMP_NUM_THREADS ctest --output-on-failure --timeout 600 --parallel "$jobs"
+          echo "::endgroup::"
+          echo "::group::ctest with OMP_NUM_THREADS=1 (per-solve serial)"
+          OMP_NUM_THREADS=1 ctest --output-on-failure --timeout 600 --parallel "$jobs"
+          echo "::endgroup::"
 
       # The published wheels ship WITHOUT MPI (we can't know the user's MPI), but this C++ build is
       # MPI-enabled (openmpi is installed above), so we verify the MPI runtime path actually works
@@ -258,10 +271,21 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release
           cmake --build build --parallel
 
-      - name: Test
+      # Run under both per-solve thread settings (see the unix C++ test job for the rationale).
+      - name: Test (threaded + OMP_NUM_THREADS=1)
         shell: pwsh
         working-directory: build
-        run: ctest --output-on-failure --timeout 600 --parallel
+        run: |
+          Remove-Item Env:\OMP_NUM_THREADS -ErrorAction SilentlyContinue
+          Write-Host "::group::ctest with OMP_NUM_THREADS unset (per-solve threading on)"
+          ctest --output-on-failure --timeout 600 --parallel
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          Write-Host "::endgroup::"
+          $env:OMP_NUM_THREADS = '1'
+          Write-Host "::group::ctest with OMP_NUM_THREADS=1 (per-solve serial)"
+          ctest --output-on-failure --timeout 600 --parallel
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          Write-Host "::endgroup::"
 
   build_macos_ubuntu_wheels:
     name: ${{ matrix.os }} Python-${{ matrix.python-version }} wheels

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -280,6 +280,7 @@ set(system_headers
 
 set(system_start_headers
 	include/bertini2/system/start/total_degree.hpp
+	include/bertini2/system/start/roots_of_unity.hpp
 	include/bertini2/system/start/mhom.hpp
 	include/bertini2/system/start/user.hpp
 	include/bertini2/system/start/utility.hpp
@@ -371,6 +372,7 @@ set(system_source_files
     src/system/system.cpp
     src/system/straight_line_program.cpp
     src/system/start/total_degree.cpp
+    src/system/start/roots_of_unity.cpp
     src/system/start/mhom.cpp
     src/system/start/user.cpp
 )

--- a/core/include/bertini2/blackbox/config.hpp
+++ b/core/include/bertini2/blackbox/config.hpp
@@ -34,40 +34,16 @@ namespace bertini{
 
 
 namespace type{
-enum class Start{ TotalDegree, MHom, User};
+enum class Start{ TotalDegree, RootsOfUnity, MHom, User};
 enum class Tracker{ FixedDouble, FixedMultiple, Adaptive};
 enum class Endgame{ PowerSeries, Cauchy};
 }
 
-
-template<typename T>
-	struct StorageSelector{};
-
-template<>
-	struct StorageSelector<start_system::User>
-	{
-		using ShouldClone = typename std::false_type;
-		// typename algorithm::StorageSelector<StartType>::Storage
-		// using Storage = typename policy::RefToGiven<System, start_system::User>;
-	};
-
-template<>
-	struct StorageSelector<start_system::TotalDegree>
-	{
-		// using Storage = typename policy::CloneGiven<System, start_system::TotalDegree>;
-		// typedef policy::CloneGiven Storage;
-		using ShouldClone = typename std::true_type;
-		// using Storage = typename policy::CloneGiven;
-	};
-
-template<>
-	struct StorageSelector<start_system::MHomogeneous>
-	{
-		using ShouldClone = typename std::true_type;
-		// template < typename T, typename S>
-		// using Storage = typename policy::CloneGiven<T,S>;
-	};
-
+// NOTE: the old StorageSelector<StartSystem> (clone-vs-ref per start-system type) is
+// gone.  ZeroDim is no longer templated on the start system, so the clone-vs-ref choice
+// is made at the construction site by picking the policy instantiation directly: the
+// blackbox always clones (CloneGiven + a start-system factory; see switches_zerodim.hpp),
+// and user homotopies use RefToGiven through the dedicated UserHomotopy path.
 
 	}
 }

--- a/core/include/bertini2/blackbox/switches_zerodim.hpp
+++ b/core/include/bertini2/blackbox/switches_zerodim.hpp
@@ -46,7 +46,10 @@ namespace blackbox{
 
 struct ZeroDimRT
 {
-	type::Start start = type::Start::TotalDegree;
+	// INTERIM default = RootsOfUnity (see policies.hpp): the linear-product TotalDegree is the
+	// eventual default but currently stalls the Cauchy endgame on harder systems, so the safe
+	// default stays roots of unity until that is fixed.
+	type::Start start = type::Start::RootsOfUnity;
 	type::Tracker tracker = type::Tracker::Adaptive;
 	type::Endgame endgame = type::Endgame::Cauchy;
 };
@@ -67,71 +70,57 @@ User-defined homotopies are not inferred here; they come with their own start sy
 */
 inline type::Start InferStartType(System const& sys)
 {
+	// INTERIM: a single affine group infers RootsOfUnity (the safe default).  The eventual choice
+	// here is TotalDegree (general position), gated on the Cauchy-endgame fix; see policies.hpp.
 	if (sys.NumVariableGroups() == 1 && sys.NumHomVariableGroups() == 0)
-		return type::Start::TotalDegree;
+		return type::Start::RootsOfUnity;
 	else
 		return type::Start::MHom;
 }
 
 
-template <typename StartType, typename TrackerType, typename EndgameType, template<typename,typename> class SystemManagementPol, typename ... ConstTs>
+// The concrete start-system type appears only at the construction site, via
+// policy::MakeStartFactory<StartType>() (see common/policies.hpp); ZeroDim downstream is a
+// single type that holds the start system polymorphically.  Add a start system => add a
+// case in ZeroDimSpecifyStart, no new ZeroDim instantiation.
+
+template <typename TrackerType, typename EndgameType, typename ... ConstTs>
 std::unique_ptr<algorithm::AnyZeroDim> ZeroDimSpecifyComplete(ConstTs const& ...ts)
 {
+	// the blackbox always clones (default CloneGiven policy); ts... = (target, start_factory).
 	return std::make_unique<
-			algorithm::ZeroDim<
-				TrackerType, 
-				EndgameType, 
-				System, 
-				StartType,
-				SystemManagementPol>
+			algorithm::ZeroDim<TrackerType, EndgameType, System>
 			>(ts...);
 }
 
-template <typename StartType, typename TrackerType, typename EndgameType, typename ... ConstTs>
-std::unique_ptr<algorithm::AnyZeroDim> ZeroDimSpecifyShouldClone(std::true_type, ConstTs const& ...ts)
-{
-	// honor EndgameType!  until 2026-06-12 this hardcoded the Cauchy endgame,
-	// so selecting PowerSeries through the blackbox silently ran Cauchy.
-	return ZeroDimSpecifyComplete<StartType, TrackerType,
-			EndgameType, policy::CloneGiven>(ts...);
-}
-
-template <typename StartType, typename TrackerType, typename EndgameType, typename ... ConstTs>
-std::unique_ptr<algorithm::AnyZeroDim> ZeroDimSpecifyShouldClone(std::false_type, ConstTs const& ...ts)
-{
-	return ZeroDimSpecifyComplete<StartType, TrackerType,
-			EndgameType, policy::RefToGiven>(ts...);
-}
-
-
-template <typename StartType, typename TrackerType, typename ... ConstTs>
+template <typename TrackerType, typename ... ConstTs>
 std::unique_ptr<algorithm::AnyZeroDim> ZeroDimSpecifyEndgame(ZeroDimRT const& rt, ConstTs const& ...ts)
 {
-	
 	switch (rt.endgame)
 	{
 		case type::Endgame::PowerSeries:
-			return ZeroDimSpecifyShouldClone<StartType, TrackerType, 
-					typename endgame::EndgameSelector<TrackerType>::PSEG>(typename StorageSelector<StartType>::ShouldClone(), ts...);
+			// honor the requested endgame!  until 2026-06-12 this hardcoded Cauchy.
+			return ZeroDimSpecifyComplete<TrackerType,
+					typename endgame::EndgameSelector<TrackerType>::PSEG>(ts...);
 
 		case type::Endgame::Cauchy:
-			return ZeroDimSpecifyShouldClone<StartType, TrackerType, 
-					typename endgame::EndgameSelector<TrackerType>::Cauchy>(typename StorageSelector<StartType>::ShouldClone(), ts...);
+			return ZeroDimSpecifyComplete<TrackerType,
+					typename endgame::EndgameSelector<TrackerType>::Cauchy>(ts...);
 	}
 	throw std::runtime_error("unrecognized endgame type in ZeroDimSpecifyEndgame");
 }
 
-template <typename StartType, typename ... ConstTs>
+template <typename ... ConstTs>
 std::unique_ptr<algorithm::AnyZeroDim> ZeroDimSpecifyTracker(ZeroDimRT const& rt, ConstTs const& ...ts)
 {
 	switch (rt.tracker)
 	{
 		case type::Tracker::FixedDouble:
-			return ZeroDimSpecifyEndgame<StartType, tracking::DoublePrecisionTracker>(rt, ts...);
+			return ZeroDimSpecifyEndgame<tracking::DoublePrecisionTracker>(rt, ts...);
 		case type::Tracker::FixedMultiple:
-			return ZeroDimSpecifyEndgame<StartType, tracking::MultiplePrecisionTracker>(rt, ts...);
+			return ZeroDimSpecifyEndgame<tracking::MultiplePrecisionTracker>(rt, ts...);
 		case type::Tracker::Adaptive:
-			return ZeroDimSpecifyEndgame<StartType, tracking::AMPTracker>(rt, ts...);
+			return ZeroDimSpecifyEndgame<tracking::AMPTracker>(rt, ts...);
 	}
 	throw std::runtime_error("unrecognized tracker type in ZeroDimSpecifyTracker");
 }
@@ -139,12 +128,15 @@ std::unique_ptr<algorithm::AnyZeroDim> ZeroDimSpecifyTracker(ZeroDimRT const& rt
 template <typename ... ConstTs>
 std::unique_ptr<algorithm::AnyZeroDim> ZeroDimSpecifyStart(ZeroDimRT const& rt, ConstTs const& ...ts)
 {
+	// append the start-system factory to the argument pack; CloneGiven consumes (target, factory).
 	switch (rt.start)
 	{
 		case type::Start::TotalDegree:
-			return ZeroDimSpecifyTracker<start_system::TotalDegree>(rt, ts...);
+			return ZeroDimSpecifyTracker(rt, ts..., policy::MakeStartFactory<start_system::TotalDegree>());
+		case type::Start::RootsOfUnity:
+			return ZeroDimSpecifyTracker(rt, ts..., policy::MakeStartFactory<start_system::RootsOfUnity>());
 		case type::Start::MHom:
-			return ZeroDimSpecifyTracker<start_system::MHomogeneous>(rt, ts...);
+			return ZeroDimSpecifyTracker(rt, ts..., policy::MakeStartFactory<start_system::MHomogeneous>());
 		case type::Start::User:
 			throw std::runtime_error("trying to use generic zero dim with user homotopy.  use the specific UserBlaBla instead");
 	}

--- a/core/include/bertini2/blackbox/user_homotopy.hpp
+++ b/core/include/bertini2/blackbox/user_homotopy.hpp
@@ -37,25 +37,57 @@
 #include "bertini2/endgames.hpp"
 
 #include "bertini2/blackbox/config.hpp"
+#include "bertini2/blackbox/switches_zerodim.hpp"   // ZeroDimRT
 
 
 namespace bertini{
 namespace blackbox{
 
 
+// User homotopies use the RefToGiven policy (the user owns target/start/homotopy), so they
+// get their own tracker/endgame dispatch chain -- distinct from the generic ZeroDimSpecify*
+// ladder, which always clones.  ts... = (target, start_system, homotopy).
 
+template <typename TrackerType, typename EndgameType, typename ... ConstTs>
+std::unique_ptr<algorithm::AnyZeroDim> UserHomSpecifyComplete(ConstTs const& ...ts)
+{
+	return std::make_unique<
+			algorithm::ZeroDim<TrackerType, EndgameType, System, policy::RefToGiven>
+			>(ts...);
+}
 
+template <typename TrackerType, typename ... ConstTs>
+std::unique_ptr<algorithm::AnyZeroDim> UserHomSpecifyEndgame(ZeroDimRT const& rt, ConstTs const& ...ts)
+{
+	switch (rt.endgame)
+	{
+		case type::Endgame::PowerSeries:
+			return UserHomSpecifyComplete<TrackerType, typename endgame::EndgameSelector<TrackerType>::PSEG>(ts...);
+		case type::Endgame::Cauchy:
+			return UserHomSpecifyComplete<TrackerType, typename endgame::EndgameSelector<TrackerType>::Cauchy>(ts...);
+	}
+	throw std::runtime_error("unrecognized endgame type in UserHomSpecifyEndgame");
+}
 
 template <typename ... ConstTs>
-std::unique_ptr<algorithm::AnyZeroDim> UserHomSpecifyStart(ZeroDimRT const& rt, ConstTs const& ...ts)
+std::unique_ptr<algorithm::AnyZeroDim> UserHomSpecifyTracker(ZeroDimRT const& rt, ConstTs const& ...ts)
 {
-	return ZeroDimSpecifyTracker<start_system::User>(rt, ts...);
+	switch (rt.tracker)
+	{
+		case type::Tracker::FixedDouble:
+			return UserHomSpecifyEndgame<tracking::DoublePrecisionTracker>(rt, ts...);
+		case type::Tracker::FixedMultiple:
+			return UserHomSpecifyEndgame<tracking::MultiplePrecisionTracker>(rt, ts...);
+		case type::Tracker::Adaptive:
+			return UserHomSpecifyEndgame<tracking::AMPTracker>(rt, ts...);
+	}
+	throw std::runtime_error("unrecognized tracker type in UserHomSpecifyTracker");
 }
 
 template <typename ... ConstTs>
 std::unique_ptr<algorithm::AnyZeroDim> MakeUserHom(ZeroDimRT const& rt, ConstTs const& ...ts)
 {
-	return UserHomSpecifyStart(rt, ts...);
+	return UserHomSpecifyTracker(rt, ts...);
 }
 
 

--- a/core/include/bertini2/nag_algorithms/common/policies.hpp
+++ b/core/include/bertini2/nag_algorithms/common/policies.hpp
@@ -32,10 +32,59 @@ You can also provide your own, that's the point of these policies.
 
 #pragma once
 
+#include "bertini2/system/start_base.hpp"   // start_system::StartSystem (polymorphic base)
+
+#include <functional>
+#include <memory>
+
 
 namespace bertini {
 
+	// forward decl so CloneGiven can default its start-system factory without pulling the concrete
+	// header in here.  The default is only instantiated at call sites, where the start systems are
+	// in scope (start_systems.hpp rides in at the bottom of zero_dim_solve.hpp, which every ZeroDim
+	// user includes).
+	//
+	// INTERIM DEFAULT = RootsOfUnity.  The eventual default is the linear-product TotalDegree (it is
+	// in general position; roots of unity has a clustering problem at t=1), but TotalDegree currently
+	// drives the Cauchy endgame into a corrector-roundoff-floor stall on harder systems (e.g. cyclic5)
+	// -- a known issue being worked separately.  Until that lands, the canonical default stays
+	// RootsOfUnity so the default solve never hangs.
+	namespace start_system { class RootsOfUnity; }
+
 	namespace policy{
+
+		/**
+		\brief A factory that builds a start system from a (prepared) target system.
+
+		The zero-dim algorithm is no longer templated on the concrete start-system type --
+		it holds the start system polymorphically through the `start_system::StartSystem`
+		base.  The CloneGiven policy is handed one of these factories at construction (by the
+		blackbox switch or the python bindings, which know the concrete type there) and calls
+		it on the homogenized/patched target to mint the start system.  Adding a new start
+		system therefore costs no new ZeroDim instantiation -- just a factory.
+		*/
+		template<typename SystemType>
+		using StartSystemFactory =
+			std::function<std::shared_ptr<bertini::start_system::StartSystem>(SystemType const&)>;
+
+		/**
+		\brief Build a StartSystemFactory that mints a concrete start system from the target.
+
+		The single place a concrete start-system type is named when wiring up a CloneGiven
+		ZeroDim.  `policy::MakeStartFactory<start_system::TotalDegree>()` yields a factory that
+		`std::make_shared`s a TotalDegree from the (prepared) target.  Used by the blackbox
+		switch ladder, the python bindings, and the C++ tests.  This template is only
+		instantiated where the concrete StartType is complete, so policies.hpp need not include
+		the concrete start systems.
+		*/
+		template<typename StartType, typename SystemType = bertini::System>
+		StartSystemFactory<SystemType> MakeStartFactory()
+		{
+			return [](SystemType const& target) -> std::shared_ptr<bertini::start_system::StartSystem> {
+				return std::make_shared<StartType>(target);
+			};
+		}
 
 
 
@@ -43,13 +92,15 @@ namespace bertini {
 		\brief A base class for system management for the zero-dim algorithm.
 		*/
 		template<	 typename D,
-					 typename SystemType, typename StartSystemType
+					 typename SystemType
 					,typename StoredSystemType, typename StoredStartSystemType>
 		struct SysMgmtPolicy
 		{
 
 			using SystemT = SystemType;
-			using StartSystemT = StartSystemType;
+			// The algorithm sees every start system through the polymorphic base; concrete
+			// start-system types live only at the construction site (factory).
+			using StartSystemT = bertini::start_system::StartSystem;
 
 			using StoredSystemT = StoredSystemType;
 			using StoredStartSystemT = StoredStartSystemType;
@@ -84,14 +135,10 @@ public:
 				return AsDerived().homotopy_;
 			}
 
-			/**
-			A getter for the start system being used.
-			*/
-			const StartSystemT & StartSystem() const
-			{
-				return AsDerived().start_system_;
-			}
-
+			// NOTE: StartSystem() get/set live on the derived policies, not here: the storage
+			// differs irreconcilably -- CloneGiven owns a shared_ptr<StartSystem> (needs *p),
+			// RefToGiven holds reference_wrapper<const StartSystem> (needs .get()) -- and neither
+			// converts to a common StoredStartSystemT& the way the old by-value/by-ref storage did.
 
 
 			/**
@@ -109,14 +156,6 @@ public:
 			{
 				AsDerived().homotopy_ = sys;
 			}
-
-			/**
-			A setter for the start system being used.
-			*/
-			void StartSystem(StoredStartSystemT const& sys)
-			{
-				AsDerived().start_system_ = sys;
-			}
 		};
 
 
@@ -129,22 +168,25 @@ public:
 
 		\see RefToGiven
 		*/
-		template<typename SystemType, typename StartSystemType>
-		struct CloneGiven : public SysMgmtPolicy<CloneGiven<SystemType, StartSystemType>, SystemType, StartSystemType, SystemType, StartSystemType>
+		template<typename SystemType>
+		struct CloneGiven : public SysMgmtPolicy<CloneGiven<SystemType>, SystemType, SystemType,
+		                                         std::shared_ptr<bertini::start_system::StartSystem>>
 		{
 
-			using SMP = SysMgmtPolicy<CloneGiven<SystemType, StartSystemType>, SystemType, StartSystemType, SystemType, StartSystemType>;
+			using SMP = SysMgmtPolicy<CloneGiven<SystemType>, SystemType, SystemType,
+			                          std::shared_ptr<bertini::start_system::StartSystem>>;
 			friend SMP;
 
 			using StoredSystemT = typename SMP::StoredSystemT;
 			using StoredStartSystemT = typename SMP::StoredStartSystemT;
 
 			using SMP::TargetSystem;
-			using SMP::StartSystem;
 			using SMP::Homotopy;
 
 			using SystemT = SystemType;
-			using StartSystemT = StartSystemType;
+			using StartSystemBaseT = bertini::start_system::StartSystem;
+			using StartSystemT = StartSystemBaseT;
+			using FactoryT = StartSystemFactory<SystemType>;
 
 			// This policy owns (deep-copies) its systems, so in a distributed solve rank 0's
 			// systems can be broadcast and installed authoritatively on every rank.  RefToGiven,
@@ -153,15 +195,21 @@ public:
 
 private:
 			StoredSystemT target_system_;
-			StoredStartSystemT start_system_;
+			StoredStartSystemT start_system_;   ///< shared_ptr<StartSystem>, polymorphic + owned
 			StoredSystemT homotopy_;
+			FactoryT start_factory_;            ///< mints the start system from the prepared target
 
 
 public:
 			/**
-			Simply forward on the systems for the constructor.  The AtConstruct function is to be called by the user of this policy, at construct time.
+			Construct from the target system and a factory that builds the start system from it.
+			The factory is invoked in SystemSetup, AFTER the target is homogenized/patched, so the
+			start system is built over the same (prepared) coordinates -- identical to the old
+			`start = StartSystemType(target)` after PrepareTarget.
 			*/
-			CloneGiven(SystemType const& target) : target_system_(AtConstruct(target))
+			CloneGiven(SystemType const& target,
+			           FactoryT factory = MakeStartFactory<bertini::start_system::RootsOfUnity, SystemType>())
+			 : target_system_(AtConstruct(target)), start_factory_(std::move(factory))
 			{}
 
 
@@ -186,7 +234,7 @@ public:
 			/**
 			Homogenize and patch the target system.
 			*/
-			static 
+			static
 			void PrepareTarget(SystemType & target)
 			{
 				// target system came from the constructor
@@ -194,29 +242,31 @@ public:
 				target.AutoPatch(); // then patch if needed
 			}
 
-			static void FormStart(StartSystemType & start, SystemType const& target)
+			/// Build the start system from the (already-prepared) target via the injected factory.
+			void FormStart()
 			{
-				start = StartSystemType(target);	
+				start_system_ = start_factory_(TargetSystem());
 			}
 
 			static
-			void FormHomotopy(SystemType & homotopy, SystemType const& target, StartSystemType const& start, std::string const& path_variable_name)
+			void FormHomotopy(SystemType & homotopy, SystemType const& target, StartSystemBaseT const& start, std::string const& path_variable_name)
 			{
 				// MakeHomotopy builds H = (1-t)*target + gamma*t*start with a random gamma,
 				// choosing a blend block when the start system carries structured blocks (e.g.
 				// the MHom products-of-linears start) and node arithmetic otherwise.  The same
 				// construction is exposed to Python as system.make_homotopy so a user-authored
-				// start system can be turned into a trackable homotopy.
+				// start system can be turned into a trackable homotopy.  MakeHomotopy takes the
+				// start as a System const& -- the polymorphic StartSystem binds directly.
 				homotopy = MakeHomotopy(target, start, path_variable_name);
 			}
 
 			/**
 			\brief Sets up the homotopy for the system to be solved.
-			
-			1. Homogenizes the system, 
-			2. patches it, 
-			3. constructs the start system,
-			4. stores the number of start points, 
+
+			1. Homogenizes the system,
+			2. patches it,
+			3. constructs the start system (via the factory, over the prepared target),
+			4. stores the number of start points,
 			5. makes a path variable,
 			6. forms the straight line homotopy between target and start, with the gamma trick
 
@@ -226,8 +276,8 @@ public:
 			{
 				PrepareTarget(TargetSystem());
 
-				// now we populate the start system
-				FormStart(StartSystem(), TargetSystem());
+				// now we populate the start system (factory consumes the prepared target)
+				FormStart();
 
 				FormHomotopy(Homotopy(), TargetSystem(), StartSystem(), path_variable_name);
 			}
@@ -236,7 +286,7 @@ public:
 			/**
 			A getter for the system to be tracked to.
 			*/
-			SystemT& TargetSystem() 
+			SystemT& TargetSystem()
 			{
 				return target_system_;
 			}
@@ -244,15 +294,26 @@ public:
 			/**
 			A getter for the homotopy being used.
 			*/
-			SystemT& Homotopy() 
+			SystemT& Homotopy()
 			{
 				return homotopy_;
 			}
 
 			/**
-			A getter for the start system being used.
+			A getter for the start system being used (through the polymorphic base).
 			*/
-			StartSystemT & StartSystem() 
+			StartSystemBaseT & StartSystem()
+			{
+				return *start_system_;
+			}
+			StartSystemBaseT const& StartSystem() const
+			{
+				return *start_system_;
+			}
+
+			/// The owning shared_ptr, so a distributed solve can broadcast the start system
+			/// polymorphically (boost serializes the concrete type via BOOST_CLASS_EXPORT).
+			StoredStartSystemT & StartSystemPtr()
 			{
 				return start_system_;
 			}
@@ -266,19 +327,22 @@ public:
 
 		\see CloneGiven
 		*/
-		template<typename SystemType, typename StartSystemType>
-		struct RefToGiven : public SysMgmtPolicy<RefToGiven<SystemType, StartSystemType>, SystemType, StartSystemType, 
-								std::reference_wrapper< const SystemType>, std::reference_wrapper< const StartSystemType>>
+		template<typename SystemType>
+		struct RefToGiven : public SysMgmtPolicy<RefToGiven<SystemType>, SystemType,
+								std::reference_wrapper< const SystemType>,
+								std::reference_wrapper< const bertini::start_system::StartSystem>>
 		{
-			using SMP = SysMgmtPolicy<RefToGiven<SystemType, StartSystemType>, SystemType, StartSystemType, 
-								std::reference_wrapper< const SystemType>, std::reference_wrapper< const StartSystemType>>;
+			using StartSystemBaseT = bertini::start_system::StartSystem;
+			using SMP = SysMgmtPolicy<RefToGiven<SystemType>, SystemType,
+								std::reference_wrapper< const SystemType>,
+								std::reference_wrapper< const StartSystemBaseT>>;
 			friend SMP;
 
 			using StoredSystemT = typename SMP::StoredSystemT;
 			using StoredStartSystemT = typename SMP::StoredStartSystemT;
+			using StartSystemT = StartSystemBaseT;
 
 			using SMP::TargetSystem;
-			using SMP::StartSystem;
 			using SMP::Homotopy;
 
 			// The user owns these systems (we only hold references); a distributed solve must not
@@ -288,18 +352,19 @@ public:
 
 private:
 			StoredSystemT target_system_; ///< The target system which we track to.
-			StoredStartSystemT start_system_; ///< The start system, which produces start points.
+			StoredStartSystemT start_system_; ///< The start system, which produces start points (held through the base).
 			StoredSystemT homotopy_; ///< homotopy, on which we wish the path vanishes.
 
 
 public:
 			/**
-			Simply forward references to the given systems on the stored systems.
+			Simply forward references to the given systems on the stored systems.  A concrete
+			start system (e.g. start_system::User) binds to the StartSystem base reference (is-a).
 			*/
-			RefToGiven(SystemType const& target, StartSystemType const& start, SystemType const& hom)
-			 : 
-			 	target_system_(std::ref(target)), 
-			 	start_system_(std::ref(start)), 
+			RefToGiven(SystemType const& target, StartSystemBaseT const& start, SystemType const& hom)
+			 :
+			 	target_system_(std::ref(target)),
+			 	start_system_(std::ref(start)),
 			 	homotopy_(std::ref(hom))
 			{}
 
@@ -321,6 +386,14 @@ public:
 			T AtSet(T const& sys)
 			{
 				return std::ref(sys);
+			}
+
+			/**
+			A getter for the start system being used (through the polymorphic base).
+			*/
+			StartSystemBaseT const& StartSystem() const
+			{
+				return start_system_.get();
 			}
 
 			void SystemSetup(std::string const& /*path_variable_name*/) const

--- a/core/include/bertini2/nag_algorithms/output.hpp
+++ b/core/include/bertini2/nag_algorithms/output.hpp
@@ -51,10 +51,10 @@ struct Classic
 {};
 
 
-template <typename A, typename B, typename C, typename D, template<typename, typename> class E>
-struct Classic <ZeroDim<A,B,C,D,E>>
+template <typename A, typename B, typename C, template<typename> class D>
+struct Classic <ZeroDim<A,B,C,D>>
 {
-	using ZDT = ZeroDim<A,B,C,D,E>;
+	using ZDT = ZeroDim<A,B,C,D>;
 
 	template <typename OutT>
 	static

--- a/core/include/bertini2/nag_algorithms/zero_dim_solve.hpp
+++ b/core/include/bertini2/nag_algorithms/zero_dim_solve.hpp
@@ -60,8 +60,8 @@ namespace bertini {
 forward declare of ZeroDim algorithm
 */
 template<	typename TrackerType, typename EndgameType,
-			typename SystemType, typename StartSystemType,
-			template<typename,typename> class SystemManagementP = policy::CloneGiven >
+			typename SystemType,
+			template<typename> class SystemManagementP = policy::CloneGiven >
 struct ZeroDim;
 
 
@@ -70,9 +70,9 @@ struct ZeroDim;
 specify the traits for the algorithm.  this is why we need the forward declare
 */
 template<typename TrackerType, typename EndgameType,
-			typename SystemType, typename StartSystemType,
-			template<typename,typename> class SystemManagementP>
-struct AlgoTraits <ZeroDim<TrackerType, EndgameType, SystemType, StartSystemType, SystemManagementP>>
+			typename SystemType,
+			template<typename> class SystemManagementP>
+struct AlgoTraits <ZeroDim<TrackerType, EndgameType, SystemType, SystemManagementP>>
 {
 	using BaseRealT = typename tracking::TrackerTraits<TrackerType>::BaseRealT;
 	using BaseComplexT = typename tracking::TrackerTraits<TrackerType>::BaseComplexT;
@@ -397,20 +397,21 @@ std::ostream& operator<<(std::ostream & out, const SolveReport & r)
 \brief the basic zero dim algorithm, which solves a system.
 */
 		template<	typename TrackerType, typename EndgameType,
-					typename SystemType, typename StartSystemType,
-					template<typename,typename> class SystemManagementP>
+					typename SystemType,
+					template<typename> class SystemManagementP>
 		struct ZeroDim :
 							public virtual AnyZeroDim,
 							public Observable,
-							public SystemManagementP<SystemType, StartSystemType>,
+							public SystemManagementP<SystemType>,
 							public detail::Configured<
-								typename AlgoTraits< ZeroDim<TrackerType, EndgameType, SystemType, StartSystemType, SystemManagementP>>::NeededConfigs>
+								typename AlgoTraits< ZeroDim<TrackerType, EndgameType, SystemType, SystemManagementP>>::NeededConfigs>
 		{
 			// these usings are for getters in python
 			using TrackerT          = TrackerType;
 			using EndgameT          = EndgameType;
 			using SystemT           = SystemType;
-			using StartSystemT       = StartSystemType;
+			// the algorithm sees the start system only through the polymorphic base
+			using StartSystemT       = bertini::start_system::StartSystem;
 
 			// This algorithm emits its lifecycle events on the AnyZeroDim base, so a
 			// single observer type can watch any templated ZeroDim.  Accept observers
@@ -431,14 +432,14 @@ std::ostream& operator<<(std::ostream & out, const SolveReport & r)
 
 			using SolnIndT 			= typename SolnCont<BaseComplexT>::size_type;
 
-			using SystemManagementPolicy = SystemManagementP<SystemType, StartSystemType>;
+			using SystemManagementPolicy = SystemManagementP<SystemType>;
 
 			using StoredSystemT = typename SystemManagementPolicy::StoredSystemT;
 			using StoredStartSystemT = typename SystemManagementPolicy::StoredStartSystemT;
 
 
 			using Config = detail::Configured<
-								typename AlgoTraits<ZeroDim<TrackerType, EndgameType, SystemType, StartSystemType, SystemManagementP>>::NeededConfigs>;
+								typename AlgoTraits<ZeroDim<TrackerType, EndgameType, SystemType, SystemManagementP>>::NeededConfigs>;
 			using Config::Get;
 
 
@@ -542,7 +543,11 @@ std::ostream& operator<<(std::ostream & out, const SolveReport & r)
 					if constexpr (SystemManagementPolicy::OwnsSystems)
 					{
 						parallel::mpi_broadcast_serialized(comm, TargetSystem(), 0);
-						parallel::mpi_broadcast_serialized(comm, StartSystem(), 0);
+						// broadcast the OWNING shared_ptr<StartSystem> so the concrete derived type
+						// (TotalDegree/MHom/RootsOfUnity, all default-constructible) is carried
+						// polymorphically via its BOOST_CLASS_EXPORT key -- a base reference would
+						// serialize only the System slice and drop the start-point data.
+						parallel::mpi_broadcast_serialized(comm, this->StartSystemPtr(), 0);
 						parallel::mpi_broadcast_serialized(comm, Homotopy(),    0);
 					}
 
@@ -1881,64 +1886,64 @@ namespace bertini {
 namespace algorithm {
 
 template<typename TrackerType, typename EndgameType,
-         typename SystemType, typename StartSystemType,
-         template<typename,typename> class SystemManagementP>
+         typename SystemType,
+         template<typename> class SystemManagementP>
 inline void
-ZeroDim<TrackerType,EndgameType,SystemType,StartSystemType,SystemManagementP>::WriteMainData(std::ostream& out) const
+ZeroDim<TrackerType,EndgameType,SystemType,SystemManagementP>::WriteMainData(std::ostream& out) const
 {
 	output::Classic<ZeroDim>::MainData(out, *this);
 }
 
 template<typename TrackerType, typename EndgameType,
-         typename SystemType, typename StartSystemType,
-         template<typename,typename> class SystemManagementP>
+         typename SystemType,
+         template<typename> class SystemManagementP>
 inline void
-ZeroDim<TrackerType,EndgameType,SystemType,StartSystemType,SystemManagementP>::WriteRawData(std::ostream& out) const
+ZeroDim<TrackerType,EndgameType,SystemType,SystemManagementP>::WriteRawData(std::ostream& out) const
 {
 	output::Classic<ZeroDim>::RawData(out, *this);
 }
 
 template<typename TrackerType, typename EndgameType,
-         typename SystemType, typename StartSystemType,
-         template<typename,typename> class SystemManagementP>
+         typename SystemType,
+         template<typename> class SystemManagementP>
 inline void
-ZeroDim<TrackerType,EndgameType,SystemType,StartSystemType,SystemManagementP>::WriteFiniteSolutions(std::ostream& out) const
+ZeroDim<TrackerType,EndgameType,SystemType,SystemManagementP>::WriteFiniteSolutions(std::ostream& out) const
 {
 	output::Classic<ZeroDim>::FiniteSolutions(out, *this);
 }
 
 template<typename TrackerType, typename EndgameType,
-         typename SystemType, typename StartSystemType,
-         template<typename,typename> class SystemManagementP>
+         typename SystemType,
+         template<typename> class SystemManagementP>
 inline void
-ZeroDim<TrackerType,EndgameType,SystemType,StartSystemType,SystemManagementP>::WriteRealFiniteSolutions(std::ostream& out) const
+ZeroDim<TrackerType,EndgameType,SystemType,SystemManagementP>::WriteRealFiniteSolutions(std::ostream& out) const
 {
 	output::Classic<ZeroDim>::RealFiniteSolutions(out, *this);
 }
 
 template<typename TrackerType, typename EndgameType,
-         typename SystemType, typename StartSystemType,
-         template<typename,typename> class SystemManagementP>
+         typename SystemType,
+         template<typename> class SystemManagementP>
 inline void
-ZeroDim<TrackerType,EndgameType,SystemType,StartSystemType,SystemManagementP>::WriteNonsingularSolutions(std::ostream& out) const
+ZeroDim<TrackerType,EndgameType,SystemType,SystemManagementP>::WriteNonsingularSolutions(std::ostream& out) const
 {
 	output::Classic<ZeroDim>::NonsingularSolutions(out, *this);
 }
 
 template<typename TrackerType, typename EndgameType,
-         typename SystemType, typename StartSystemType,
-         template<typename,typename> class SystemManagementP>
+         typename SystemType,
+         template<typename> class SystemManagementP>
 inline void
-ZeroDim<TrackerType,EndgameType,SystemType,StartSystemType,SystemManagementP>::WriteSingularSolutions(std::ostream& out) const
+ZeroDim<TrackerType,EndgameType,SystemType,SystemManagementP>::WriteSingularSolutions(std::ostream& out) const
 {
 	output::Classic<ZeroDim>::SingularSolutions(out, *this);
 }
 
 template<typename TrackerType, typename EndgameType,
-         typename SystemType, typename StartSystemType,
-         template<typename,typename> class SystemManagementP>
+         typename SystemType,
+         template<typename> class SystemManagementP>
 inline void
-ZeroDim<TrackerType,EndgameType,SystemType,StartSystemType,SystemManagementP>::WriteRawSolutions(std::ostream& out) const
+ZeroDim<TrackerType,EndgameType,SystemType,SystemManagementP>::WriteRawSolutions(std::ostream& out) const
 {
 	output::Classic<ZeroDim>::RawSolutions(out, *this);
 }
@@ -1962,10 +1967,10 @@ void InjectParsedTuple(Target& target, std::tuple<Ts...> const& t) {
 }
 
 template<typename TrackerType, typename EndgameType,
-         typename SystemType, typename StartSystemType,
-         template<typename,typename> class SystemManagementP>
+         typename SystemType,
+         template<typename> class SystemManagementP>
 void
-ZeroDim<TrackerType,EndgameType,SystemType,StartSystemType,SystemManagementP>
+ZeroDim<TrackerType,EndgameType,SystemType,SystemManagementP>
     ::ApplyParsedConfigs(std::string const& config_str)
 {
 	using namespace parsing::classic;
@@ -2015,36 +2020,30 @@ ZeroDim<TrackerType,EndgameType,SystemType,StartSystemType,SystemManagementP>
 } // ns bertini
 
 
-// Explicit instantiation declarations — suppress re-instantiation of the six
-// production ZeroDim types in every including TU.  Definitions live in
-// core/src/eti/zero_dim_eti.cpp; see ADR-0014.  Other combos (different start
-// systems, RefToGiven policy) simply instantiate implicitly as before.
+// Explicit instantiation declarations — suppress re-instantiation of the production
+// ZeroDim types in every including TU.  Since ZeroDim is no longer templated on the
+// start-system type (it holds the start system polymorphically), there are just six
+// CloneGiven combos that cover EVERY clone-owned start system (TotalDegree, MHom,
+// RootsOfUnity, future Polyhedral, ...), plus six RefToGiven combos for user homotopies.
+// Definitions in core/src/eti/zero_dim_eti.cpp + zero_dim_blackbox_eti.cpp; see ADR-0014.
 #include "bertini2/endgames.hpp"
 #include "bertini2/system/start_systems.hpp"
 
 namespace bertini{ namespace algorithm{
 
-extern template struct ZeroDim<tracking::DoublePrecisionTracker,   typename endgame::EndgameSelector<tracking::DoublePrecisionTracker>::PSEG,     System, start_system::TotalDegree>;
-extern template struct ZeroDim<tracking::DoublePrecisionTracker,   typename endgame::EndgameSelector<tracking::DoublePrecisionTracker>::Cauchy,   System, start_system::TotalDegree>;
-extern template struct ZeroDim<tracking::MultiplePrecisionTracker, typename endgame::EndgameSelector<tracking::MultiplePrecisionTracker>::PSEG,   System, start_system::TotalDegree>;
-extern template struct ZeroDim<tracking::MultiplePrecisionTracker, typename endgame::EndgameSelector<tracking::MultiplePrecisionTracker>::Cauchy, System, start_system::TotalDegree>;
-extern template struct ZeroDim<tracking::AMPTracker,               typename endgame::EndgameSelector<tracking::AMPTracker>::PSEG,                 System, start_system::TotalDegree>;
-extern template struct ZeroDim<tracking::AMPTracker,               typename endgame::EndgameSelector<tracking::AMPTracker>::Cauchy,               System, start_system::TotalDegree>;
+extern template struct ZeroDim<tracking::DoublePrecisionTracker,   typename endgame::EndgameSelector<tracking::DoublePrecisionTracker>::PSEG,     System>;
+extern template struct ZeroDim<tracking::DoublePrecisionTracker,   typename endgame::EndgameSelector<tracking::DoublePrecisionTracker>::Cauchy,   System>;
+extern template struct ZeroDim<tracking::MultiplePrecisionTracker, typename endgame::EndgameSelector<tracking::MultiplePrecisionTracker>::PSEG,   System>;
+extern template struct ZeroDim<tracking::MultiplePrecisionTracker, typename endgame::EndgameSelector<tracking::MultiplePrecisionTracker>::Cauchy, System>;
+extern template struct ZeroDim<tracking::AMPTracker,               typename endgame::EndgameSelector<tracking::AMPTracker>::PSEG,                 System>;
+extern template struct ZeroDim<tracking::AMPTracker,               typename endgame::EndgameSelector<tracking::AMPTracker>::Cauchy,               System>;
 
-// the blackbox switch ladder additionally reaches MHomogeneous (CloneGiven) and
-// User (RefToGiven) starts; definitions in core/src/eti/zero_dim_blackbox_eti.cpp
-extern template struct ZeroDim<tracking::DoublePrecisionTracker,   typename endgame::EndgameSelector<tracking::DoublePrecisionTracker>::PSEG,     System, start_system::MHomogeneous>;
-extern template struct ZeroDim<tracking::DoublePrecisionTracker,   typename endgame::EndgameSelector<tracking::DoublePrecisionTracker>::Cauchy,   System, start_system::MHomogeneous>;
-extern template struct ZeroDim<tracking::MultiplePrecisionTracker, typename endgame::EndgameSelector<tracking::MultiplePrecisionTracker>::PSEG,   System, start_system::MHomogeneous>;
-extern template struct ZeroDim<tracking::MultiplePrecisionTracker, typename endgame::EndgameSelector<tracking::MultiplePrecisionTracker>::Cauchy, System, start_system::MHomogeneous>;
-extern template struct ZeroDim<tracking::AMPTracker,               typename endgame::EndgameSelector<tracking::AMPTracker>::PSEG,                 System, start_system::MHomogeneous>;
-extern template struct ZeroDim<tracking::AMPTracker,               typename endgame::EndgameSelector<tracking::AMPTracker>::Cauchy,               System, start_system::MHomogeneous>;
-
-extern template struct ZeroDim<tracking::DoublePrecisionTracker,   typename endgame::EndgameSelector<tracking::DoublePrecisionTracker>::PSEG,     System, start_system::User, policy::RefToGiven>;
-extern template struct ZeroDim<tracking::DoublePrecisionTracker,   typename endgame::EndgameSelector<tracking::DoublePrecisionTracker>::Cauchy,   System, start_system::User, policy::RefToGiven>;
-extern template struct ZeroDim<tracking::MultiplePrecisionTracker, typename endgame::EndgameSelector<tracking::MultiplePrecisionTracker>::PSEG,   System, start_system::User, policy::RefToGiven>;
-extern template struct ZeroDim<tracking::MultiplePrecisionTracker, typename endgame::EndgameSelector<tracking::MultiplePrecisionTracker>::Cauchy, System, start_system::User, policy::RefToGiven>;
-extern template struct ZeroDim<tracking::AMPTracker,               typename endgame::EndgameSelector<tracking::AMPTracker>::PSEG,                 System, start_system::User, policy::RefToGiven>;
-extern template struct ZeroDim<tracking::AMPTracker,               typename endgame::EndgameSelector<tracking::AMPTracker>::Cauchy,               System, start_system::User, policy::RefToGiven>;
+// user homotopies: the user owns the systems, so RefToGiven; definitions in zero_dim_blackbox_eti.cpp
+extern template struct ZeroDim<tracking::DoublePrecisionTracker,   typename endgame::EndgameSelector<tracking::DoublePrecisionTracker>::PSEG,     System, policy::RefToGiven>;
+extern template struct ZeroDim<tracking::DoublePrecisionTracker,   typename endgame::EndgameSelector<tracking::DoublePrecisionTracker>::Cauchy,   System, policy::RefToGiven>;
+extern template struct ZeroDim<tracking::MultiplePrecisionTracker, typename endgame::EndgameSelector<tracking::MultiplePrecisionTracker>::PSEG,   System, policy::RefToGiven>;
+extern template struct ZeroDim<tracking::MultiplePrecisionTracker, typename endgame::EndgameSelector<tracking::MultiplePrecisionTracker>::Cauchy, System, policy::RefToGiven>;
+extern template struct ZeroDim<tracking::AMPTracker,               typename endgame::EndgameSelector<tracking::AMPTracker>::PSEG,                 System, policy::RefToGiven>;
+extern template struct ZeroDim<tracking::AMPTracker,               typename endgame::EndgameSelector<tracking::AMPTracker>::Cauchy,               System, policy::RefToGiven>;
 
 }} // namespaces

--- a/core/include/bertini2/system/start/roots_of_unity.hpp
+++ b/core/include/bertini2/system/start/roots_of_unity.hpp
@@ -1,0 +1,146 @@
+//This file is part of Bertini 2.
+//
+//roots_of_unity.hpp is free software: you can redistribute it and/or modify
+//it under the terms of the GNU General Public License as published by
+//the Free Software Foundation, either version 3 of the License, or
+//(at your option) any later version.
+//
+//roots_of_unity.hpp is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//GNU General Public License for more details.
+//
+//You should have received a copy of the GNU General Public License
+//along with roots_of_unity.hpp.  If not, see <http://www.gnu.org/licenses/>.
+//
+// Copyright(C) Bertini2 Development Team
+//
+// See <http://www.gnu.org/licenses/> for a copy of the license,
+// as well as COPYING.  Bertini2 is provided with permitted
+// additional terms in the b2/licenses/ directory.
+
+// individual authors of this file include:
+// silviana amethyst, university of wisconsin eau claire
+
+/**
+\file roots_of_unity.hpp
+
+\brief Defines the RootsOfUnity start system type.
+*/
+
+#pragma once
+
+#include "bertini2/system/start_base.hpp"
+#include "bertini2/system/start/utility.hpp"
+
+namespace bertini
+{
+	namespace start_system{
+
+
+		/**
+		\brief Roots-of-unity start system for 1-homogeneous polynomial systems.
+
+		A basic and easy-to-construct start system in Numerical Algebraic Geometry.
+
+		This start system uses functions of the form \f$x_i^{d_i} - r_i\f$, where \f$i\f$ is the index of the function relative to the system, \f$d_i\f$ is the degree of that function, and \f$r_i\f$ is a random complex number.  Its start points are \f$r_i^{1/d_i}\f$ times the \f$d_i\f$-th roots of unity -- a structured (roots-of-unity) grid, only the overall scale/phase per variable being randomized.  For start points in *generic* position (random linear products), use TotalDegree instead.
+
+		Note that the corresponding target system MUST be square -- have the same number of functions and variables.  The start system cannot be constructed otherwise, particularly because it is written to throw at the moment if not square.
+
+		The start points are accesses by index (unsigned long long), instead of being generated all at once.
+		*/
+		class RootsOfUnity : public StartSystem
+		{
+		public:
+			RootsOfUnity() = default;
+			virtual ~RootsOfUnity() = default;
+
+			/**
+			 Constructor for making a roots-of-unity start system from a polynomial system
+
+			 \throws std::runtime_error, if the input target system is not square, is not polynomial, has a path variable already, has more than one variable group, or has any homogeneous variable groups.
+			*/
+			RootsOfUnity(System const& s);
+
+
+			/**
+			Get the random value for start function with index
+
+			\param index The index of the start function for which you want the corresponding random value.
+			*/
+			template<typename NumT>
+			NumT RandomValue(size_t index) const
+			{
+				// A direct read of the literal constant --- no node-level evaluation.
+				return random_values_[index]->Value<NumT>();
+			}
+
+
+			/**
+			Get all the random values, in their Node form.
+			*/
+			std::vector<std::shared_ptr<node::Rational> > const& RandomValues()
+			{
+				return random_values_;
+			}
+
+
+			/**
+			Get the number of start points for this roots-of-unity start system.  This is the Bezout bound for the target system.  Provided here for your convenience.
+			*/
+			unsigned long long NumStartPoints() const override;
+
+			RootsOfUnity& operator*=(Nd const& n);
+
+			RootsOfUnity& operator+=(System const& sys) = delete;
+
+			void SanityChecks(System const& s);
+
+		private:
+
+			/**
+			Copy the degrees from another system into this one
+			*/
+			void CopyDegrees(System const& s);
+
+			/**
+			Populate the random values of this system.
+			*/
+			void SeedRandomValues(int num_functions);
+
+			/**
+			Generate the functions for this roots-of-unity start system.  Assumes the random values, degrees, and variables are already g2g.
+			*/
+			void GenerateFunctions();
+
+
+			/**
+			Get the ith start point, in double precision.
+
+			Called by the base StartSystem's StartPoint(index) method.
+			*/
+			Vec<complex_dbl> GenerateStartPoint(complex_dbl,unsigned long long index) const override;
+
+			/**
+			Get the ith start point, in current default precision.
+
+			Called by the base StartSystem's StartPoint(index) method.
+			*/
+			Vec<complex_mp> GenerateStartPoint(complex_mp,unsigned long long index) const override;
+
+			std::vector<std::shared_ptr<node::Rational> > random_values_; ///< stores the random values for the start functions.  x^d-r, where r is stored in this vector.
+			std::vector<unsigned long long> degrees_; ///< stores the degrees of the functions.
+
+
+			friend class boost::serialization::access;
+
+			template <typename Archive>
+			void serialize(Archive& ar, const unsigned /*version*/) {
+				ar & boost::serialization::base_object<StartSystem>(*this);
+				ar & random_values_;
+				ar & degrees_;
+			}
+
+		};
+	}
+}

--- a/core/include/bertini2/system/start/total_degree.hpp
+++ b/core/include/bertini2/system/start/total_degree.hpp
@@ -15,15 +15,15 @@
 //
 // Copyright(C) Bertini2 Development Team
 //
-// See <http://www.gnu.org/licenses/> for a copy of the license, 
-// as well as COPYING.  Bertini2 is provided with permitted 
+// See <http://www.gnu.org/licenses/> for a copy of the license,
+// as well as COPYING.  Bertini2 is provided with permitted
 // additional terms in the b2/licenses/ directory.
 
 // individual authors of this file include:
 // silviana amethyst, university of wisconsin eau claire
 
 /**
-\file total_degree.hpp 
+\file total_degree.hpp
 
 \brief Defines the TotalDegree start system type.
 */
@@ -33,56 +33,45 @@
 #include "bertini2/system/start_base.hpp"
 #include "bertini2/system/start/utility.hpp"
 
-namespace bertini 
+namespace bertini
 {
 	namespace start_system{
 
 
 		/**
-		\brief Total degree start system for 1-homogeneous polynomial systems.
+		\brief Total degree start system for 1-homogeneous polynomial systems, built from random linear products.
 
-		The most basic and easy-to-construct start system in Numerical Algebraic Geometry.  
+		The standard, well-conditioned total-degree start system in Numerical Algebraic Geometry.
 
-		The total degree start system uses functions of the form \f$x_i^{d_i} - r_i\f$, where \f$i\f$ is the index of the function relative to the system, \f$d_i\f$ is the degree of that function, and \f$r_i\f$ is a random complex number.  This is very similar to the roots of unity, except that they are moved away from being centered around the origin, to being centered around a random complex number.  
+		For a square target system with a single affine variable group of \f$n\f$ variables, the
+		start function for a degree-\f$d_i\f$ target function is a product of \f$d_i\f$ random affine
+		linear forms, \f$\prod_{j=1}^{d_i} (a_{ij}\cdot x + b_{ij})\f$.  Its start points are generic
+		intersections (in general position), found by linear algebra -- NOT a roots-of-unity lattice.
+		The number of start points is the Bezout bound \f$\prod_i d_i\f$.  For the (cheaper, structured)
+		roots-of-unity start, see RootsOfUnity.
 
-		Note that the corresponding target system MUST be square -- have the same number of functions and variables.  The start system cannot be constructed otherwise, particularly because it is written to throw at the moment if not square.
+		This is the single-affine-variable-group specialization of MHomogeneous: like MHom, the start
+		system evaluates through a products-of-linears block (the SLP compiler cannot compile
+		linear-product node trees), and each start point is the solution of an \f$n\times n\f$ linear
+		system formed from one chosen linear factor per function.
 
-		The start points are accesses by index (unsigned long long), instead of being generated all at once.
+		Note that the corresponding target system MUST be square -- have the same number of functions
+		and variables.  The start system cannot be constructed otherwise; it throws if not square.
+
+		The start points are accessed by index (unsigned long long), instead of being generated all at once.
 		*/
 		class TotalDegree : public StartSystem
 		{
 		public:
 			TotalDegree() = default;
 			virtual ~TotalDegree() = default;
-			
+
 			/**
 			 Constructor for making a total degree start system from a polynomial system
 
 			 \throws std::runtime_error, if the input target system is not square, is not polynomial, has a path variable already, has more than one variable group, or has any homogeneous variable groups.
 			*/
 			TotalDegree(System const& s);
-
-
-			/**
-			Get the random value for start function with index
-
-			\param index The index of the start function for which you want the corresponding random value.
-			*/
-			template<typename NumT>
-			NumT RandomValue(size_t index) const
-			{
-				// A direct read of the literal constant --- no node-level evaluation.
-				return random_values_[index]->Value<NumT>();
-			}
-
-
-			/**
-			Get all the random values, in their Node form.
-			*/
-			std::vector<std::shared_ptr<node::Rational> > const& RandomValues()
-			{
-				return random_values_;
-			}
 
 
 			/**
@@ -93,7 +82,7 @@ namespace bertini
 			TotalDegree& operator*=(Nd const& n);
 
 			TotalDegree& operator+=(System const& sys) = delete;
-			
+
 			void SanityChecks(System const& s);
 
 		private:
@@ -104,14 +93,18 @@ namespace bertini
 			void CopyDegrees(System const& s);
 
 			/**
-			Populate the random values of this system.
+			Populate the random linear-factor coefficients of this start system.  For each function i
+			(degree d_i) this fills linear_coeffs_[i], a (d_i) x (n+1) matrix whose rows are the random
+			affine linear factors (the trailing column being each factor's constant term).
 			*/
-			void SeedRandomValues(int num_functions);
+			void SeedLinearCoeffs(System const& s);
 
 			/**
-			Generate the functions for this total degree start system.  Assumes the random values, degrees, and variables are already g2g.
+			Build the products-of-linears evaluation block from linear_coeffs_ (so the start system
+			evaluates via the block, as MHomogeneous does).  Assumes the variable structure is set up
+			(homogenized/patched as appropriate) and the coefficients are seeded.
 			*/
-			void GenerateFunctions();
+			void BuildBlock(System const& s);
 
 
 			/**
@@ -128,8 +121,19 @@ namespace bertini
 			*/
 			Vec<complex_mp> GenerateStartPoint(complex_mp,unsigned long long index) const override;
 
-			std::vector<std::shared_ptr<node::Rational> > random_values_; ///< stores the random values for the start functions.  x^d-r, where r is stored in this vector.
+			/**
+			 A local version of GenerateStartPoint that can be templated.
+			*/
+			template<typename T>
+			void GenerateStartPointT(Vec<T>& start_point, unsigned long long index) const;
+
 			std::vector<unsigned long long> degrees_; ///< stores the degrees of the functions.
+			/// Random linear-factor coefficients, one matrix per function.  Entry i is a
+			/// (degrees_[i]) x (NumNaturalVariables()+1) matrix: each row is an affine linear factor
+			/// over the variables, the trailing column being the factor's constant term.  Generated at
+			/// MaxPrecisionAllowed so the block's master is precision-faithful.  This is the
+			/// single-group analogue of MHomogeneous::linear_coeffs_.
+			std::vector<Mat<complex_mp>> linear_coeffs_;
 
 
 			friend class boost::serialization::access;
@@ -137,13 +141,12 @@ namespace bertini
 			template <typename Archive>
 			void serialize(Archive& ar, const unsigned /*version*/) {
 				ar & boost::serialization::base_object<StartSystem>(*this);
-				ar & random_values_;
 				ar & degrees_;
+				// serialize the coefficients too (unlike MHomogeneous, which persists only degrees_):
+				// a round-tripped TotalDegree can then regenerate its start points, not merely evaluate.
+				ar & linear_coeffs_;
 			}
 
 		};
 	}
 }
-
-
-

--- a/core/include/bertini2/system/start_systems.hpp
+++ b/core/include/bertini2/system/start_systems.hpp
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "bertini2/system/start/total_degree.hpp"
+#include "bertini2/system/start/roots_of_unity.hpp"
 #include "bertini2/system/start/mhom.hpp"
 #include "bertini2/system/start/user.hpp"
 

--- a/core/src/eti/zero_dim_blackbox_eti.cpp
+++ b/core/src/eti/zero_dim_blackbox_eti.cpp
@@ -25,11 +25,12 @@
 /**
 \file zero_dim_blackbox_eti.cpp
 
-Explicit instantiation definitions for the ZeroDim combos reachable through
-the blackbox switch ladder beyond the TotalDegree six (see zero_dim_eti.cpp):
-MHomogeneous start (CloneGiven) and User start (RefToGiven), per
-blackbox/config.hpp's StorageSelector.  Pairs with the extern block at the
-bottom of bertini2/nag_algorithms/zero_dim_solve.hpp.  See ADR-0014.
+Explicit instantiation definitions for the User-homotopy ZeroDim combos, which
+use the RefToGiven policy (the user owns the systems).  The clone-owned starts
+(TotalDegree, MHomogeneous, RootsOfUnity, ...) are ALL covered by the six default
+CloneGiven combos in zero_dim_eti.cpp now that ZeroDim is not templated on the
+start-system type.  Pairs with the extern block at the bottom of
+bertini2/nag_algorithms/zero_dim_solve.hpp.  See ADR-0014.
 */
 
 #include "bertini2/nag_algorithms/zero_dim_solve.hpp"
@@ -42,18 +43,11 @@ using DPT  = tracking::DoublePrecisionTracker;
 using MPT  = tracking::MultiplePrecisionTracker;
 using AMPT = tracking::AMPTracker;
 
-template struct ZeroDim<DPT,  typename endgame::EndgameSelector<DPT>::PSEG,    System, start_system::MHomogeneous>;
-template struct ZeroDim<DPT,  typename endgame::EndgameSelector<DPT>::Cauchy,  System, start_system::MHomogeneous>;
-template struct ZeroDim<MPT,  typename endgame::EndgameSelector<MPT>::PSEG,    System, start_system::MHomogeneous>;
-template struct ZeroDim<MPT,  typename endgame::EndgameSelector<MPT>::Cauchy,  System, start_system::MHomogeneous>;
-template struct ZeroDim<AMPT, typename endgame::EndgameSelector<AMPT>::PSEG,   System, start_system::MHomogeneous>;
-template struct ZeroDim<AMPT, typename endgame::EndgameSelector<AMPT>::Cauchy, System, start_system::MHomogeneous>;
-
-template struct ZeroDim<DPT,  typename endgame::EndgameSelector<DPT>::PSEG,    System, start_system::User, policy::RefToGiven>;
-template struct ZeroDim<DPT,  typename endgame::EndgameSelector<DPT>::Cauchy,  System, start_system::User, policy::RefToGiven>;
-template struct ZeroDim<MPT,  typename endgame::EndgameSelector<MPT>::PSEG,    System, start_system::User, policy::RefToGiven>;
-template struct ZeroDim<MPT,  typename endgame::EndgameSelector<MPT>::Cauchy,  System, start_system::User, policy::RefToGiven>;
-template struct ZeroDim<AMPT, typename endgame::EndgameSelector<AMPT>::PSEG,   System, start_system::User, policy::RefToGiven>;
-template struct ZeroDim<AMPT, typename endgame::EndgameSelector<AMPT>::Cauchy, System, start_system::User, policy::RefToGiven>;
+template struct ZeroDim<DPT,  typename endgame::EndgameSelector<DPT>::PSEG,    System, policy::RefToGiven>;
+template struct ZeroDim<DPT,  typename endgame::EndgameSelector<DPT>::Cauchy,  System, policy::RefToGiven>;
+template struct ZeroDim<MPT,  typename endgame::EndgameSelector<MPT>::PSEG,    System, policy::RefToGiven>;
+template struct ZeroDim<MPT,  typename endgame::EndgameSelector<MPT>::Cauchy,  System, policy::RefToGiven>;
+template struct ZeroDim<AMPT, typename endgame::EndgameSelector<AMPT>::PSEG,   System, policy::RefToGiven>;
+template struct ZeroDim<AMPT, typename endgame::EndgameSelector<AMPT>::Cauchy, System, policy::RefToGiven>;
 
 }} // namespaces

--- a/core/src/eti/zero_dim_eti.cpp
+++ b/core/src/eti/zero_dim_eti.cpp
@@ -44,13 +44,15 @@ namespace bertini{ namespace algorithm{
 using DPT  = tracking::DoublePrecisionTracker;
 using MPT  = tracking::MultiplePrecisionTracker;
 using AMPT = tracking::AMPTracker;
-using TD   = start_system::TotalDegree;
 
-template struct ZeroDim<DPT,  typename endgame::EndgameSelector<DPT>::PSEG,    System, TD>;
-template struct ZeroDim<DPT,  typename endgame::EndgameSelector<DPT>::Cauchy,  System, TD>;
-template struct ZeroDim<MPT,  typename endgame::EndgameSelector<MPT>::PSEG,    System, TD>;
-template struct ZeroDim<MPT,  typename endgame::EndgameSelector<MPT>::Cauchy,  System, TD>;
-template struct ZeroDim<AMPT, typename endgame::EndgameSelector<AMPT>::PSEG,   System, TD>;
-template struct ZeroDim<AMPT, typename endgame::EndgameSelector<AMPT>::Cauchy, System, TD>;
+// ZeroDim no longer carries the start-system type, so these six default-CloneGiven
+// instantiations cover EVERY clone-owned start system (TotalDegree, MHomogeneous,
+// RootsOfUnity, future Polyhedral, ...).  Adding a start system costs zero ETI.
+template struct ZeroDim<DPT,  typename endgame::EndgameSelector<DPT>::PSEG,    System>;
+template struct ZeroDim<DPT,  typename endgame::EndgameSelector<DPT>::Cauchy,  System>;
+template struct ZeroDim<MPT,  typename endgame::EndgameSelector<MPT>::PSEG,    System>;
+template struct ZeroDim<MPT,  typename endgame::EndgameSelector<MPT>::Cauchy,  System>;
+template struct ZeroDim<AMPT, typename endgame::EndgameSelector<AMPT>::PSEG,   System>;
+template struct ZeroDim<AMPT, typename endgame::EndgameSelector<AMPT>::Cauchy, System>;
 
 }} // namespaces

--- a/core/src/system/start/roots_of_unity.cpp
+++ b/core/src/system/start/roots_of_unity.cpp
@@ -1,0 +1,182 @@
+//This file is part of Bertini 2.
+//
+//roots_of_unity.cpp is free software: you can redistribute it and/or modify
+//it under the terms of the GNU General Public License as published by
+//the Free Software Foundation, either version 3 of the License, or
+//(at your option) any later version.
+//
+//roots_of_unity.cpp is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//GNU General Public License for more details.
+//
+//You should have received a copy of the GNU General Public License
+//along with roots_of_unity.cpp.  If not, see <http://www.gnu.org/licenses/>.
+//
+// Copyright(C) Bertini2 Development Team
+//
+// See <http://www.gnu.org/licenses/> for a copy of the license,
+// as well as COPYING.  Bertini2 is provided with permitted
+// additional terms in the b2/licenses/ directory.
+
+// individual authors of this file include:
+// silviana amethyst, university of wisconsin eau claire
+
+#include "bertini2/system/start/roots_of_unity.hpp"
+
+#include <boost/math/constants/constants.hpp>
+
+
+BOOST_CLASS_EXPORT(bertini::start_system::RootsOfUnity);
+
+
+namespace bertini {
+	using namespace bertini::node;
+
+	namespace start_system {
+
+		// constructor for RootsOfUnity start system, from any other *suitable* system.
+		RootsOfUnity::RootsOfUnity(System const& s)
+		{
+			SanityChecks(s);
+			CopyDegrees(s);
+			CopyVariableStructure(s);
+			SeedRandomValues(static_cast<int>(s.NumNaturalFunctions()));
+			GenerateFunctions();
+
+			if (s.IsHomogeneous())
+				Homogenize();
+
+			if (s.IsPatched())
+				CopyPatches(s);
+		}// roots of unity constructor
+
+
+		RootsOfUnity& RootsOfUnity::operator*=(Nd const& n)
+		{
+			System::operator*=(n);
+			return *this;
+		}
+
+
+
+		unsigned long long RootsOfUnity::NumStartPoints() const
+		{
+			unsigned long long num_start_points = 1;
+			for (const auto& iter : degrees_)
+				num_start_points*=iter;
+			return num_start_points;
+		}
+
+
+
+		Vec<complex_dbl> RootsOfUnity::GenerateStartPoint(complex_dbl,unsigned long long index) const
+		{
+			Vec<complex_dbl> start_point(NumVariables());
+			auto indices = IndexToSubscript(index, degrees_);
+
+			unsigned offset = 0;
+			if (IsPatched())
+			{
+				start_point(0) = complex_dbl(1);
+				offset = 1;
+			}
+
+			// authoritative pi (see issue #156 / special_number.cpp), not acos(-1)
+			auto two_i_pi = boost::math::constants::pi<double>() * complex_dbl(0,2);
+
+			for (size_t ii = 0; ii< NumNaturalVariables(); ++ii)
+				start_point(static_cast<Eigen::Index>(ii+offset)) = exp( two_i_pi * static_cast<double>(indices[ii]) / static_cast<double>(degrees_[ii])  ) * pow(random_values_[ii]->Value<complex_dbl>(), 1.0 / static_cast<double>(degrees_[ii]));
+
+			if (IsPatched())
+				RescalePointToFitPatchInPlace(start_point);
+
+			return start_point;
+		}
+
+
+		Vec<complex_mp> RootsOfUnity::GenerateStartPoint(complex_mp,unsigned long long index) const
+		{
+			using bertini::ThreadPrecision;
+
+			Vec<complex_mp> start_point(NumVariables()); // make the value we're returning
+			auto indices = IndexToSubscript(index, degrees_); // get the position of it -- used in the angle of the coordinates of the produced point.
+
+			unsigned offset = 0;
+			if (IsPatched())
+			{
+				start_point(0) = complex_mp(1,0,ThreadPrecision());
+				offset = 1;
+			}
+
+// TODO: this code should be cleaned up after issue 308 is solved -- namely, the two precision adjustment calls should be removed.  They're only necessary because prec16 / ulonglog = prec19.
+
+			auto one = real_mp(1);
+			// authoritative pi (see issue #156 / special_number.cpp), not acos(-1)
+			complex_mp two_i_pi = complex_mp(0,2) * boost::math::constants::pi<real_mp>();
+			for (size_t ii = 0; ii< NumNaturalVariables(); ++ii)
+			{
+				complex_mp a = exp( (two_i_pi * indices[ii]) / degrees_[ii]);
+				complex_mp b = pow(random_values_[ii]->Value<complex_mp>(), one / degrees_[ii]);
+
+				Precision(a,ThreadPrecision());
+				Precision(b,ThreadPrecision());
+
+				start_point(static_cast<Eigen::Index>(ii+offset)) = a*b;
+			}
+
+			if (IsPatched())
+				RescalePointToFitPatchInPlace(start_point);
+
+			return start_point;
+		}
+
+		inline
+		RootsOfUnity operator*(RootsOfUnity td, std::shared_ptr<node::Node> const& n)
+		{
+			td *= n;
+			return td;
+		}
+
+		void RootsOfUnity::SanityChecks(System const& s)
+		{
+			if (s.NumHomVariableGroups() > 0)
+				throw std::runtime_error("a homogeneous variable group is present.  currently unallowed");
+
+			if (s.NumTotalFunctions() != s.NumVariables())
+				throw std::runtime_error("attempting to construct roots-of-unity start system from non-square target system");
+
+			if (s.HavePathVariable())
+				throw std::runtime_error("attempting to construct roots-of-unity start system, but target system has path varible declared already");
+
+			if (s.NumVariableGroups() != 1)
+				throw std::runtime_error("more than one affine variable group.  currently unallowed");
+
+			if (!s.IsPolynomial())
+				throw std::runtime_error("attempting to construct roots-of-unity start system from non-polynomial target system");
+		}
+
+		void RootsOfUnity::CopyDegrees(System const& s)
+		{
+			auto deg = s.Degrees();
+			for (const auto& d : deg)
+				degrees_.push_back(static_cast<size_t>(d));
+		}
+
+
+		void RootsOfUnity::SeedRandomValues(int num_functions)
+		{
+			random_values_.resize(static_cast<size_t>(num_functions));
+			for (int ii = 0; ii < num_functions; ++ii)
+				random_values_[static_cast<size_t>(ii)] = Rational::Make(node::Rational::Rand());
+		}
+
+		void RootsOfUnity::GenerateFunctions()
+		{
+			// by hypothesis, the system has a single variable group.
+			auto v = this->AffineVariableGroup(0);
+			for (auto iter = v.begin(); iter!=v.end(); iter++)
+				AddFunction(pow(*iter,(int) *(degrees_.begin() + (iter-v.begin()))) - random_values_[static_cast<size_t>(iter-v.begin())]);
+		}
+	} // namespace start_system
+} //namespace bertini

--- a/core/src/system/start/total_degree.cpp
+++ b/core/src/system/start/total_degree.cpp
@@ -15,8 +15,8 @@
 //
 // Copyright(C) Bertini2 Development Team
 //
-// See <http://www.gnu.org/licenses/> for a copy of the license, 
-// as well as COPYING.  Bertini2 is provided with permitted 
+// See <http://www.gnu.org/licenses/> for a copy of the license,
+// as well as COPYING.  Bertini2 is provided with permitted
 // additional terms in the b2/licenses/ directory.
 
 // individual authors of this file include:
@@ -24,7 +24,10 @@
 
 #include "bertini2/system/start/total_degree.hpp"
 
-#include <boost/math/constants/constants.hpp>
+#include "bertini2/system/blocks/block.hpp"
+#include "bertini2/random.hpp"
+
+#include <map>
 
 
 BOOST_CLASS_EXPORT(bertini::start_system::TotalDegree);
@@ -32,33 +35,35 @@ BOOST_CLASS_EXPORT(bertini::start_system::TotalDegree);
 
 namespace bertini {
 	using namespace bertini::node;
-	
+
 	namespace start_system {
 
 		// constructor for TotalDegree start system, from any other *suitable* system.
+		// This is the single-affine-variable-group specialization of MHomogeneous: one variable
+		// group, no homogeneous groups, no partitions.  See mhom.cpp for the multi-group version.
 		TotalDegree::TotalDegree(System const& s)
 		{
 			SanityChecks(s);
 			CopyDegrees(s);
 			CopyVariableStructure(s);
-			SeedRandomValues(static_cast<int>(s.NumNaturalFunctions()));
-			GenerateFunctions();
+			SeedLinearCoeffs(s);
 
 			if (s.IsHomogeneous())
 				Homogenize();
 
 			if (s.IsPatched())
 				CopyPatches(s);
+
+			BuildBlock(s);
 		}// total degree constructor
 
-		
+
 		TotalDegree& TotalDegree::operator*=(Nd const& n)
 		{
 			System::operator*=(n);
 			return *this;
 		}
-		
-		
+
 
 		unsigned long long TotalDegree::NumStartPoints() const
 		{
@@ -68,75 +73,6 @@ namespace bertini {
 			return num_start_points;
 		}
 
-
-		
-		Vec<complex_dbl> TotalDegree::GenerateStartPoint(complex_dbl,unsigned long long index) const
-		{
-			Vec<complex_dbl> start_point(NumVariables());
-			auto indices = IndexToSubscript(index, degrees_);
-
-			unsigned offset = 0;
-			if (IsPatched())
-			{
-				start_point(0) = complex_dbl(1);
-				offset = 1;
-			}
-
-			// authoritative pi (see issue #156 / special_number.cpp), not acos(-1)
-			auto two_i_pi = boost::math::constants::pi<double>() * complex_dbl(0,2);
-
-			for (size_t ii = 0; ii< NumNaturalVariables(); ++ii)
-				start_point(static_cast<Eigen::Index>(ii+offset)) = exp( two_i_pi * static_cast<double>(indices[ii]) / static_cast<double>(degrees_[ii])  ) * pow(random_values_[ii]->Value<complex_dbl>(), 1.0 / static_cast<double>(degrees_[ii]));
-
-			if (IsPatched())
-				RescalePointToFitPatchInPlace(start_point);
-
-			return start_point;
-		}
-
-
-		Vec<complex_mp> TotalDegree::GenerateStartPoint(complex_mp,unsigned long long index) const
-		{
-			using bertini::ThreadPrecision;
-
-			Vec<complex_mp> start_point(NumVariables()); // make the value we're returning
-			auto indices = IndexToSubscript(index, degrees_); // get the position of it -- used in the angle of the coordinates of the produced point.
-
-			unsigned offset = 0;
-			if (IsPatched())
-			{
-				start_point(0) = complex_mp(1,0,ThreadPrecision());
-				offset = 1;
-			}
-
-// TODO: this code should be cleaned up after issue 308 is solved -- namely, the two precision adjustment calls should be removed.  They're only necessary because prec16 / ulonglog = prec19.
-
-			auto one = real_mp(1);
-			// authoritative pi (see issue #156 / special_number.cpp), not acos(-1)
-			complex_mp two_i_pi = complex_mp(0,2) * boost::math::constants::pi<real_mp>();
-			for (size_t ii = 0; ii< NumNaturalVariables(); ++ii)
-			{
-				complex_mp a = exp( (two_i_pi * indices[ii]) / degrees_[ii]);
-				complex_mp b = pow(random_values_[ii]->Value<complex_mp>(), one / degrees_[ii]);
-
-				Precision(a,ThreadPrecision());
-				Precision(b,ThreadPrecision());
-
-				start_point(static_cast<Eigen::Index>(ii+offset)) = a*b;
-			}
-
-			if (IsPatched())
-				RescalePointToFitPatchInPlace(start_point);
-
-			return start_point;
-		}
-
-		inline
-		TotalDegree operator*(TotalDegree td, std::shared_ptr<node::Node> const& n)
-		{
-			td *= n;
-			return td;
-		}
 
 		void TotalDegree::SanityChecks(System const& s)
 		{
@@ -156,6 +92,7 @@ namespace bertini {
 				throw std::runtime_error("attempting to construct total degree start system from non-polynomial target system");
 		}
 
+
 		void TotalDegree::CopyDegrees(System const& s)
 		{
 			auto deg = s.Degrees();
@@ -164,19 +101,160 @@ namespace bertini {
 		}
 
 
-		void TotalDegree::SeedRandomValues(int num_functions)
+		// Generate the random linear-factor coefficients directly (no node::LinearProduct), exactly
+		// as mhom.cpp does for one (function, group) pair.  For each function i (degree d_i) fill a
+		// d_i x (n+1) matrix: each row is an affine linear factor over the n natural variables, the
+		// trailing column being the factor's constant.  Generated at MaxPrecisionAllowed so the
+		// block's master is precision-faithful.
+		void TotalDegree::SeedLinearCoeffs(System const& s)
 		{
-			random_values_.resize(static_cast<size_t>(num_functions));
-			for (int ii = 0; ii < num_functions; ++ii)
-				random_values_[static_cast<size_t>(ii)] = Rational::Make(node::Rational::Rand());
+			auto const saved_prec = DefaultPrecision();
+			DefaultPrecision(MaxPrecisionAllowed());
+
+			const Eigen::Index n = static_cast<Eigen::Index>(s.NumNaturalVariables());
+			linear_coeffs_.clear();
+			linear_coeffs_.reserve(degrees_.size());
+			for (size_t ii = 0; ii < degrees_.size(); ++ii)
+			{
+				const Eigen::Index d = static_cast<Eigen::Index>(degrees_[ii]);
+				Mat<complex_mp> C(d, n + 1);
+				for (Eigen::Index f = 0; f < d; ++f)
+					for (Eigen::Index k = 0; k < n + 1; ++k)   // includes the trailing constant column
+						C(f, k) = complex_mp(real_mp(RandomRat()), real_mp(RandomRat()));
+				linear_coeffs_.push_back(std::move(C));
+			}
+
+			DefaultPrecision(saved_prec);
 		}
 
-		void TotalDegree::GenerateFunctions()
+
+		// Build the products-of-linears evaluation block from linear_coeffs_, so the start system
+		// evaluates via the block (the SLP compiler cannot compile linear-product node trees).  Per
+		// function we assemble an augmented coefficient matrix (one row per factor, length
+		// NumVariables()+1): each factor's coefficients are placed by VARIABLE IDENTITY into the full
+		// variable ordering, and the factor's constant multiplies the group's homogenizing variable
+		// when the system is homogeneous (so it goes in that variable's column), else it is the
+		// augmented constant in the trailing column.  This is mhom.cpp's block assembly with a single
+		// affine group (no projective groups).  Built at MaxPrecisionAllowed.
+		void TotalDegree::BuildBlock(System const& /*s*/)
 		{
-			// by hypothesis, the system has a single variable group.
-			auto v = this->AffineVariableGroup(0);
-			for (auto iter = v.begin(); iter!=v.end(); iter++)
-				AddFunction(pow(*iter,(int) *(degrees_.begin() + (iter-v.begin()))) - random_values_[static_cast<size_t>(iter-v.begin())]);
+			auto const saved_prec = DefaultPrecision();
+			DefaultPrecision(MaxPrecisionAllowed());
+			this->precision(MaxPrecisionAllowed());
+
+			const VariableGroup& vars = this->Variables();
+			std::map<node::Node const*, Eigen::Index> col_of;
+			for (Eigen::Index c = 0; c < static_cast<Eigen::Index>(vars.size()); ++c)
+				col_of[vars[static_cast<size_t>(c)].get()] = c;
+			const Eigen::Index n = static_cast<Eigen::Index>(this->NumVariables());
+
+			// the single affine group's variables, and (if homogenized) its homogenizing variable.
+			const VariableGroup& gvars = this->AffineVariableGroup(0);
+			std::shared_ptr<node::Variable> hom_var;
+			if (!this->HomogenizingVariables().empty())
+				hom_var = this->HomogenizingVariables()[0];
+
+			std::vector<Mat<complex_mp>> per_function;
+			per_function.reserve(linear_coeffs_.size());
+
+			for (size_t ii = 0; ii < linear_coeffs_.size(); ++ii)
+			{
+				const Mat<complex_mp>& C = linear_coeffs_[ii];
+				const Eigen::Index d = C.rows();
+				Mat<complex_mp> M(d, n + 1);
+				for (Eigen::Index f = 0; f < d; ++f)
+				{
+					Vec<complex_mp> row = Vec<complex_mp>::Zero(n + 1);
+					for (size_t k = 0; k < gvars.size(); ++k)
+						row(col_of.at(gvars[k].get())) = C(f, static_cast<Eigen::Index>(k));
+					const complex_mp& constant = C(f, static_cast<Eigen::Index>(gvars.size()));
+					if (hom_var && col_of.count(hom_var.get()))
+						row(col_of.at(hom_var.get())) = constant;
+					else
+						row(n) = constant;   // augmented constant (affine, un-homogenized)
+					M.row(f) = row.transpose();
+				}
+				per_function.push_back(std::move(M));
+			}
+
+			this->AddBlock(blocks::ProductsOfLinearsBlock(static_cast<size_t>(n), std::move(per_function)));
+
+			DefaultPrecision(saved_prec);
+			this->precision(saved_prec);
+		}
+
+
+		template<typename T>
+		void TotalDegree::GenerateStartPointT(Vec<T>& start_point, unsigned long long index) const
+		{
+			// Decompose the flat index into one chosen linear factor per function.  (Single group =>
+			// no partition search, unlike MHomogeneous.)
+			std::vector<size_t> dim_vector(degrees_.size());
+			for (size_t ii = 0; ii < degrees_.size(); ++ii)
+				dim_vector[ii] = static_cast<size_t>(degrees_[ii]);
+			std::vector<size_t> subscript = IndexToSubscript<size_t>(index, dim_vector);
+
+			// Build the n x n linear system whose solution is this start point, in natural
+			// coordinates: function i contributes its chosen affine linear factor = 0, i.e. row i is
+			// the factor's variable coefficients and the right-hand side is minus its constant.
+			const Eigen::Index n = static_cast<Eigen::Index>(NumNaturalVariables());
+			Mat<T> A = Mat<T>::Zero(n, n);
+			Vec<T> b = Vec<T>::Zero(n);
+
+			// coefficients come from linear_coeffs_ (mpfr master); cast each to the working type T
+			// (a no-op widen for mpfr, a narrowing for complex_dbl).
+			auto as_T = [](complex_mp const& z) -> T {
+				if constexpr (std::is_same<T, complex_dbl>::value) return complex_dbl(z);
+				else return z;
+			};
+
+			for (Eigen::Index ii = 0; ii < n; ++ii)
+			{
+				const Mat<complex_mp>& C = linear_coeffs_[static_cast<size_t>(ii)];
+				const Eigen::Index f = static_cast<Eigen::Index>(subscript[static_cast<size_t>(ii)]);
+				for (Eigen::Index k = 0; k < n; ++k)
+					A(ii, k) = as_T(C(f, k));
+				b(ii) = -as_T(C(f, n));   // move the constant term to the right-hand side
+			}
+
+			Vec<T> affine_solution = A.partialPivLu().solve(b);
+
+			// The linear solve gives the start point in affine (dehomogenized) coordinates; lift it
+			// onto the homogenized + patched coordinate system the homotopy is tracked in
+			// (HomogenizePoint inserts the homogenizing coordinate and rescales onto the patch, and is
+			// a no-op if not homogenized).
+			start_point = this->HomogenizePoint(affine_solution);
+
+			// Return the point at the current working precision.  The coefficients and the patch are
+			// stored at MaxPrecisionAllowed, which would otherwise leak into the start point and
+			// mismatch the tracker's working precision (the adaptive tracker begins at the ambient
+			// precision).
+			if constexpr (!std::is_same<T, complex_dbl>::value)
+				for (Eigen::Index i = 0; i < start_point.size(); ++i)
+					start_point(i).precision(DefaultPrecision());
+		}
+
+
+		Vec<complex_dbl> TotalDegree::GenerateStartPoint(complex_dbl,unsigned long long index) const
+		{
+			Vec<complex_dbl> start_point(NumVariables());
+			GenerateStartPointT(start_point, index);
+			return start_point;
+		}
+
+
+		Vec<complex_mp> TotalDegree::GenerateStartPoint(complex_mp,unsigned long long index) const
+		{
+			Vec<complex_mp> start_point(NumVariables());
+			GenerateStartPointT(start_point, index);
+			return start_point;
+		}
+
+		inline
+		TotalDegree operator*(TotalDegree td, std::shared_ptr<node::Node> const& n)
+		{
+			td *= n;
+			return td;
 		}
 	} // namespace start_system
 } //namespace bertini

--- a/core/test/blackbox/zerodim.cpp
+++ b/core/test/blackbox/zerodim.cpp
@@ -70,8 +70,10 @@ BOOST_AUTO_TEST_CASE(make_zero_dim_honors_endgame_choice)
 	blackbox::ZeroDimRT rt;
 	rt.tracker = blackbox::type::Tracker::Adaptive;
 
-	using PSEGZD   = algorithm::ZeroDim<AMPTracker, typename EndgameSelector<AMPTracker>::PSEG,   System, start_system::TotalDegree>;
-	using CauchyZD = algorithm::ZeroDim<AMPTracker, typename EndgameSelector<AMPTracker>::Cauchy, System, start_system::TotalDegree>;
+	// the start system is no longer in the ZeroDim type, but the endgame still is, so these
+	// dynamic_casts still discriminate PowerSeries vs Cauchy.
+	using PSEGZD   = algorithm::ZeroDim<AMPTracker, typename EndgameSelector<AMPTracker>::PSEG,   System>;
+	using CauchyZD = algorithm::ZeroDim<AMPTracker, typename EndgameSelector<AMPTracker>::Cauchy, System>;
 
 	rt.endgame = blackbox::type::Endgame::PowerSeries;
 	auto zd_pseg = blackbox::MakeZeroDim(rt, sys);
@@ -104,7 +106,7 @@ BOOST_AUTO_TEST_CASE(single_affine_group_infers_total_degree)
 	sys.AddFunction(x*x + y*y - 1);
 	sys.AddFunction(x + y);
 
-	BOOST_CHECK(blackbox::InferStartType(sys) == blackbox::type::Start::TotalDegree);
+	BOOST_CHECK(blackbox::InferStartType(sys) == blackbox::type::Start::RootsOfUnity);
 }
 
 BOOST_AUTO_TEST_CASE(two_affine_groups_infer_mhom)
@@ -135,7 +137,7 @@ BOOST_AUTO_TEST_CASE(homogeneous_group_infers_mhom)
 BOOST_AUTO_TEST_CASE(griewank_osborn_single_group_infers_total_degree)
 {
 	auto sys = system::Precon::GriewankOsborn();
-	BOOST_CHECK(blackbox::InferStartType(sys) == blackbox::type::Start::TotalDegree);
+	BOOST_CHECK(blackbox::InferStartType(sys) == blackbox::type::Start::RootsOfUnity);
 }
 
 // DISABLED pending the block-composed MHom start system (plan
@@ -166,12 +168,16 @@ BOOST_AUTO_TEST_CASE(inferred_mhom_builds_an_mhomogeneous_zerodim,
 	rt.endgame = blackbox::type::Endgame::Cauchy;
 	BOOST_CHECK(rt.start == blackbox::type::Start::MHom);
 
-	using MHomZD = algorithm::ZeroDim<AMPTracker, typename EndgameSelector<AMPTracker>::Cauchy, System, start_system::MHomogeneous>;
-	using TotDegZD = algorithm::ZeroDim<AMPTracker, typename EndgameSelector<AMPTracker>::Cauchy, System, start_system::TotalDegree>;
+	// After the de-templating refactor the start system is held polymorphically -- it is no
+	// longer part of the ZeroDim type -- so MHom and TotalDegree solves are the SAME type and
+	// cannot be told apart by dynamic_cast.  Verify the choice behaviorally instead: building
+	// the inferred (MHom) solver succeeds on this two-variable-group system, whereas forcing
+	// TotalDegree throws, because its start system requires a single affine variable group.
+	BOOST_CHECK_NO_THROW(blackbox::MakeZeroDim(rt, sys));
 
-	auto zd = blackbox::MakeZeroDim(rt, sys);
-	BOOST_CHECK(dynamic_cast<MHomZD*>(zd.get()) != nullptr);
-	BOOST_CHECK(dynamic_cast<TotDegZD*>(zd.get()) == nullptr);
+	blackbox::ZeroDimRT rt_forced_td = rt;
+	rt_forced_td.start = blackbox::type::Start::TotalDegree;
+	BOOST_CHECK_THROW(blackbox::MakeZeroDim(rt_forced_td, sys), std::runtime_error);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // end the start_system_inference sub-suite

--- a/core/test/classes/slp_test.cpp
+++ b/core/test/classes/slp_test.cpp
@@ -71,7 +71,7 @@ bertini::System HomotopyTotalDegreeTestSystem(){
 
 	Var t = Variable::Make("t");
 
-	bertini::start_system::TotalDegree start(sys);
+	bertini::start_system::RootsOfUnity start(sys);
 
 	auto homotopy = (1-t)*sys + t*start;
 

--- a/core/test/classes/start_system_test.cpp
+++ b/core/test/classes/start_system_test.cpp
@@ -140,7 +140,7 @@ BOOST_AUTO_TEST_CASE(make_total_degree_system_linear)
 	sys.AddFunction(x - real_mp("0.5")*y - 1);
 
 
-	bertini::start_system::TotalDegree TD(sys);
+	bertini::start_system::RootsOfUnity TD(sys);
 
 	auto d = TD.Degrees();
 
@@ -172,7 +172,7 @@ BOOST_AUTO_TEST_CASE(make_total_degree_system_quadratic)
 	sys.AddFunction(x*x - real_mp("0.5")*y - x*y);
 
 
-	bertini::start_system::TotalDegree TD(sys);
+	bertini::start_system::RootsOfUnity TD(sys);
 
 	auto d = TD.Degrees();
 
@@ -202,7 +202,7 @@ BOOST_AUTO_TEST_CASE(linear_total_degree_start_system)
 	sys.AddFunction(y+1);
 	sys.AddFunction(x+y+bertini::node::Pi());
 
-	bertini::start_system::TotalDegree TD(sys);
+	bertini::start_system::RootsOfUnity TD(sys);
 
 	auto deg = TD.Degrees();
 
@@ -276,7 +276,7 @@ BOOST_AUTO_TEST_CASE(quadratic_cubic_quartic_total_degree_start_system)
 	sys.AddFunction(pow(x,3)+x*y+bertini::node::E());
 	sys.AddFunction(pow(x,2)*pow(y,2)+x*y*z*z - 1);
 
-	bertini::start_system::TotalDegree TD(sys);
+	bertini::start_system::RootsOfUnity TD(sys);
 
 	auto deg = TD.Degrees();
 
@@ -355,7 +355,7 @@ BOOST_AUTO_TEST_CASE(quadratic_cubic_quartic_start_points)
 	sys.AddFunction(pow(x,3)+x*y+bertini::node::E());
 	sys.AddFunction(pow(x,2)*pow(y,2)+x*y*z*z - 1);
 
-	bertini::start_system::TotalDegree TD(sys);
+	bertini::start_system::RootsOfUnity TD(sys);
 
 	for (decltype(TD.NumStartPoints()) ii = 0; ii < TD.NumStartPoints(); ++ii)
 	{
@@ -402,7 +402,7 @@ BOOST_AUTO_TEST_CASE(quadratic_cubic_quartic_start_points_homogenized_patched)
 	sys.Homogenize();
 	sys.AutoPatch();
 
-	bertini::start_system::TotalDegree TD(sys);
+	bertini::start_system::RootsOfUnity TD(sys);
 	TD.Homogenize();
 
 	BOOST_CHECK(TD.IsHomogeneous());
@@ -470,7 +470,7 @@ BOOST_AUTO_TEST_CASE(total_degree_start_system_precision_16)
 	sys.AddFunction(pow(x-1,3));
 	sys.AddFunction(pow(y-1,2));
 
-	auto TD = bertini::start_system::TotalDegree(sys);
+	auto TD = bertini::start_system::RootsOfUnity(sys);
 
 	BOOST_CHECK(!sys.IsHomogeneous());
 	BOOST_CHECK(!sys.IsPatched());
@@ -521,7 +521,7 @@ BOOST_AUTO_TEST_CASE(total_degree_start_system_homogenized_patched_precision_16)
 	BOOST_CHECK(sys.IsHomogeneous());
 	BOOST_CHECK(sys.IsPatched());
 
-	auto TD = bertini::start_system::TotalDegree(sys);
+	auto TD = bertini::start_system::RootsOfUnity(sys);
 	TD.Homogenize();
 	BOOST_CHECK(TD.IsHomogeneous());
 	BOOST_CHECK(TD.IsPatched());
@@ -565,7 +565,7 @@ BOOST_AUTO_TEST_CASE(quadratic_cubic_quartic_all_the_way_to_final_system)
 	sys.AddFunction(pow(x,3)+x*y+bertini::node::E());
 	sys.AddFunction(pow(x,2)*pow(y,2)+x*y*z*z - 1);
 
-	bertini::start_system::TotalDegree TD(sys);
+	bertini::start_system::RootsOfUnity TD(sys);
 
 	Var t = Variable::Make("t");
 
@@ -615,7 +615,7 @@ BOOST_AUTO_TEST_CASE(start_system_total_degree_nonpolynomial_should_throw)
 	sys.AddFunction(pow(x,3)+x*y+bertini::node::E());
 	sys.AddFunction(pow(x,2)*pow(y,2)+x*y*z*z - 1);
 
-	BOOST_CHECK_THROW(bertini::start_system::TotalDegree TD(sys), std::runtime_error);
+	BOOST_CHECK_THROW(bertini::start_system::RootsOfUnity TD(sys), std::runtime_error);
 }
 
 
@@ -646,7 +646,7 @@ BOOST_AUTO_TEST_CASE(total_degree_start_system_coefficient_bound_degree_bound)
 
 
 
-	auto TD = bertini::start_system::TotalDegree(sys);
+	auto TD = bertini::start_system::RootsOfUnity(sys);
 	TD.Homogenize();
 	BOOST_CHECK(TD.IsHomogeneous());
 	BOOST_CHECK(TD.IsPatched());

--- a/core/test/endgames/generic_cauchy_test.hpp
+++ b/core/test/endgames/generic_cauchy_test.hpp
@@ -1728,7 +1728,7 @@ BOOST_AUTO_TEST_CASE(griewank_osborne)
 	BOOST_CHECK(griewank_osborn_sys.IsHomogeneous());
 	BOOST_CHECK(griewank_osborn_sys.IsPatched());	
 
-	auto griewank_TD = bertini::start_system::TotalDegree(griewank_osborn_sys);
+	auto griewank_TD = bertini::start_system::RootsOfUnity(griewank_osborn_sys);
 	griewank_TD.Homogenize();
 	BOOST_CHECK(griewank_TD.IsHomogeneous());
 	BOOST_CHECK(griewank_TD.IsPatched());
@@ -1903,7 +1903,7 @@ BOOST_AUTO_TEST_CASE(total_degree_start_system)
 
 	
 
-	auto TD = bertini::start_system::TotalDegree(sys);
+	auto TD = bertini::start_system::RootsOfUnity(sys);
 	TD.Homogenize();
 	BOOST_CHECK(TD.IsHomogeneous());
 	BOOST_CHECK(TD.IsPatched());

--- a/core/test/endgames/generic_pseg_test.hpp
+++ b/core/test/endgames/generic_pseg_test.hpp
@@ -1146,7 +1146,7 @@ BOOST_AUTO_TEST_CASE(total_degree_start_system)
 
 	
 
-	auto TD = bertini::start_system::TotalDegree(sys);
+	auto TD = bertini::start_system::RootsOfUnity(sys);
 	TD.Homogenize();
 	BOOST_CHECK(TD.IsHomogeneous());
 	BOOST_CHECK(TD.IsPatched());

--- a/core/test/nag_algorithms/threaded_solve.cpp
+++ b/core/test/nag_algorithms/threaded_solve.cpp
@@ -234,7 +234,7 @@ void ThreadedMatchesSerial(MakeSys make_sys, std::size_t expected_finite)
 	auto sys_thread = make_sys();
 
 	using ZD = algorithm::ZeroDim<TrackerT, endgame::EndgameSelector<TrackerT>::Cauchy,
-	                              System, start_system::TotalDegree>;
+	                              System>;
 
 	ZD zd_serial(sys_serial);  zd_serial.DefaultSetup();
 	ZD zd_thread(sys_thread);  zd_thread.DefaultSetup();
@@ -268,7 +268,7 @@ BOOST_AUTO_TEST_CASE(num_threads_one_equals_default_solve)
 	using namespace bertini;
 	auto sys = TwoQuadrics();
 	using ZD = algorithm::ZeroDim<TrackerT, endgame::EndgameSelector<TrackerT>::Cauchy,
-	                              System, start_system::TotalDegree>;
+	                              System>;
 	ZD zd(sys); zd.DefaultSetup();
 	auto one = SolveWith(zd, 1);
 	BOOST_CHECK_EQUAL(one.size(), 4u);
@@ -304,7 +304,7 @@ BOOST_AUTO_TEST_CASE(event_tracker_is_member_tracker_when_serial)
 	using namespace bertini;
 	auto sys = TwoCubics();
 	using ZD = algorithm::ZeroDim<TrackerT, endgame::EndgameSelector<TrackerT>::Cauchy,
-	                              System, start_system::TotalDegree>;
+	                              System>;
 	ZD zd(sys); zd.DefaultSetup();
 
 	TrackerCapture cap;
@@ -323,9 +323,21 @@ BOOST_AUTO_TEST_CASE(event_tracker_is_member_tracker_when_serial)
 BOOST_AUTO_TEST_CASE(event_tracker_is_a_clone_when_threaded)
 {
 	using namespace bertini;
+	// OMP_NUM_THREADS overrides the requested thread count (parallel::EffectiveThreadCount), so under
+	// OMP_NUM_THREADS=1 a "threaded" solve actually runs serially on the member tracker, and the
+	// clone-per-thread expectation below does not hold.  CI runs the test suite both with and without
+	// OMP_NUM_THREADS=1; the threaded path is exercised in the non-serial leg, so skip here when the
+	// environment forces serial.
+	if (parallel::EffectiveThreadCount(4) <= 1)
+	{
+		BOOST_TEST_MESSAGE("event_tracker_is_a_clone_when_threaded: skipped -- OMP_NUM_THREADS forces "
+		                   "a serial run (threaded clone behavior is covered by the OMP_NUM_THREADS!=1 "
+		                   "CI leg).");
+		return;
+	}
 	auto sys = TwoCubics();
 	using ZD = algorithm::ZeroDim<TrackerT, endgame::EndgameSelector<TrackerT>::Cauchy,
-	                              System, start_system::TotalDegree>;
+	                              System>;
 	ZD zd(sys); zd.DefaultSetup();
 
 	TrackerCapture cap;

--- a/core/test/nag_algorithms/zero_dim.cpp
+++ b/core/test/nag_algorithms/zero_dim.cpp
@@ -59,7 +59,7 @@ BOOST_AUTO_TEST_CASE(can_run_griewank_osborn)
 
 	auto sys = system::Precon::GriewankOsborn();
 
-	auto zd = algorithm::ZeroDim<TrackerT, bertini::endgame::EndgameSelector<TrackerT>::Cauchy, decltype(sys), start_system::TotalDegree>(sys);
+	auto zd = algorithm::ZeroDim<TrackerT, bertini::endgame::EndgameSelector<TrackerT>::Cauchy, decltype(sys)>(sys);
 
 	zd.DefaultSetup();
 	
@@ -96,7 +96,7 @@ BOOST_AUTO_TEST_CASE(can_run_change_some_settings)
 
 	auto sys = system::Precon::GriewankOsborn();
 
-	auto zd = algorithm::ZeroDim<TrackerT, bertini::endgame::EndgameSelector<TrackerT>::PSEG, decltype(sys), start_system::TotalDegree>(sys);
+	auto zd = algorithm::ZeroDim<TrackerT, bertini::endgame::EndgameSelector<TrackerT>::PSEG, decltype(sys)>(sys);
 
 	zd.DefaultSetup();
 	
@@ -129,7 +129,7 @@ BOOST_AUTO_TEST_CASE(reference_managed_systems_GO_nonhom)
 	using namespace tracking;
 
 	auto sys = system::Precon::GriewankOsborn();
-	auto TD = start_system::TotalDegree(sys);
+	auto TD = start_system::RootsOfUnity(sys);
 
 	auto t = Variable::Make("t");
 	auto h = (1-t)* sys + t*TD;
@@ -138,8 +138,7 @@ BOOST_AUTO_TEST_CASE(reference_managed_systems_GO_nonhom)
 	auto zd = algorithm::ZeroDim<
 				TrackerT, 
 				bertini::endgame::EndgameSelector<TrackerT>::PSEG, 
-				decltype(sys), 
-				start_system::TotalDegree,
+				decltype(sys),
 				policy::RefToGiven
 					>
 			(sys, TD, h); 
@@ -168,7 +167,7 @@ BOOST_AUTO_TEST_CASE(reference_managed_systems_GO)
 	sys.Homogenize();
 	sys.AutoPatch();
 
-	auto TD = start_system::TotalDegree(sys);
+	auto TD = start_system::RootsOfUnity(sys);
 
 	auto t = Variable::Make("t");
 	auto h = (1-t)* sys + t*TD;
@@ -177,8 +176,7 @@ BOOST_AUTO_TEST_CASE(reference_managed_systems_GO)
 	auto zd = algorithm::ZeroDim<
 				TrackerT, 
 				bertini::endgame::EndgameSelector<TrackerT>::PSEG, 
-				decltype(sys), 
-				start_system::TotalDegree,
+				decltype(sys),
 				policy::RefToGiven
 					>
 			(sys, TD, h); 
@@ -239,7 +237,6 @@ BOOST_AUTO_TEST_CASE(user_homotopy_parameter_homotopy_solves)
 				AMPTracker,
 				bertini::endgame::EndgameSelector<AMPTracker>::Cauchy,
 				System,
-				start_system::User,
 				policy::RefToGiven>
 			(target, user_start, H); // (target, start, homotopy) -- references, so all three
 
@@ -292,8 +289,7 @@ BOOST_AUTO_TEST_CASE(mhom_solves_two_variable_group_system)
 
 	auto zd = algorithm::ZeroDim<AMPTracker,
 	                             bertini::endgame::EndgameSelector<AMPTracker>::Cauchy,
-	                             decltype(sys),
-	                             start_system::MHomogeneous>(sys);
+	                             decltype(sys)>(sys, bertini::policy::MakeStartFactory<bertini::start_system::MHomogeneous>());
 	zd.DefaultSetup();
 	zd.Solve();
 
@@ -346,8 +342,7 @@ BOOST_AUTO_TEST_CASE(mhom_homotopy_block_matches_function_tree)
 
 	auto zd = algorithm::ZeroDim<AMPTracker,
 	                             bertini::endgame::EndgameSelector<AMPTracker>::Cauchy,
-	                             decltype(sys),
-	                             start_system::MHomogeneous>(sys);
+	                             decltype(sys)>(sys, bertini::policy::MakeStartFactory<bertini::start_system::MHomogeneous>());
 	zd.DefaultSetup();
 
 	System const& H = zd.Homotopy();          // the block-composed blend homotopy
@@ -454,7 +449,7 @@ BOOST_AUTO_TEST_CASE(solve_report_from_a_real_solve)
 	sys.AddFunction(pow(y, 2) - 1);
 	sys.AddVariableGroup(VariableGroup{x, y});
 
-	auto zd = algorithm::ZeroDim<TrackerT, endgame::EndgameSelector<TrackerT>::Cauchy, System, start_system::TotalDegree>(sys);
+	auto zd = algorithm::ZeroDim<TrackerT, endgame::EndgameSelector<TrackerT>::Cauchy, System>(sys);
 	zd.DefaultSetup();
 	zd.Solve();
 
@@ -508,7 +503,7 @@ BOOST_AUTO_TEST_CASE(cyclic5_amp_does_not_overescalate_precision)
 	sys.AddFunction(prod - 1);
 	sys.AddVariableGroup(x);
 
-	auto zd = algorithm::ZeroDim<TrackerT, endgame::EndgameSelector<TrackerT>::Cauchy, System, start_system::TotalDegree>(sys);
+	auto zd = algorithm::ZeroDim<TrackerT, endgame::EndgameSelector<TrackerT>::Cauchy, System>(sys);
 	zd.DefaultSetup();
 	zd.Solve();
 
@@ -535,7 +530,7 @@ BOOST_AUTO_TEST_CASE(filtered_solution_accessors)
 	sys.AddFunction(pow(y, 2) - 1);
 	sys.AddVariableGroup(VariableGroup{x, y});
 
-	auto zd = algorithm::ZeroDim<TrackerT, endgame::EndgameSelector<TrackerT>::Cauchy, System, start_system::TotalDegree>(sys);
+	auto zd = algorithm::ZeroDim<TrackerT, endgame::EndgameSelector<TrackerT>::Cauchy, System>(sys);
 	zd.DefaultSetup();
 	zd.Solve();
 
@@ -574,7 +569,7 @@ BOOST_AUTO_TEST_CASE(classic_solution_file_output)
 	sys.AddFunction(pow(y, 2) - 1);
 	sys.AddVariableGroup(VariableGroup{x, y});
 
-	auto zd = algorithm::ZeroDim<TrackerT, endgame::EndgameSelector<TrackerT>::Cauchy, System, start_system::TotalDegree>(sys);
+	auto zd = algorithm::ZeroDim<TrackerT, endgame::EndgameSelector<TrackerT>::Cauchy, System>(sys);
 	zd.DefaultSetup();
 	zd.Solve();
 
@@ -621,7 +616,7 @@ BOOST_AUTO_TEST_CASE(infinite_solutions_at_infinity)
 	sys.AddFunction(x - 1);
 	sys.AddVariableGroup(VariableGroup{x, y});
 
-	auto zd = algorithm::ZeroDim<TrackerT, endgame::EndgameSelector<TrackerT>::Cauchy, System, start_system::TotalDegree>(sys);
+	auto zd = algorithm::ZeroDim<TrackerT, endgame::EndgameSelector<TrackerT>::Cauchy, System>(sys);
 	zd.DefaultSetup();
 	// SecurityLevel <= 0 truncates paths heading to infinity as failures (SecurityMaxNormReached);
 	// this test wants the at-infinity path actually computed, so raise the level to keep tracking it
@@ -662,7 +657,7 @@ BOOST_AUTO_TEST_CASE(multiplicity_representative_marks_one_per_cluster)
 	sys.AddFunction(pow(y, 2));
 	sys.AddVariableGroup(VariableGroup{x, y});
 
-	auto zd = algorithm::ZeroDim<TrackerT, endgame::EndgameSelector<TrackerT>::Cauchy, System, start_system::TotalDegree>(sys);
+	auto zd = algorithm::ZeroDim<TrackerT, endgame::EndgameSelector<TrackerT>::Cauchy, System>(sys);
 	zd.DefaultSetup();
 	zd.Solve();
 
@@ -688,7 +683,7 @@ BOOST_AUTO_TEST_CASE(multiplicity_representative_marks_one_per_cluster)
 	simple.AddFunction(pow(x, 2) - 1);
 	simple.AddFunction(pow(y, 2) - 1);
 	simple.AddVariableGroup(VariableGroup{x, y});
-	auto zd2 = algorithm::ZeroDim<TrackerT, endgame::EndgameSelector<TrackerT>::Cauchy, System, start_system::TotalDegree>(simple);
+	auto zd2 = algorithm::ZeroDim<TrackerT, endgame::EndgameSelector<TrackerT>::Cauchy, System>(simple);
 	zd2.DefaultSetup();
 	zd2.Solve();
 	unsigned reps2 = 0;
@@ -716,7 +711,7 @@ BOOST_AUTO_TEST_CASE(fixed_multiple_precision_solves_uniformly)
 		sys.AddFunction(pow(x, 2) - 1);
 		sys.AddVariableGroup(VariableGroup{x});
 		auto zd = algorithm::ZeroDim<MPTracker, endgame::EndgameSelector<MPTracker>::Cauchy,
-		                             System, start_system::TotalDegree>(sys);
+		                             System>(sys);
 		zd.DefaultSetup();
 		zd.Solve();                                  // used to throw on the precision mismatch
 		auto n = zd.Report().num_finite_solutions;
@@ -744,7 +739,7 @@ BOOST_AUTO_TEST_CASE(fixed_multiple_precision_set_via_config)
 	sys.AddFunction(pow(x, 2) - 1);
 	sys.AddVariableGroup(VariableGroup{x});
 	auto zd = algorithm::ZeroDim<MPTracker, endgame::EndgameSelector<MPTracker>::Cauchy,
-	                             System, start_system::TotalDegree>(sys);
+	                             System>(sys);
 	zd.DefaultSetup();
 
 	// the tracker reports its precision honestly
@@ -929,7 +924,7 @@ BOOST_AUTO_TEST_CASE(clean_solve_reports_no_crossings)
 	using TrackerT = tracking::DoublePrecisionTracker;
 
 	auto sys = system::Precon::GriewankOsborn();
-	auto zd = algorithm::ZeroDim<TrackerT, endgame::EndgameSelector<TrackerT>::Cauchy, decltype(sys), start_system::TotalDegree>(sys);
+	auto zd = algorithm::ZeroDim<TrackerT, endgame::EndgameSelector<TrackerT>::Cauchy, decltype(sys)>(sys);
 	zd.DefaultSetup();
 	zd.Solve();
 
@@ -982,7 +977,7 @@ BOOST_AUTO_TEST_CASE(finite_real_nonsingular)
 	sys.AddVariableGroup(VariableGroup{x});
 	sys.AddFunction(x*x - 1);
 
-	auto zd = algorithm::ZeroDim<TrackerT, endgame::EndgameSelector<TrackerT>::Cauchy, decltype(sys), start_system::TotalDegree>(sys);
+	auto zd = algorithm::ZeroDim<TrackerT, endgame::EndgameSelector<TrackerT>::Cauchy, decltype(sys)>(sys);
 	zd.DefaultSetup();
 	zd.Solve();
 
@@ -1006,7 +1001,7 @@ BOOST_AUTO_TEST_CASE(finite_complex_not_real)
 	sys.AddVariableGroup(VariableGroup{x});
 	sys.AddFunction(x*x + 1);
 
-	auto zd = algorithm::ZeroDim<TrackerT, endgame::EndgameSelector<TrackerT>::Cauchy, decltype(sys), start_system::TotalDegree>(sys);
+	auto zd = algorithm::ZeroDim<TrackerT, endgame::EndgameSelector<TrackerT>::Cauchy, decltype(sys)>(sys);
 	zd.DefaultSetup();
 	zd.Solve();
 
@@ -1027,7 +1022,7 @@ BOOST_AUTO_TEST_CASE(singular_double_root)
 	sys.AddVariableGroup(VariableGroup{x});
 	sys.AddFunction(x*x);
 
-	auto zd = algorithm::ZeroDim<TrackerT, endgame::EndgameSelector<TrackerT>::Cauchy, decltype(sys), start_system::TotalDegree>(sys);
+	auto zd = algorithm::ZeroDim<TrackerT, endgame::EndgameSelector<TrackerT>::Cauchy, decltype(sys)>(sys);
 	zd.DefaultSetup();
 	zd.Solve();
 
@@ -1053,7 +1048,7 @@ BOOST_AUTO_TEST_CASE(endpoint_finite_threshold_is_applied)
 	sys.AddVariableGroup(VariableGroup{x});
 	sys.AddFunction(x*x - 1);                    // roots +/-1, infinity norm 1
 
-	auto zd = algorithm::ZeroDim<TrackerT, endgame::EndgameSelector<TrackerT>::Cauchy, decltype(sys), start_system::TotalDegree>(sys);
+	auto zd = algorithm::ZeroDim<TrackerT, endgame::EndgameSelector<TrackerT>::Cauchy, decltype(sys)>(sys);
 	zd.DefaultSetup();
 	auto pp = zd.Get<PostProcessing>();
 	pp.endpoint_finite_threshold = 0.5;          // 1 > 0.5 -> "at infinity"
@@ -1076,7 +1071,7 @@ BOOST_AUTO_TEST_CASE(condition_number_threshold_is_applied)
 	sys.AddVariableGroup(VariableGroup{x});
 	sys.AddFunction(x*x - 1);                    // simple, well-conditioned roots
 
-	auto zd = algorithm::ZeroDim<TrackerT, endgame::EndgameSelector<TrackerT>::Cauchy, decltype(sys), start_system::TotalDegree>(sys);
+	auto zd = algorithm::ZeroDim<TrackerT, endgame::EndgameSelector<TrackerT>::Cauchy, decltype(sys)>(sys);
 	zd.DefaultSetup();
 	auto pp = zd.Get<PostProcessing>();
 	pp.condition_number_threshold = 1e-3;        // any condition number exceeds this
@@ -1098,7 +1093,7 @@ BOOST_AUTO_TEST_CASE(postprocessing_config_roundtrip)
 	sys.AddVariableGroup(VariableGroup{x});
 	sys.AddFunction(x*x - 1);
 
-	auto zd = algorithm::ZeroDim<TrackerT, endgame::EndgameSelector<TrackerT>::Cauchy, decltype(sys), start_system::TotalDegree>(sys);
+	auto zd = algorithm::ZeroDim<TrackerT, endgame::EndgameSelector<TrackerT>::Cauchy, decltype(sys)>(sys);
 	zd.DefaultSetup();
 
 	auto pp = zd.Get<PostProcessing>();
@@ -1157,7 +1152,7 @@ BOOST_AUTO_TEST_CASE(zerodim_emits_lifecycle_events)
 
 	auto sys = system::Precon::GriewankOsborn();
 	auto zd = algorithm::ZeroDim<TrackerT, bertini::endgame::EndgameSelector<TrackerT>::Cauchy,
-	                             decltype(sys), start_system::TotalDegree>(sys);
+	                             decltype(sys)>(sys);
 	zd.DefaultSetup();
 
 	ZeroDimLifecycleCounter counter;
@@ -1179,7 +1174,7 @@ BOOST_AUTO_TEST_CASE(zerodim_rejects_a_tracker_observer)
 
 	auto sys = system::Precon::GriewankOsborn();
 	auto zd = algorithm::ZeroDim<TrackerT, bertini::endgame::EndgameSelector<TrackerT>::Cauchy,
-	                             decltype(sys), start_system::TotalDegree>(sys);
+	                             decltype(sys)>(sys);
 
 	// a tracker observer is for a tracker, not the ZeroDim -> rejected
 	GoryDetailLogger<TrackerT> tracker_observer;

--- a/core/test/tracking_basics/amp_tracker_test.cpp
+++ b/core/test/tracking_basics/amp_tracker_test.cpp
@@ -800,7 +800,7 @@ BOOST_AUTO_TEST_CASE(AMP_track_total_degree_start_system)
 
 	
 
-	auto TD = bertini::start_system::TotalDegree(sys);
+	auto TD = bertini::start_system::RootsOfUnity(sys);
 	TD.Homogenize();
 	BOOST_CHECK(TD.IsHomogeneous());
 	BOOST_CHECK(TD.IsPatched());
@@ -855,7 +855,7 @@ BOOST_AUTO_TEST_CASE(AMP_track_total_degree_start_system)
 
 
 
-std::vector<Vec<mpfr> > track_total_degree(bertini::tracking::AMPTracker const& tracker, bertini::start_system::TotalDegree const& TD)
+std::vector<Vec<mpfr> > track_total_degree(bertini::tracking::AMPTracker const& tracker, bertini::start_system::RootsOfUnity const& TD)
 {
 	[[maybe_unused]] auto initial_precision = DefaultPrecision();
 	using namespace bertini::tracking;
@@ -901,7 +901,7 @@ BOOST_AUTO_TEST_CASE(AMP_track_TD_functionalized)
 
 	
 
-	auto TD = bertini::start_system::TotalDegree(sys);
+	auto TD = bertini::start_system::RootsOfUnity(sys);
 	TD.Homogenize();
 	BOOST_CHECK(TD.IsHomogeneous());
 	BOOST_CHECK(TD.IsPatched());

--- a/python/bertini/nag_algorithm/__init__.py
+++ b/python/bertini/nag_algorithm/__init__.py
@@ -353,8 +353,9 @@ _attach_to_dataframe()
 
 # --- ZeroDim: a friendly factory over the 18 bound ZeroDim<endgame x precision x start> classes ---
 
-# Each bound class is named ZeroDim<Endgame><Precision>Precision<StartSystem>; rather than type
-# ZeroDimCauchyFixedMultiplePrecisionTotalDegree, select the pieces by string.
+# Each bound solver class is named ZeroDim<Endgame><Precision>Precision (the start system is NO
+# longer part of the type -- it is chosen at construction).  Select endgame + precision by string to
+# pick the class, then pick the start system separately (default total_degree, else a factory).
 _ZD_ENDGAMES = {
     'cauchy': 'Cauchy',
     'powerseries': 'PowerSeries', 'power_series': 'PowerSeries', 'pseg': 'PowerSeries',
@@ -365,9 +366,11 @@ _ZD_PRECISIONS = {
     'fixed_multiple': 'FixedMultiplePrecision', 'multiprecision': 'FixedMultiplePrecision',
     'adaptive': 'AdaptivePrecision', 'amp': 'AdaptivePrecision',
 }
+# string -> the StartSystemType enum value name on _pybnalag (the C++ blackbox::type::Start).
 _ZD_START_SYSTEMS = {
-    'totaldegree': 'TotalDegree', 'total_degree': 'TotalDegree', 'td': 'TotalDegree',
-    'mhom': 'MHomogeneous', 'mhomogeneous': 'MHomogeneous', 'multihomogeneous': 'MHomogeneous',
+    'totaldegree': 'total_degree', 'total_degree': 'total_degree', 'td': 'total_degree',
+    'rootsofunity': 'roots_of_unity', 'roots_of_unity': 'roots_of_unity', 'rou': 'roots_of_unity',
+    'mhom': 'mhomogeneous', 'mhomogeneous': 'mhomogeneous', 'multihomogeneous': 'mhomogeneous',
 }
 
 
@@ -384,12 +387,16 @@ def _infer_start_system(system):
     """Pick the start system from the system's variable-group structure.
 
     Mirrors the C++ blackbox ``InferStartType`` (core/.../blackbox/switches_zerodim.hpp): a single
-    affine variable group with no homogeneous/projective groups is the 1-homogeneous (total-degree)
-    case; anything else -- two or more variable groups, or any homogeneous group -- is
-    multihomogeneous, and total degree would be the wrong (over-counting) start system there.
+    affine variable group with no homogeneous/projective groups is the 1-homogeneous case; anything
+    else -- two or more variable groups, or any homogeneous group -- is multihomogeneous (total
+    degree / roots of unity would be the wrong, over-counting start system there).
+
+    INTERIM: the single-affine-group case infers ``rootsofunity`` (the safe default).  The eventual
+    inference is the linear-product ``totaldegree`` (general position), gated on the Cauchy-endgame
+    fix; see core/.../nag_algorithms/common/policies.hpp.
     """
     if system.num_variable_groups() == 1 and system.num_hom_variable_groups() == 0:
-        return 'totaldegree'
+        return 'rootsofunity'
     return 'mhom'
 
 
@@ -428,9 +435,9 @@ def ZeroDim(system, *, endgame='cauchy', mptype='adaptive', startsystem='infer',
         >>> sys.add_variable_group(bertini.VariableGroup([x]))
         >>> sys.add_function(x * x - 1)
         >>> type(ZeroDim(sys)).__name__
-        'ZeroDimCauchyAdaptivePrecisionTotalDegree'
+        'ZeroDimCauchyAdaptivePrecision'
         >>> type(ZeroDim(sys, mptype='amp', startsystem='mhom')).__name__
-        'ZeroDimCauchyAdaptivePrecisionMHomogeneous'
+        'ZeroDimCauchyAdaptivePrecision'
         >>> solver = ZeroDim(sys, mptype='adaptive')   # robust path
         >>> solver.solve()                             # doctest: +SKIP
         >>> solver.all_solutions()                         # doctest: +SKIP
@@ -447,11 +454,50 @@ def ZeroDim(system, *, endgame='cauchy', mptype='adaptive', startsystem='infer',
             "nag_algorithm.user_homotopy(homotopy, start_points, target).")
     if start_key == 'infer':
         startsystem = _infer_start_system(system)
+    # the solver class encodes only endgame + precision now; the start system is a constructor choice.
     cls_name = ('ZeroDim'
                 + _zd_select(endgame, _ZD_ENDGAMES, 'endgame')
-                + _zd_select(mptype, _ZD_PRECISIONS, 'mptype')
-                + _zd_select(startsystem, _ZD_START_SYSTEMS, 'startsystem'))
-    return getattr(_pybnalag, cls_name)(system)
+                + _zd_select(mptype, _ZD_PRECISIONS, 'mptype'))
+    cls = getattr(_pybnalag, cls_name)
+    start_enum = getattr(_pybnalag.StartSystemType,
+                         _zd_select(startsystem, _ZD_START_SYSTEMS, 'startsystem'))
+    # total_degree is the default constructor; any other start is selected with a factory.
+    if start_enum == _pybnalag.StartSystemType.total_degree:
+        return cls(system)
+    return cls(system, _pybnalag.start_system_factory(start_enum))
+
+
+# --- backward-compatible solver-name shims -----------------------------------------------------
+# Before ZeroDim was de-templated off the start-system type, every (endgame, precision, start)
+# combination was its own bound class, e.g. ``ZeroDimCauchyAdaptivePrecisionTotalDegree``.  The start
+# system is no longer part of the solver type (it is a construction choice), so those classes are
+# gone.  These thin shims delegate to the ``ZeroDim(...)`` facade so existing code -- including the
+# many places that import a name and pass it around as a callable -- keeps working.  Prefer
+# ``ZeroDim(system, endgame=..., mptype=..., startsystem=...)`` in new code.
+def _install_legacy_zerodim_aliases():
+    import sys as _sys
+    _EG = {'Cauchy': 'cauchy', 'PowerSeries': 'powerseries'}
+    _PR = {'DoublePrecision': 'double', 'FixedMultiplePrecision': 'multiple',
+           'AdaptivePrecision': 'adaptive'}
+    # NOTE: the legacy ``...TotalDegree`` classes were the OLD total-degree start system, which was
+    # really roots of unity -- so map them to 'rootsofunity' to preserve their historical behavior
+    # (and to avoid the new linear-product TotalDegree's current Cauchy-endgame stall).
+    _SS = {'TotalDegree': 'rootsofunity', 'MHomogeneous': 'mhom'}
+    _mod = _sys.modules[__name__]
+    for eg_name, eg in _EG.items():
+        for pr_name, pr in _PR.items():
+            for ss_name, ss in _SS.items():
+                name = 'ZeroDim{}{}{}'.format(eg_name, pr_name, ss_name)
+                def _shim(system, *, _eg=eg, _pr=pr, _ss=ss):
+                    return ZeroDim(system, endgame=_eg, mptype=_pr, startsystem=_ss)
+                _shim.__name__ = _shim.__qualname__ = name
+                _shim.__doc__ = ("Deprecated alias for ZeroDim(system, endgame={!r}, mptype={!r}, "
+                                 "startsystem={!r}); the start system is no longer baked into the "
+                                 "solver type.".format(eg, pr, ss))
+                setattr(_mod, name, _shim)
+
+
+_install_legacy_zerodim_aliases()
 
 
 # --- user homotopy: run the zero-dim solver on a homotopy YOU built, from start points YOU have ---

--- a/python/test/classes/start_system_test.py
+++ b/python/test/classes/start_system_test.py
@@ -80,7 +80,7 @@ def test_total_degree_linear(linear_system):
 
     Mirrors start_system_test.cpp/make_total_degree_system_linear.
     """
-    td = ss.TotalDegree(linear_system)
+    td = ss.RootsOfUnity(linear_system)
     assert td.num_start_points() == 1
     assert list(td.degrees()) == [1]
 
@@ -92,7 +92,7 @@ def test_total_degree_quad_cubic_quartic(quad_cubic_quartic_system):
     (generalised to the 3-variable case).
     """
     s, *_ = quad_cubic_quartic_system
-    td = ss.TotalDegree(s)
+    td = ss.RootsOfUnity(s)
     assert list(td.degrees()) == [2, 3, 4]
     assert td.num_start_points() == 24
 
@@ -107,7 +107,7 @@ def test_start_points_evaluate_to_zero_double(quad_cubic_quartic_system):
     Mirrors start_system_test.cpp/quadratic_cubic_quartic_start_points.
     """
     s, *_ = quad_cubic_quartic_system
-    td = ss.TotalDegree(s)
+    td = ss.RootsOfUnity(s)
     n = td.num_start_points()
     assert n == 24
     for i in range(n):
@@ -124,7 +124,7 @@ def test_total_degree_jacobian_at_111(quad_cubic_quartic_system):
     are d_i * x_i^{d_i - 1}.
     """
     s, *_ = quad_cubic_quartic_system
-    td = ss.TotalDegree(s)
+    td = ss.RootsOfUnity(s)
     td.differentiate()
     pt = np.array([complex(1, 0)] * 3)
     J = td.eval_jacobian(pt)
@@ -143,7 +143,7 @@ def test_start_points_evaluate_to_zero_mp(quad_cubic_quartic_system):
     Mirrors start_system_test.cpp/quadratic_cubic_quartic_start_points (mp variant).
     """
     s, *_ = quad_cubic_quartic_system
-    td = ss.TotalDegree(s)
+    td = ss.RootsOfUnity(s)
     n = td.num_start_points()
     for i in range(n):
         p = td.start_point_mp(i)
@@ -167,7 +167,7 @@ def test_total_degree_homogenized_patched(quad_cubic_quartic_system):
     assert s.is_homogeneous()
     assert s.is_patched()
 
-    td = ss.TotalDegree(s)
+    td = ss.RootsOfUnity(s)
     td.homogenize()
     assert td.is_homogeneous()
     assert td.is_patched()
@@ -192,7 +192,7 @@ def test_start_point_precision_16(quad_cubic_quartic_system):
     bertini.default_precision(16)
 
     s, *_ = quad_cubic_quartic_system
-    td = ss.TotalDegree(s)
+    td = ss.RootsOfUnity(s)
     n = td.num_start_points()
     for i in range(n):
         p = td.start_point_mp(i)

--- a/python/test/tracking/endgame_test.py
+++ b/python/test/tracking/endgame_test.py
@@ -76,7 +76,7 @@ def test_using_total_degree_ss():
     assert sys.is_patched() == 1
     assert sys.is_homogeneous() == 1
 
-    td = ss.TotalDegree(sys)
+    td = ss.RootsOfUnity(sys)
 
     assert td.is_patched() == 1
     assert td.is_homogeneous() == 1

--- a/python/test/zero_dim/zero_dim_factory_test.py
+++ b/python/test/zero_dim/zero_dim_factory_test.py
@@ -1,7 +1,12 @@
 """The friendly ZeroDim(...) factory selects the right bound solver class by string.
 
-Instead of typing ZeroDimCauchyAdaptivePrecisionTotalDegree, you say ZeroDim(system) (the
-defaults) or ZeroDim(system, endgame=..., mptype=..., startsystem=...).
+Instead of typing ZeroDimCauchyAdaptivePrecision, you say ZeroDim(system) (the defaults) or
+ZeroDim(system, endgame=..., mptype=..., startsystem=...).
+
+Note: after ZeroDim was de-templated off the start-system type, the bound solver class encodes only
+the endgame and precision (e.g. ``ZeroDimCauchyAdaptivePrecision``); the start system is chosen at
+construction and held polymorphically, so it is NO LONGER part of the class name.  Start-system
+selection is therefore verified behaviorally here, not by the type.
 """
 
 import pytest
@@ -21,26 +26,27 @@ def _system():
     return sys
 
 
-def test_defaults_are_cauchy_adaptive_totaldegree():
+def test_defaults_are_cauchy_adaptive():
+    # default endgame + precision; start system (total degree) is not in the type name anymore.
     solver = ZeroDim(_system())
-    assert isinstance(solver, _n.ZeroDimCauchyAdaptivePrecisionTotalDegree)
+    assert isinstance(solver, _n.ZeroDimCauchyAdaptivePrecision)
 
 
 @pytest.mark.parametrize("kwargs, expected", [
-    (dict(),                                                   'ZeroDimCauchyAdaptivePrecisionTotalDegree'),
-    (dict(mptype='double'),                                   'ZeroDimCauchyDoublePrecisionTotalDegree'),
-    (dict(mptype='dbl'),                                      'ZeroDimCauchyDoublePrecisionTotalDegree'),
-    (dict(mptype='multiple'),                                 'ZeroDimCauchyFixedMultiplePrecisionTotalDegree'),
-    (dict(mptype='amp'),                                      'ZeroDimCauchyAdaptivePrecisionTotalDegree'),
-    (dict(mptype='adaptive'),                                 'ZeroDimCauchyAdaptivePrecisionTotalDegree'),
-    (dict(endgame='powerseries'),                             'ZeroDimPowerSeriesAdaptivePrecisionTotalDegree'),
-    (dict(endgame='power_series'),                            'ZeroDimPowerSeriesAdaptivePrecisionTotalDegree'),
-    (dict(startsystem='mhom'),                                'ZeroDimCauchyAdaptivePrecisionMHomogeneous'),
-    (dict(startsystem='td'),                                  'ZeroDimCauchyAdaptivePrecisionTotalDegree'),
-    # the docstring's headline example, and a fully-specified power-series/double/total-degree:
-    (dict(endgame='cauchy', mptype='amp', startsystem='mhom'),'ZeroDimCauchyAdaptivePrecisionMHomogeneous'),
+    (dict(),                                                   'ZeroDimCauchyAdaptivePrecision'),
+    (dict(mptype='double'),                                   'ZeroDimCauchyDoublePrecision'),
+    (dict(mptype='dbl'),                                      'ZeroDimCauchyDoublePrecision'),
+    (dict(mptype='multiple'),                                 'ZeroDimCauchyFixedMultiplePrecision'),
+    (dict(mptype='amp'),                                      'ZeroDimCauchyAdaptivePrecision'),
+    (dict(mptype='adaptive'),                                 'ZeroDimCauchyAdaptivePrecision'),
+    (dict(endgame='powerseries'),                             'ZeroDimPowerSeriesAdaptivePrecision'),
+    (dict(endgame='power_series'),                            'ZeroDimPowerSeriesAdaptivePrecision'),
+    # the start system no longer changes the type -- only endgame + precision do:
+    (dict(startsystem='mhom'),                                'ZeroDimCauchyAdaptivePrecision'),
+    (dict(startsystem='td'),                                  'ZeroDimCauchyAdaptivePrecision'),
+    (dict(endgame='cauchy', mptype='amp', startsystem='mhom'),'ZeroDimCauchyAdaptivePrecision'),
     (dict(endgame='power_series', mptype='dbl', startsystem='td'),
-                                                              'ZeroDimPowerSeriesDoublePrecisionTotalDegree'),
+                                                              'ZeroDimPowerSeriesDoublePrecision'),
 ])
 def test_factory_selects_expected_class(kwargs, expected):
     solver = ZeroDim(_system(), **kwargs)
@@ -68,10 +74,10 @@ def test_factory_returns_a_real_solver():
 
 def test_precision_is_an_alias_for_mptype():
     assert isinstance(ZeroDim(_system(), precision='amp'),
-                      _n.ZeroDimCauchyAdaptivePrecisionTotalDegree)
+                      _n.ZeroDimCauchyAdaptivePrecision)
     # precision overrides mptype when both are given
     assert isinstance(ZeroDim(_system(), mptype='double', precision='adaptive'),
-                      _n.ZeroDimCauchyAdaptivePrecisionTotalDegree)
+                      _n.ZeroDimCauchyAdaptivePrecision)
 
 
 def test_user_startsystem_points_at_user_homotopy():
@@ -100,14 +106,21 @@ def _projective_system():
 
 def test_startsystem_inferred_from_variable_groups():
     # default startsystem='infer' mirrors the C++ blackbox InferStartType: a single affine group is
-    # total degree; two-or-more groups, or any projective group, is multihomogeneous.  This matters
-    # because total degree THROWS ("more than one affine variable group") on a multi-group system.
-    assert isinstance(ZeroDim(_system()),
-                      _n.ZeroDimCauchyAdaptivePrecisionTotalDegree)
-    assert isinstance(ZeroDim(_two_affine_group_system()),
-                      _n.ZeroDimCauchyAdaptivePrecisionMHomogeneous)
-    assert isinstance(ZeroDim(_projective_system()),
-                      _n.ZeroDimCauchyAdaptivePrecisionMHomogeneous)
+    # total degree; two-or-more groups, or any projective group, is multihomogeneous.  Since the start
+    # system is no longer in the solver type, we verify the inference BEHAVIORALLY: a multi-group /
+    # projective system would THROW ("more than one affine variable group") if total degree were
+    # (wrongly) inferred, so successfully constructing AND solving it proves MHom was chosen.
+    single = ZeroDim(_system())
+    single.solve()
+    assert len(single.finite_solutions()) == 2
+
+    multi = ZeroDim(_two_affine_group_system())     # total degree would throw here
+    multi.solve()
+    assert len(multi.finite_solutions()) == 2       # x*y=1, x+y=0 -> (i,-i) and (-i,i)
+
+    proj = ZeroDim(_projective_system())            # projective group -> MHom
+    proj.solve()
+    assert len(proj.all_solutions()) >= 1
 
 
 def test_fixed_multiple_precision_solves():

--- a/python_bindings/include/system_export.hpp
+++ b/python_bindings/include/system_export.hpp
@@ -69,6 +69,7 @@ namespace bertini{
 		void ExportStartSystems();
 		void ExportStartSystemBase();
 		void ExportTotalDegree();
+		void ExportRootsOfUnity();
 		
 		
 		

--- a/python_bindings/include/zero_dim_export.hpp
+++ b/python_bindings/include/zero_dim_export.hpp
@@ -43,6 +43,7 @@
 #include <bertini2/nag_algorithms/zero_dim_solve.hpp>
 #include <bertini2/nag_algorithms/events.hpp>
 #include <bertini2/system/start_systems.hpp>
+#include <bertini2/blackbox/config.hpp>   // blackbox::type::Start (start-system selector enum)
 #include <bertini2/io/classic_writer.hpp>
 
 #include <boost/python/stl_iterator.hpp>
@@ -320,19 +321,73 @@ void ZDVisitor<AlgoT>::visit(PyClass& cl) const
 }
 
 
-// Helper template — defined here so all split TUs can use it without duplication.
-template<typename TrackerT, typename EndgameT, typename SystemT, typename StartSystemT>
+// Map a Start enum choice to a clone factory -- the one place a concrete start-system type is named
+// on the binding side.  User is rejected: it needs the user_homotopy path (RefToGiven).
+inline policy::StartSystemFactory<System> StartFactoryFor(blackbox::type::Start which)
+{
+	switch (which)
+	{
+		case blackbox::type::Start::MHom:
+			return policy::MakeStartFactory<start_system::MHomogeneous>();
+		case blackbox::type::Start::RootsOfUnity:
+			return policy::MakeStartFactory<start_system::RootsOfUnity>();
+		case blackbox::type::Start::User:
+			throw std::runtime_error("the User start system is not a clone-owned start; build the "
+			                         "homotopy with nag_algorithm.user_homotopy(...) instead");
+		case blackbox::type::Start::TotalDegree:
+		default:
+			return policy::MakeStartFactory<start_system::TotalDegree>();
+	}
+}
+
+// Expose the blackbox start-system selector enum to Python (call once).
+inline void ExportStartSystemEnum()
+{
+	boost::python::enum_<blackbox::type::Start>("StartSystemType",
+		"Which start system a ZeroDim solver builds: total_degree (default) or mhomogeneous. "
+		"User homotopies use nag_algorithm.user_homotopy(...) instead.")
+		.value("total_degree", blackbox::type::Start::TotalDegree)
+		.value("roots_of_unity", blackbox::type::Start::RootsOfUnity)
+		.value("mhomogeneous", blackbox::type::Start::MHom)
+		;
+}
+
+// Register the opaque start-system factory type + a producer function (call once).  ZeroDim no
+// longer bakes the start system into its type; a non-default start is selected by passing one of
+// these factories as the solver constructor's second argument.
+inline void ExportStartSystemFactory()
+{
+	class_<policy::StartSystemFactory<System>>("StartSystemFactory",
+		"Opaque factory that builds a start system for a ZeroDim solver.  Get one from "
+		"start_system_factory(StartSystemType.X) and pass it as the solver's second constructor arg.",
+		no_init);
+	def("start_system_factory", &StartFactoryFor,
+		(boost::python::arg("which")),
+		"start_system_factory(which): the start-system factory for a StartSystemType, to pass as the "
+		"second argument of a ZeroDim solver constructor (the default constructor uses total_degree).");
+}
+
+// Helper template — defined here so all split TUs can use it without duplication.  ZeroDim is no
+// longer templated on the start system; the concrete start system is chosen at construction (default
+// TotalDegree, or an explicit factory) and held polymorphically.
+template<typename TrackerT, typename EndgameT>
 void ExportZeroDimSpecific(std::string const& class_name){
-	using ZeroDimT = algorithm::ZeroDim<TrackerT, EndgameT, SystemT, StartSystemT>;
-	// with_custodian_and_ward<1,2>: keep the Python System (arg 2) alive as long as the solver
-	// (self, arg 1).  The solver's internal system is a SHALLOW copy that shares the function-tree
-	// nodes' shared_ptrs with the user's System; those shared_ptrs carry boost.python deleters tied
-	// to the Python node wrappers, so if the user passes a temporary System and lets it die, the
-	// endgame's Differentiate() drops a node and the deleter touches an already-freed Python object
-	// -> crash.  Tying the System's lifetime to the solver makes the documented `ZeroDim(sys)` usage
-	// safe even when the caller keeps no reference to `sys` (e.g. building it in a helper function).
+	using ZeroDimT = algorithm::ZeroDim<TrackerT, EndgameT, System>;
+	// with_custodian_and_ward<1,2>: keep the Python System (ctor arg, index 2) alive as long as the
+	// solver (self, index 1).  The solver's internal system is a SHALLOW copy that shares the
+	// function-tree nodes' shared_ptrs with the user's System; those shared_ptrs carry boost.python
+	// deleters tied to the Python node wrappers, so if the user passes a temporary System and lets it
+	// die, the endgame's Differentiate() drops a node and the deleter touches an already-freed Python
+	// object -> crash.  Tying the System's lifetime to the solver makes the documented `ZeroDim(sys)`
+	// usage safe even when the caller keeps no reference to `sys`.
+	//
+	// Two constructors: (system) defaults to the TotalDegree start; (system, start_factory) selects
+	// a non-default start (e.g. MHomogeneous) -- the factory is a value, copied into the solver.
 	class_<ZeroDimT, std::shared_ptr<ZeroDimT>, bases<algorithm::AnyZeroDim> >(class_name.c_str(),
-		init<SystemT>()[with_custodian_and_ward<1, 2>()])
+		init<System const&>()[with_custodian_and_ward<1, 2>()])
+	.def(init<System const&, policy::StartSystemFactory<System> const&>(
+			(boost::python::arg("system"), boost::python::arg("start_factory")))
+			[with_custodian_and_ward<1, 2>()])
 	.def(ZDVisitor<ZeroDimT>())
 	;
 }
@@ -375,7 +430,7 @@ inline void ExportUserStartSystem(){
 // reference (RefToGiven); the Python wrapper retains all three so the references stay valid.
 template<typename TrackerT, typename EndgameT>
 void ExportZeroDimUserHomotopy(std::string const& class_name){
-	using ZeroDimT = algorithm::ZeroDim<TrackerT, EndgameT, System, start_system::User, policy::RefToGiven>;
+	using ZeroDimT = algorithm::ZeroDim<TrackerT, EndgameT, System, policy::RefToGiven>;
 	// RefToGiven: this solver holds REFERENCES to all three given systems, so each must outlive the
 	// solver.  Chain with_custodian_and_ward to keep target (arg 2), start (arg 3) and homotopy
 	// (arg 4) alive as long as the solver (self, arg 1).

--- a/python_bindings/src/system_export.cpp
+++ b/python_bindings/src/system_export.cpp
@@ -348,6 +348,7 @@ namespace bertini{
 
 				ExportStartSystemBase();
 				ExportTotalDegree();
+				ExportRootsOfUnity();
 			}
 		}
 
@@ -366,13 +367,22 @@ namespace bertini{
 
 		void ExportTotalDegree()
 		{
-			class_<start_system::TotalDegree, bases<start_system::StartSystem>, std::shared_ptr<start_system::TotalDegree> >("TotalDegree",init<System const&>())//,"Only constructor for a TotalDegree start system, requires a system.  You cannot construct one without.  If this is a problem, please contact the authors for help.")
-			.def("random_value", &start_system::TotalDegree::RandomValue<complex_dbl>,(arg("self"), arg("index")), "Get the k-th random value, in double precision")
-			.def("random_value", &start_system::TotalDegree::RandomValue<mpfr>,(arg("self"), arg("index")), "Get the k-th random value, in current multiple precision")
-			.def("random_values", &start_system::TotalDegree::RandomValues,(arg("self")), return_value_policy<copy_const_reference>(), "Get (a reference to) the random values for the start system, as Nodes")
+			// The total-degree start system is now built from random linear products (generic
+			// position); it has no per-variable "random value" (that was the roots-of-unity start,
+			// now RootsOfUnity).  It evaluates through a products-of-linears block.
+			class_<start_system::TotalDegree, bases<start_system::StartSystem>, std::shared_ptr<start_system::TotalDegree> >("TotalDegree",init<System const&>())
 			;
+		}
 
-			
+		void ExportRootsOfUnity()
+		{
+			// The roots-of-unity start system: x_i^{d_i} - r_i (formerly misnamed "TotalDegree").
+			// A structured, teaching/novelty start; kept reachable but not the default.
+			class_<start_system::RootsOfUnity, bases<start_system::StartSystem>, std::shared_ptr<start_system::RootsOfUnity> >("RootsOfUnity",init<System const&>())
+			.def("random_value", &start_system::RootsOfUnity::RandomValue<complex_dbl>,(arg("self"), arg("index")), "Get the k-th random value, in double precision")
+			.def("random_value", &start_system::RootsOfUnity::RandomValue<mpfr>,(arg("self"), arg("index")), "Get the k-th random value, in current multiple precision")
+			.def("random_values", &start_system::RootsOfUnity::RandomValues,(arg("self")), return_value_policy<copy_const_reference>(), "Get (a reference to) the random values for the start system, as Nodes")
+			;
 		}
 	}
 }

--- a/python_bindings/src/zero_dim_amp_export.cpp
+++ b/python_bindings/src/zero_dim_amp_export.cpp
@@ -7,10 +7,8 @@ namespace bertini{
 
 		void ExportZDAMP(){
 			using TrackerT = bertini::tracking::AMPTracker;
-			ExportZeroDimSpecific<TrackerT, bertini::endgame::EndgameSelector<TrackerT>::PSEG, bertini::System, bertini::start_system::TotalDegree>("ZeroDimPowerSeriesAdaptivePrecisionTotalDegree");
-			ExportZeroDimSpecific<TrackerT, bertini::endgame::EndgameSelector<TrackerT>::Cauchy, bertini::System, bertini::start_system::TotalDegree>("ZeroDimCauchyAdaptivePrecisionTotalDegree");
-			ExportZeroDimSpecific<TrackerT, bertini::endgame::EndgameSelector<TrackerT>::PSEG, bertini::System, bertini::start_system::MHomogeneous>("ZeroDimPowerSeriesAdaptivePrecisionMHomogeneous");
-			ExportZeroDimSpecific<TrackerT, bertini::endgame::EndgameSelector<TrackerT>::Cauchy, bertini::System, bertini::start_system::MHomogeneous>("ZeroDimCauchyAdaptivePrecisionMHomogeneous");
+			ExportZeroDimSpecific<TrackerT, bertini::endgame::EndgameSelector<TrackerT>::PSEG>("ZeroDimPowerSeriesAdaptivePrecision");
+			ExportZeroDimSpecific<TrackerT, bertini::endgame::EndgameSelector<TrackerT>::Cauchy>("ZeroDimCauchyAdaptivePrecision");
 
 			ExportZeroDimUserHomotopy<TrackerT, bertini::endgame::EndgameSelector<TrackerT>::PSEG>("ZeroDimPowerSeriesAdaptivePrecisionUserHomotopy");
 			ExportZeroDimUserHomotopy<TrackerT, bertini::endgame::EndgameSelector<TrackerT>::Cauchy>("ZeroDimCauchyAdaptivePrecisionUserHomotopy");

--- a/python_bindings/src/zero_dim_double_export.cpp
+++ b/python_bindings/src/zero_dim_double_export.cpp
@@ -7,10 +7,12 @@ namespace bertini{
 
 		void ExportZDDouble(){
 			using TrackerT = bertini::tracking::DoublePrecisionTracker;
-			ExportZeroDimSpecific<TrackerT, bertini::endgame::EndgameSelector<TrackerT>::PSEG, bertini::System, bertini::start_system::TotalDegree>("ZeroDimPowerSeriesDoublePrecisionTotalDegree");
-			ExportZeroDimSpecific<TrackerT, bertini::endgame::EndgameSelector<TrackerT>::Cauchy, bertini::System, bertini::start_system::TotalDegree>("ZeroDimCauchyDoublePrecisionTotalDegree");
-			ExportZeroDimSpecific<TrackerT, bertini::endgame::EndgameSelector<TrackerT>::PSEG, bertini::System, bertini::start_system::MHomogeneous>("ZeroDimPowerSeriesDoublePrecisionMHomogeneous");
-			ExportZeroDimSpecific<TrackerT, bertini::endgame::EndgameSelector<TrackerT>::Cauchy, bertini::System, bertini::start_system::MHomogeneous>("ZeroDimCauchyDoublePrecisionMHomogeneous");
+			// the start-system selector enum + factory are not tracker-specific; register them once,
+			// here, and BEFORE the ZeroDim classes (whose 2nd constructor takes a StartSystemFactory).
+			ExportStartSystemEnum();
+			ExportStartSystemFactory();
+			ExportZeroDimSpecific<TrackerT, bertini::endgame::EndgameSelector<TrackerT>::PSEG>("ZeroDimPowerSeriesDoublePrecision");
+			ExportZeroDimSpecific<TrackerT, bertini::endgame::EndgameSelector<TrackerT>::Cauchy>("ZeroDimCauchyDoublePrecision");
 
 			// the User start system is not tracker-specific; register it once, here.
 			ExportUserStartSystem();

--- a/python_bindings/src/zero_dim_mp_export.cpp
+++ b/python_bindings/src/zero_dim_mp_export.cpp
@@ -7,10 +7,8 @@ namespace bertini{
 
 		void ExportZDMP(){
 			using TrackerT = bertini::tracking::MultiplePrecisionTracker;
-			ExportZeroDimSpecific<TrackerT, bertini::endgame::EndgameSelector<TrackerT>::PSEG, bertini::System, bertini::start_system::TotalDegree>("ZeroDimPowerSeriesFixedMultiplePrecisionTotalDegree");
-			ExportZeroDimSpecific<TrackerT, bertini::endgame::EndgameSelector<TrackerT>::Cauchy, bertini::System, bertini::start_system::TotalDegree>("ZeroDimCauchyFixedMultiplePrecisionTotalDegree");
-			ExportZeroDimSpecific<TrackerT, bertini::endgame::EndgameSelector<TrackerT>::PSEG, bertini::System, bertini::start_system::MHomogeneous>("ZeroDimPowerSeriesFixedMultiplePrecisionMHomogeneous");
-			ExportZeroDimSpecific<TrackerT, bertini::endgame::EndgameSelector<TrackerT>::Cauchy, bertini::System, bertini::start_system::MHomogeneous>("ZeroDimCauchyFixedMultiplePrecisionMHomogeneous");
+			ExportZeroDimSpecific<TrackerT, bertini::endgame::EndgameSelector<TrackerT>::PSEG>("ZeroDimPowerSeriesFixedMultiplePrecision");
+			ExportZeroDimSpecific<TrackerT, bertini::endgame::EndgameSelector<TrackerT>::Cauchy>("ZeroDimCauchyFixedMultiplePrecision");
 
 			ExportZeroDimUserHomotopy<TrackerT, bertini::endgame::EndgameSelector<TrackerT>::PSEG>("ZeroDimPowerSeriesFixedMultiplePrecisionUserHomotopy");
 			ExportZeroDimUserHomotopy<TrackerT, bertini::endgame::EndgameSelector<TrackerT>::Cauchy>("ZeroDimCauchyFixedMultiplePrecisionUserHomotopy");


### PR DESCRIPTION
## What

**De-templates `ZeroDim` on the start-system type**, and **adds a genuine linear-product `TotalDegree`** start system (renaming the old, misnamed roots-of-unity one to `RootsOfUnity`).

### De-templating
`ZeroDim` no longer carries the start-system type as a template parameter. It holds the start system **polymorphically** (`shared_ptr<start_system::StartSystem>`) built by a `policy::StartSystemFactory` injected at the construction site. Every use inside `ZeroDim` was already base-class API (`NumStartPoints`/`StartPoint<T>`, `MakeHomotopy`, midpath `Check`), so this is a clean refactor.

- **ETI collapses 18 → 12** (6 `CloneGiven` covering *all* clone-owned start systems + 6 `RefToGiven` for user homotopies). **Adding a start system now costs zero new `ZeroDim` instantiation.**
- **Python**: the 12 `ZeroDim…{TotalDegree,MHomogeneous}` classes collapse to **6** base names with the start system chosen via a `StartSystemType` enum/factory. The friendly `nag_algorithm.ZeroDim(system, …, startsystem=…)` facade keeps its public signature; thin shims keep the old class names working.

### Start systems
- The old `TotalDegree` was actually roots of unity (`x_i^{d_i} − r_i`) → **renamed `RootsOfUnity`** (behavior verbatim).
- New **linear-product `TotalDegree`** added (single-affine-group specialization of `MHomogeneous`: random products of linear forms, evaluated via `ProductsOfLinearsBlock`, start points by an n×n linear solve — verified Bézout-many, ~1e-12 residual).

### ⚠️ Interim default = `RootsOfUnity`
The linear-product `TotalDegree` is the *intended* default (general position; roots of unity clusters at t=1), but it currently drives the **Cauchy endgame into a corrector roundoff-floor stall** on harder systems (e.g. cyclic-5) — root-caused, being fixed separately. So the default stays `RootsOfUnity` until that lands; `TotalDegree` is fully implemented and reachable (`startsystem='totaldegree'`). The flip points are documented in code comments.

### CI
C++ test suites now run under **both** `OMP_NUM_THREADS=1` and unset (unix + Windows) to catch serial-vs-threaded divergences; the threaded clone test skips cleanly when forced serial.

## Test status
- C++: all 10 ctest suites pass under both thread settings (cyclic-5 = 70 finite via the RootsOfUnity default, no hang).
- Python: full suite green except one pre-existing numpy-2.5.0/eigenpy env failure in the local dev venv (`np.sum` over mpfr; passes in CI with pinned numpy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)