### PR TITLE
feat: show low-precision coefficients in system describe (bertiniteam/b2#264)

### DIFF
--- a/core/include/bertini2/system/blocks/describe.hpp
+++ b/core/include/bertini2/system/blocks/describe.hpp
@@ -37,15 +37,35 @@ namespace bertini {
 namespace blocks {
 namespace describe_detail {
 
+/// How many function rows a block lists in *terse* (non-verbose) describe before truncating with a
+/// `... (k more ...)` line.  Keeps a large system (e.g. a slice with many forms) from flooding the
+/// terminal now that the terse output carries actual coefficients; verbose prints every row.
+inline constexpr size_t kTerseRowCap = 10;
+
+/// Format one multiprecision real part.  `sig > 0` renders that many significant digits (the terse
+/// default -- short and legible); `sig <= 0` renders full precision (verbose / round-trippable).
+template <typename R>
+inline std::string FmtReal(R const& r, int sig)
+{
+	return (sig > 0) ? r.str(sig) : r.str();
+}
+
 /// Print one (complex_mp) coefficient compactly: a real prints as its real part, a pure imaginary
-/// as `b*i`, otherwise as `(a+b*i)`.
-inline void PrintCoeff(std::ostream& out, complex_mp const& c)
+/// as `b*i`, otherwise as `(a+b*i)`.  `sig` controls the digit count (see FmtReal); the default of
+/// 0 keeps full precision for any caller that does not opt into the short form.
+inline void PrintCoeff(std::ostream& out, complex_mp const& c, int sig = 0)
 {
 	const bool re0 = (c.real() == 0), im0 = (c.imag() == 0);
-	if (im0)            out << c.real();
-	else if (re0)       out << c.imag() << "*i";
-	else                out << "(" << c.real() << "+" << c.imag() << "*i)";
+	if (im0)            out << FmtReal(c.real(), sig);
+	else if (re0)       out << FmtReal(c.imag(), sig) << "*i";
+	else                out << "(" << FmtReal(c.real(), sig) << "+" << FmtReal(c.imag(), sig) << "*i)";
 }
+
+/// The significant-digit count for coefficient printing: 4 for terse (short and legible), the
+/// current working precision for verbose (every digit the system actually carries -- the master
+/// coefficient matrix is stored at a much higher precision than that, so printing its full string
+/// would dump thousands of digits).
+inline int CoeffSig(bool verbose) { return verbose ? static_cast<int>(DefaultPrecision()) : 4; }
 
 /// `f_k` for a single row, or `f_a..f_b` for a contiguous range of `n` rows starting at `row`.
 inline void PrintRowLabel(std::ostream& out, size_t row, size_t n)

--- a/core/include/bertini2/system/blocks/linear_forms_block.hpp
+++ b/core/include/bertini2/system/blocks/linear_forms_block.hpp
@@ -127,21 +127,46 @@ public:
 	/// Whether Homogenize has folded the constant column onto a homogenizing variable.
 	bool IsHomogenized() const { return homogeneous_; }
 
-	/// Human-facing description: terse shows the placeholder `c.[x, y, 1]` (a linear form whose
-	/// coefficients are hidden); verbose shows the actual affine combination `2*x + 1*y - 1`.
+	/// Human-facing description: each form prints as the placeholder `f_k = c.[x, y, 1]` (structure
+	/// stays legible) followed by its actual coefficient row in a `c =` legend below -- short (4
+	/// significant figures) in terse, full precision in verbose.  Terse truncates after kTerseRowCap
+	/// forms so a large slice does not flood the terminal.
 	void Describe(std::ostream& out, size_t& row, VariableGroup const& vars, bool verbose) const
 	{
-		for (Eigen::Index r = 0; r < coefficients_highest_precision_.rows(); ++r)
+		auto const& M = coefficients_highest_precision_;
+		const Eigen::Index n = M.rows();
+		if (n == 0)
+			return;
+		const Eigen::Index cap   = static_cast<Eigen::Index>(describe_detail::kTerseRowCap);
+		const Eigen::Index shown = (verbose || n <= cap) ? n : cap;
+
+		// placeholder line per form: f_k = c.[x, y, 1]
+		for (Eigen::Index r = 0; r < shown; ++r)
 		{
-			out << "  f_" << row++ << " = ";
-			if (verbose)
-				describe_detail::PrintLinearFormVerbose(out, coefficients_highest_precision_, r, vars, num_vars_, homogeneous_);
-			else
-			{
-				out << "c.";
-				describe_detail::PrintAugmentedVars(out, vars, num_vars_, homogeneous_);
-			}
+			out << "  f_" << row++ << " = c.";
+			describe_detail::PrintAugmentedVars(out, vars, num_vars_, homogeneous_);
 			out << "\n";
+		}
+
+		// the actual coefficients below, as a named-expression-style legend (row r <-> f_k above)
+		const int sig = describe_detail::CoeffSig(verbose);
+		out << "    c =\n";
+		for (Eigen::Index r = 0; r < shown; ++r)
+		{
+			out << "      [ ";
+			for (Eigen::Index c = 0; c < M.cols(); ++c)
+			{
+				if (c) out << ", ";
+				describe_detail::PrintCoeff(out, M(r, c), sig);
+			}
+			out << " ]\n";
+		}
+
+		if (shown < n)
+		{
+			row += static_cast<size_t>(n - shown);     // keep the global row index correct
+			out << "    ... (" << (n - shown) << " more form" << (n - shown == 1 ? "" : "s")
+			    << "; describe(verbose=True) for all)\n";
 		}
 	}
 

--- a/core/include/bertini2/system/blocks/randomization_block.hpp
+++ b/core/include/bertini2/system/blocks/randomization_block.hpp
@@ -239,23 +239,36 @@ public:
 		describe_detail::PrintRowLabel(out, row, n);
 		out << " = R . g   (R: " << n << "x" << N << " randomization matrix)\n";
 		row += n;
+
+		const size_t cap = describe_detail::kTerseRowCap;
+
 		auto g = operand_->NaturalFunctionsAsNodes();
-		for (size_t j = 0; j < g.size(); ++j)
+		const size_t gshown = (verbose || g.size() <= cap) ? g.size() : cap;
+		for (size_t j = 0; j < gshown; ++j)
 			out << "      g_" << j << " = " << g[j] << "\n";
-		if (verbose)
+		if (gshown < g.size())
+			out << "      ... (" << (g.size() - gshown) << " more; describe(verbose=True) for all)\n";
+
+		// the actual randomization matrix below -- 4 significant figures in terse (the default),
+		// full precision in verbose.  Shown always (not gated behind verbose) so the numbers a
+		// randomize() produced are visible at a glance.
+		auto const& R   = coefficients_highest_precision_;
+		const int   sig = describe_detail::CoeffSig(verbose);
+		const Eigen::Index rcap   = static_cast<Eigen::Index>(cap);
+		const Eigen::Index rshown = (verbose || R.rows() <= rcap) ? R.rows() : rcap;
+		out << "    R =\n";
+		for (Eigen::Index i = 0; i < rshown; ++i)
 		{
-			out << "    R =\n";
-			for (Eigen::Index i = 0; i < coefficients_highest_precision_.rows(); ++i)
+			out << "      [ ";
+			for (Eigen::Index j = 0; j < R.cols(); ++j)
 			{
-				out << "      [ ";
-				for (Eigen::Index j = 0; j < coefficients_highest_precision_.cols(); ++j)
-				{
-					if (j) out << ", ";
-					describe_detail::PrintCoeff(out, coefficients_highest_precision_(i, j));
-				}
-				out << " ]\n";
+				if (j) out << ", ";
+				describe_detail::PrintCoeff(out, R(i, j), sig);
 			}
+			out << " ]\n";
 		}
+		if (rshown < R.rows())
+			out << "      ... (" << (R.rows() - rshown) << " more rows; describe(verbose=True) for all)\n";
 	}
 
 	unsigned Precision() const { return precision_; }

--- a/core/test/classes/system_printing_test.cpp
+++ b/core/test/classes/system_printing_test.cpp
@@ -76,11 +76,11 @@ BOOST_AUTO_TEST_CASE(randomization_placeholder_and_underlying)
 	BOOST_CHECK(Has(t, "(R: 2x3 randomization matrix)"));
 	BOOST_CHECK(Has(t, "g_0 = "));
 	BOOST_CHECK(Has(t, "g_2 = "));
-	BOOST_CHECK(!Has(t, "R =\n"));               // the matrix is not in the terse form
+	BOOST_CHECK(Has(t, "R ="));                  // the matrix is shown by default now
 	NoNoise(t);
 
 	std::string v = Verbose(r);
-	BOOST_CHECK(Has(v, "R ="));                  // ... but it is in verbose
+	BOOST_CHECK(Has(v, "R ="));                  // ... and in verbose too (full precision)
 }
 
 BOOST_AUTO_TEST_CASE(linear_forms_placeholder_vs_actual)
@@ -94,10 +94,12 @@ BOOST_AUTO_TEST_CASE(linear_forms_placeholder_vs_actual)
 
 	std::string t = Terse(m);
 	BOOST_CHECK(Has(t, "f_0 = "));
-	BOOST_CHECK(Has(t, "f_1 = c.[x, y, 1]"));    // both rows visible; structured row is a placeholder
+	BOOST_CHECK(Has(t, "f_1 = c.[x, y, 1]"));    // both rows visible; structured row keeps its placeholder
+	BOOST_CHECK(Has(t, "c ="));                  // ... with the coefficient legend below it
+	BOOST_CHECK(Has(t, "2") && Has(t, "-1"));    // the actual coefficient values (exact integers here)
 
 	std::string v = Verbose(m);
-	BOOST_CHECK(Has(v, "*x") && Has(v, "*y"));   // actual coefficients shown
+	BOOST_CHECK(Has(v, "c.[x, y, 1]") && Has(v, "c ="));   // same layout, full precision
 }
 
 BOOST_AUTO_TEST_CASE(moving_homotopy_blend)

--- a/python/test/classes/system_printing_test.py
+++ b/python/test/classes/system_printing_test.py
@@ -1,10 +1,12 @@
 """Human-facing printing of block-composed systems.
 
-print(system) / str(system) describes the system block by block, with placeholder symbols for the
-structured blocks' coefficients (terse, the default) or the actual numbers and underlying functions
-(system.describe(verbose=True)).  The old debugging leftovers -- the working-vector dump, the
-differentiated flag, the 'unnamed_function' names -- are gone, and structured-block rows are no
-longer invisible.
+print(system) / str(system) describes the system block by block.  A structured block keeps its
+placeholder symbol for legibility (a linear form prints as ``c.[x, y, 1]``, a randomization as
+``R . g``) and shows the actual coefficients just below it -- short (4 significant figures) in the
+default/terse form, full working precision with system.describe(verbose=True).  Terse truncates a
+block's listing after the first several rows so a large system does not flood the terminal.  The old
+debugging leftovers -- the working-vector dump, the differentiated flag, the 'unnamed_function'
+names -- are gone, and structured-block rows are no longer invisible.
 """
 
 import numpy as np
@@ -40,21 +42,21 @@ def test_randomization_shows_placeholder_and_underlying_functions():
     r = linalg.randomize(o)
 
     terse = str(r)
-    assert 'R . g' in terse                       # placeholder, not the matrix
+    assert 'R . g' in terse                       # placeholder label
     assert '(R: 2x3 randomization matrix)' in terse
     assert 'g_0 = x*x+y*y-1' in terse              # the underlying functions, indented and shown
     assert 'g_1 = x*y' in terse
     assert 'g_2 = x*x+y*y-x-y' in terse
-    assert 'R =' not in terse                      # the actual matrix is NOT in the terse form
+    assert 'R =' in terse                          # the actual matrix is shown by default now
+    assert terse.count('[') >= 2                   # its two rows
 
     verbose = r.describe(verbose=True)
-    assert 'R =' in verbose                        # ... but it is in verbose
-    assert verbose.count('[') >= 2                 # the two matrix rows
+    assert 'R =' in verbose                        # same layout, full precision
     for n in NOISE:
         assert n not in verbose
 
 
-def test_linear_forms_block_placeholder_vs_actual():
+def test_linear_forms_block_placeholder_and_coefficients():
     x, y = pb.Variable('x'), pb.Variable('y')
     m = pb.System(); m.add_variable_group(_vg(x, y))
     m.add_function(x*x + y*y - 1)
@@ -62,10 +64,40 @@ def test_linear_forms_block_placeholder_vs_actual():
 
     terse = str(m)
     assert 'f_0 = x*x+y*y-1' in terse              # poly row
-    assert 'f_1 = c.[x, y, 1]' in terse            # linear-forms row: placeholder, both rows visible
+    assert 'f_1 = c.[x, y, 1]' in terse            # linear-forms placeholder kept (legible structure)
+    assert 'c =' in terse                          # ... with the coefficients in a legend below
+    assert '2' in terse and '-1' in terse          # the actual values (here exact integers)
 
     verbose = m.describe(verbose=True)
-    assert '(2)*x' in verbose and '(1)*y' in verbose and '(-1)' in verbose   # actual coefficients
+    assert 'c.[x, y, 1]' in verbose and 'c =' in verbose   # same layout, full precision
+    assert '2' in verbose
+
+
+def test_linear_form_coefficients_short_in_terse_full_in_verbose():
+    import re
+    x, y, z = pb.Variable('x'), pb.Variable('y'), pb.Variable('z')
+    s = na.Slice.random_complex(_vg(x, y, z), 1).as_system()   # irrational random coefficients
+
+    terse, verbose = s.describe(), s.describe(verbose=True)
+    assert 'c.[x, y, z, 1]' in terse and 'c =' in terse
+
+    def longest_decimal(text):
+        return max((len(t) for t in re.findall(r'\d+\.\d+', text)), default=0)
+
+    assert longest_decimal(terse) <= 8             # ~4 significant figures, e.g. 0.3163 / 0.04692
+    assert longest_decimal(verbose) >= 12          # full working precision (~30 digits)
+
+
+def test_terse_truncates_many_forms_but_verbose_shows_all():
+    x, y = pb.Variable('x'), pb.Variable('y')
+    coeffs = [[i + 1, i + 2, i + 3] for i in range(12)]        # 12 affine forms on (x, y), > the cap of 10
+    s = linalg.slice_from_coefficients(coeffs, [x, y]).as_system()
+
+    terse, verbose = s.describe(), s.describe(verbose=True)
+    assert terse.count('c.[') == 10                # capped at kTerseRowCap
+    assert 'more form' in terse                    # with a truncation note
+    assert verbose.count('c.[') == 12              # verbose shows every form
+    assert 'more form' not in verbose
 
 
 def test_products_of_linears_block():


### PR DESCRIPTION
Fixes bertiniteam/b2#264.

## Problem
A system built from a slice printed every function as the opaque placeholder, hiding the coefficients:
```
1 function:
  f_0 = c.[x, y, z, 1]
```

## Fix
Keep the placeholder (the structure stays legible) and print the actual coefficient matrix just below it as a named-expression-style `c =` legend — **4 significant figures** in the default/terse describe, **full working precision** under `describe(verbose=True)`:
```
1 function:
  f_0 = c.[x, y, z, 1]
    c =
      [ (-0.3557+-0.4101*i), (-0.04314+-0.5304*i), (-0.5177+-0.3925*i), (0.7577+0.5555*i) ]
```
The same treatment applies to a **randomization block's `R` matrix**, which was previously gated behind `verbose` — it now shows in the default describe too.

## Notes
- `PrintCoeff` gains a significant-digits parameter (terse = 4; verbose = current working precision — the master coefficient matrix is stored far above working precision, so its full string would be thousands of digits).
- Each structured block truncates its terse listing after **10 rows** (`... (k more; describe(verbose=True) for all)`) so a large slice doesn't flood the terminal; verbose prints everything.
- products-of-linears and blend keep their existing structural terse output (no inline coefficients to shorten). Happy to extend products-of-linears the same way if wanted.

## Tests
- `system_printing_test` (Python + C++) updated for the new default output; extended with terse-vs-verbose digit-width and row-cap-truncation cases.
- Full Python suite green (529 passed, 4 skipped); C++ `test_classes` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)