### PR TITLE
fix: function() on slice-derived systems + system.slices() (bertiniteam/b2#263)

### DIFF
--- a/core/include/bertini2/system/system.hpp
+++ b/core/include/bertini2/system/system.hpp
@@ -65,6 +65,9 @@ namespace bertini {
 
 	// (included above) so the evaluation blocks can see them.
 
+	class Slice;  // system/slice.hpp -- a thin wrapper over a LinearFormsBlock; System::Slices()
+	              // recovers them from a slice-derived system without binding the block variant.
+
 	/**
 	\brief The fundamental polynomial system class for Bertini2.
 	
@@ -998,6 +1001,12 @@ namespace bertini {
 		/// itself stays out of the Python surface.
 		std::vector<Block> const& Blocks() const { return blocks_; }
 
+		/// \brief Recover the linear-form slices embedded in this system, one per LinearFormsBlock
+		/// (empty if the system has none).  Lets a user back out the slice structure of a system
+		/// built from a slice -- the Python-facing alternative to exposing the Block variant.
+		/// Defined in system.cpp (needs the full Slice type).
+		std::vector<Slice> Slices() const;
+
 		/// Remove the polynomial block (the System's natural functions), leaving any structured
 		/// blocks and the variable structure / patch intact.  Used to turn a copy of a System
 		/// into a homotopy shell whose rows come from a blend block rather than its own
@@ -1252,24 +1261,32 @@ namespace bertini {
 
 
 		/**
-		 \brief Get a function by its index.  
+		 \brief Get a function by its index, as a function-tree node.
 
-		 This is just as scary as you think it is.  It is up to you to make sure the function at this index exists.
+		 Works for every block type: structured blocks (linear forms, products of linears,
+		 randomization, blend) are expanded to their node form on demand, so this is in sync with
+		 NumNaturalFunctions().  Throws std::out_of_range if the index is past the end (rather than
+		 dereferencing past it -- the old un-checked version segfaulted on slice-derived systems
+		 that have no PolynomialBlock).
 		*/
 		auto Function(unsigned index) const
 		{
-			return PolyBlockPtr()->Functions()[index];
+			auto fns = NaturalFunctionsAsNodes();
+			if (index >= fns.size())
+				throw std::out_of_range("System::Function index out of range");
+			return fns[index];
 		}
 
 
 		/**
-		 \brief Get the functions.
+		 \brief Get the functions, as function-tree nodes.
+
+		 Expands any structured block (so it agrees with NumNaturalFunctions() and Function(i),
+		 even for systems built purely from a slice / start-system block).
 		*/
 		std::vector<Nd> GetNaturalFunctions() const
 		{
-			if (auto* p = PolyBlockPtr())
-				return p->Functions();
-			return {};
+			return NaturalFunctionsAsNodes();
 		}
 
 

--- a/core/src/system/system.cpp
+++ b/core/src/system/system.cpp
@@ -27,6 +27,7 @@
 #include <type_traits>
 
 #include "bertini2/system/system.hpp"
+#include "bertini2/system/slice.hpp"   // for System::Slices() (needs the full Slice type)
 #include "bertini2/function_tree/find.hpp"
 
 #include <algorithm>
@@ -1038,6 +1039,40 @@ namespace bertini
 			}, blk);
 		}
 
+		return out;
+	}
+
+
+	std::vector<Slice> System::Slices() const
+	{
+		// Recover one Slice per LinearFormsBlock.  The block's columns are indexed by the system's
+		// variable ordering (see Slice::AddTo), so the slice is rebuilt over Variables().
+		std::vector<Slice> out;
+		auto const& vars = Variables();
+
+		for (auto const& blk : blocks_)
+		{
+			auto* p = std::get_if<blocks::LinearFormsBlock>(&blk);
+			if (!p)
+				continue;
+
+			auto const& M = p->Coefficients();
+			if (!p->IsHomogenized())
+			{
+				// affine: M is already augmented (trailing column is each form's constant).
+				out.push_back(Slice::FromCoefficients(vars, M, /*homogeneous=*/false));
+			}
+			else
+			{
+				// homogenized: M has one column per variable and no separate constant column.
+				// Re-augment with a zero constant so the recovered (homogeneous) slice evaluates
+				// identically (the old constant already rides on the homogenizing variable's column).
+				Mat<complex_mp> aug(M.rows(), M.cols() + 1);
+				aug.leftCols(M.cols()) = M;
+				aug.col(M.cols()).setZero();
+				out.push_back(Slice::FromCoefficients(vars, aug, /*homogeneous=*/true));
+			}
+		}
 		return out;
 	}
 

--- a/core/test/classes/system_blocks_test.cpp
+++ b/core/test/classes/system_blocks_test.cpp
@@ -21,7 +21,10 @@
 #include <boost/archive/text_oarchive.hpp>
 #include <boost/archive/text_iarchive.hpp>
 
+#include <stdexcept>
+
 #include "bertini2/system/system.hpp"
+#include "bertini2/system/slice.hpp"
 #include "bertini2/system/blocks/products_of_linears_block.hpp"
 #include "bertini2/system/blocks/linear_forms_block.hpp"
 #include "bertini2/system/blocks/blend_block.hpp"
@@ -99,6 +102,48 @@ BOOST_AUTO_TEST_CASE(eval_mpfr)
 	auto v = sys.Eval(x);
 
 	BOOST_CHECK(abs(v(0) - complex_mp(24)) < real_mp("1e-25"));
+}
+
+// issue #263: Function(i) on a system with no PolynomialBlock used to dereference a null
+// PolyBlockPtr() and segfault.  It now expands the structured block to a node on demand.
+BOOST_AUTO_TEST_CASE(function_accessor_on_structured_block)
+{
+	DefaultPrecision(30);
+	auto sys = MakeBlockSystem();                 // a single products-of-linears function, no PolynomialBlock
+
+	BOOST_CHECK_EQUAL(sys.GetNaturalFunctions().size(), 1u);  // not empty, in sync with NumNaturalFunctions
+	auto f = sys.Function(0);
+	BOOST_CHECK(f != nullptr);                                // a real function-tree node
+	BOOST_CHECK_THROW(sys.Function(1), std::out_of_range);    // past the end raises, no segfault
+}
+
+// issue #263: Slices() recovers the linear-form slices embedded in a system (inverse of AsSystem).
+BOOST_AUTO_TEST_CASE(slices_round_trip_linear_forms)
+{
+	DefaultPrecision(30);
+	Var x = node::Variable::Make("x"), y = node::Variable::Make("y");
+	VariableGroup vars{x, y};
+
+	bertini::Mat<complex_mp> M(2, 3);             // 2x+3y+1 ; x-y+4  (augmented, last col = constant)
+	M << complex_mp(2), complex_mp(3),  complex_mp(1),
+	     complex_mp(1), complex_mp(-1), complex_mp(4);
+
+	System sys;
+	sys.AddVariableGroup(vars);
+	sys.AddBlock(LinearFormsBlock(2, M));
+
+	auto slices = sys.Slices();
+	BOOST_REQUIRE_EQUAL(slices.size(), 1u);
+	auto const& C = slices[0].Coefficients();
+	BOOST_CHECK_EQUAL(C.rows(), 2);
+	BOOST_CHECK_EQUAL(C.cols(), 3);
+	BOOST_CHECK(abs(C(0, 0) - complex_mp(2)) < real_mp("1e-25"));
+	BOOST_CHECK(abs(C(1, 2) - complex_mp(4)) < real_mp("1e-25"));
+
+	System empty;                                  // a system with no linear-forms block has no slices
+	empty.AddVariableGroup(vars);
+	empty.AddFunction(x * x - y);
+	BOOST_CHECK(empty.Slices().empty());
 }
 
 // round-trip a System through a boost text archive, returning the deserialized copy.

--- a/python/test/classes/function_accessor_test.py
+++ b/python/test/classes/function_accessor_test.py
@@ -1,0 +1,146 @@
+# This file is part of Bertini 2.
+#
+# python/test/classes/function_accessor_test.py is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# python/test/classes/function_accessor_test.py is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this file.  If not, see <http://www.gnu.org/licenses/>.
+#
+#  Copyright(C) Bertini2 Development Team
+#
+#  See <http://www.gnu.org/licenses/> for a copy of the license,
+#  as well as COPYING.  Bertini2 is provided with permitted
+#  additional terms in the b2/licenses/ directory.
+
+"""``system.function(i)`` for every kind of evaluation block.
+
+A System is block-composed: its rows come from a PolynomialBlock and/or structured blocks
+(linear forms, products of linears, randomization, blend).  ``function(i)`` must return the
+i-th natural function as a function-tree node for *every* block type -- structured blocks are
+expanded to nodes on demand.  Regression for issue #263, where ``function(0)`` segfaulted on a
+system built from a slice (a pure LinearFormsBlock, so no PolynomialBlock to dereference).
+
+``system.slices()`` is the companion accessor: it backs out the linear-form slices embedded in
+a system -- the inverse of ``Slice.as_system()``.
+"""
+
+import numpy as np
+import pytest
+
+import bertini as pb
+from bertini._pybertini.function_tree import AbstractNode
+from bertini import linalg, nag_algorithm as na
+from bertini.nag_algorithm import Slice
+
+
+def _vg(*vs):
+    return pb.VariableGroup(list(vs))
+
+
+def _all_functions_are_nodes(system):
+    """function(i) returns a function-tree node for every i in range, and overshoot raises."""
+    n = system.num_functions()
+    assert n > 0
+    for i in range(n):
+        f = system.function(i)
+        assert isinstance(f, AbstractNode)
+        assert str(f)                         # has a printable form
+    with pytest.raises(IndexError):
+        system.function(n)                    # past the end raises, no longer segfaults
+    return [system.function(i) for i in range(n)]
+
+
+# ---- function(i) across every block type ----------------------------------------------------
+
+def test_function_polynomial_block():
+    x, y = pb.Variable('x'), pb.Variable('y')
+    s = pb.System(); s.add_variable_group(_vg(x, y))
+    s.add_function(x * x + y * y - 1); s.add_function(x - y)
+    fns = _all_functions_are_nodes(s)
+    assert 'x' in str(fns[0]) and 'y' in str(fns[0])
+
+
+def test_function_linear_forms_block_from_slice():
+    # issue #263: a system built from a slice has only a LinearFormsBlock (no PolynomialBlock).
+    x, y, z = pb.Variable('x'), pb.Variable('y'), pb.Variable('z')
+    s = Slice.random_complex(_vg(x, y, z), 1)
+    sys = s.as_system()
+    fns = _all_functions_are_nodes(sys)       # used to segfault here
+    text = str(fns[0])
+    assert 'x' in text and 'y' in text and 'z' in text   # the expanded linear form
+
+
+def test_function_products_of_linears_block():
+    x, y = pb.Variable('x'), pb.Variable('y')
+    s = pb.System(); s.add_variable_group(_vg(x, y))
+    linalg.add_products_of_linears(s, [[[1, 0, -1], [1, 0, 1]]])   # (x-1)(x+1)
+    fns = _all_functions_are_nodes(s)
+    assert 'x' in str(fns[0])
+
+
+def test_function_randomization_block():
+    x, y = pb.Variable('x'), pb.Variable('y')
+    o = pb.System(); o.add_variable_group(_vg(x, y))
+    o.add_function(x * x + y * y - 1); o.add_function(x * y); o.add_function(x * x - y)
+    r = linalg.randomize(o)                   # only a RandomizationBlock, no PolynomialBlock
+    _all_functions_are_nodes(r)
+
+
+def test_function_blend_block():
+    x, y = pb.Variable('x'), pb.Variable('y')
+    fx = pb.System(); fx.add_variable_group(_vg(x, y)); fx.add_function(x * x + y * y - 1)
+    sm = pb.System(); sm.add_variable_group(_vg(x, y)); sm.add_function(y)
+    em = pb.System(); em.add_variable_group(_vg(x, y)); em.add_function(y - x)
+    H = na.moving_homotopy(fx, sm, em,
+                           gamma=linalg.coefficient(pb.multiprec.Complex('0.6', '0.8')))
+    _all_functions_are_nodes(H)               # a BlendBlock row expands recursively
+
+
+def test_function_matches_eval_for_slice_system():
+    # the node returned by function(i) must evaluate to the same value as the block.
+    x, y = pb.Variable('x'), pb.Variable('y')
+    sys = linalg.slice_from_coefficients([[2, 3, 1], [1, -1, 4]], [x, y]).as_system()
+    one = pb.multiprec.Complex('1')
+    pt = np.array([one, one], dtype=pb.multiprec.Complex)
+    from_block = sys.eval(pt)                  # System eval: a vector in variable order
+    for i in range(sys.num_functions()):
+        node_val = sys.function(i).eval(x=one, y=one)   # node eval: variable values by keyword
+        assert abs(complex(node_val) - complex(from_block[i])) < 1e-12
+
+
+# ---- slices(): back out the slice structure -------------------------------------------------
+
+def test_slices_empty_for_polynomial_system():
+    x, y = pb.Variable('x'), pb.Variable('y')
+    s = pb.System(); s.add_variable_group(_vg(x, y)); s.add_function(x * x - y)
+    assert s.slices() == []
+
+
+def test_slices_roundtrips_coefficients():
+    x, y = pb.Variable('x'), pb.Variable('y')
+    s = linalg.slice_from_coefficients([[2, 3, 1], [1, -1, 4]], [x, y])
+    recovered = s.as_system().slices()
+    assert len(recovered) == 1
+    orig = np.asarray(s.coefficients())
+    back = np.asarray(recovered[0].coefficients())
+    assert back.shape == orig.shape
+    assert all(abs(complex(orig[i, j]) - complex(back[i, j])) < 1e-25
+               for i in range(orig.shape[0]) for j in range(orig.shape[1]))
+
+
+def test_slices_one_per_linear_forms_block():
+    # a system that mixes a polynomial row and a linear-forms block exposes exactly one slice.
+    x, y = pb.Variable('x'), pb.Variable('y')
+    m = pb.System(); m.add_variable_group(_vg(x, y))
+    m.add_function(x * x + y * y - 1)
+    linalg.add_linear(m, np.array([[2, 1]]), np.array([x, y]), [-1])   # 2x + y - 1
+    slices = m.slices()
+    assert len(slices) == 1
+    assert slices[0].dimension() == 1

--- a/python_bindings/src/system_export.cpp
+++ b/python_bindings/src/system_export.cpp
@@ -40,6 +40,7 @@
 #include <boost/archive/text_oarchive.hpp>
 #include <boost/archive/text_iarchive.hpp>
 #include "system_export.hpp"
+#include <bertini2/system/slice.hpp>   // for System::Slices() -> list of Slice
 #include <bertini2/io/classic_writer.hpp>
 
 
@@ -158,6 +159,15 @@ namespace bertini{
 				},
 				(arg("self"), arg("num_vars"), arg("factors")),
 				"Add a block of products-of-linear-forms f_i(x) = prod_r ( c_{i,r} . [x;1] ) to the System, evaluated as matrix-multiplies-then-row-products rather than as scalar expressions.  factors is a list with one entry per function; entry i is an complex_mp matrix with one row per linear factor and num_vars+1 columns (the trailing column carries each factor's constant term).  Each function's degree is its number of factors.")
+			.def("slices",
+				+[](SystemBaseT const& self) {
+					boost::python::list out;
+					for (auto const& s : self.Slices())
+						out.append(s);
+					return out;
+				},
+				(arg("self")),
+				"The linear-form slices embedded in this system, one per linear-forms block (an empty list if none).  Lets you back out the slice structure of a system that was built from a slice -- the inverse of Slice.as_system().")
 			// .def("add_ungrouped_variable", &SystemBaseT::AddUngroupedVariable,"Add an ungrouped variable to the system.  I honestly don't know why you'd do that.  This should be removed, and is a holdover from Bertini 1")
 			// .def("add_ungrouped_variables", &SystemBaseT::AddUngroupedVariables,"Add some ungrouped variables to the system.  I honestly don't know why you'd do that.  This should be removed, and is a holdover from Bertini 1")
 			// .def("add_implicit_parameter", &SystemBaseT::AddImplicitParameter)


### PR DESCRIPTION
Fixes the segfault reported in bertiniteam/b2#263.

## Problem
`sys.function(0)` segfaulted on a system built from a slice:
```python
s = Slice.random_complex(vars, 1)
sys = s.as_system()
sys.function(0)   # <- segfault
```
A slice is a pure `LinearFormsBlock` — `as_system()` never creates a `PolynomialBlock`. `System::Function(index)` dereferenced `PolyBlockPtr()` (null) with no check. Related: `GetNaturalFunctions()` returned `{}` for such systems while `NumNaturalFunctions()` counted the real rows.

## Fix
- `Function(index)` and `GetNaturalFunctions()` now route through `NaturalFunctionsAsNodes()`, which expands **every** block type (polynomial, linear forms, products of linears, randomization, blend) to a function-tree node on demand. Returns are in sync with `NumNaturalFunctions()`; out-of-range throws `std::out_of_range` (→ Python `IndexError`) instead of crashing.
- New `System::Slices()` (bound as `system.slices()`) backs out the linear-form slices embedded in a system — the inverse of `Slice.as_system()` — without exposing the `Block` variant to Python.

## Decision
`function(i)` returns a **function-tree node** (consistent with every other system type), not a `Slice`. Use `system.slices()` to recover slice structure.

## Tests
- `python/test/classes/function_accessor_test.py`: `function(i)` across all five block types, out-of-range raises, node/block eval agreement, and `slices()` round-trip.
- C++ `system_blocks_suite`: structured-block `Function()`/`Slices()` cases.
- Full Python suite green (536 passed, 4 skipped); C++ `test_classes` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)