### PR TITLE
fix(docs): moving_slice eval_time_derivative doctest precision mismatch

### DIFF
--- a/python/docs/source/tutorials/moving_slice.rst
+++ b/python/docs/source/tutorials/moving_slice.rst
@@ -107,10 +107,13 @@ never differentiated as the slice moves -- while only the moving row is nonzero:
 
 .. testcode::
 
-    dHdt = H.eval_time_derivative(np.array([bertini.multiprec.Complex('0.3'),
-                                            bertini.multiprec.Complex('0.4'),
-                                            bertini.multiprec.Complex('0.5')]),
-                                  bertini.multiprec.Complex('0.5'))
+    pt = np.array([bertini.multiprec.Complex('0.3'),
+                   bertini.multiprec.Complex('0.4'),
+                   bertini.multiprec.Complex('0.5')])
+    # the adaptive solve above left H at double precision; match it to the evaluation point's
+    # precision before evaluating the homotopy directly.
+    H.precision(pt[0].precision)
+    dHdt = H.eval_time_derivative(pt, bertini.multiprec.Complex('0.5'))
     assert abs(complex(dHdt[0])) == 0.0      # sphere row: out of dH/dt
     assert abs(complex(dHdt[1])) == 0.0      # static slice row: out of dH/dt
     assert abs(complex(dHdt[2])) > 0.0       # only the moving slice carries t


### PR DESCRIPTION
## What

The `H.eval_time_derivative(...)` block in `tutorials/moving_slice.rst` fails under `sphinx -b doctest`:

```
RuntimeError: precision of input point in SetVariables (20) must match the precision of the system (16).
```

The preceding adaptive `solver.solve()` leaves the homotopy `H` at double precision (16), while the multiprecision evaluation point (`bertini.multiprec.Complex('0.3')`, …) is created at the multiprec literal default (20). The direct evaluation then mismatches.

## Fix

Match `H` to the evaluation point's precision (`H.precision(pt[0].precision)`) before the direct eval. Minimal, tutorial-local.

> Note: `bertini.default_precision()` is **not** the right value here — the AMP solve leaves the *global default* at 16, which disagrees with the *multiprec literal default* of 20. That `default_precision()` ≠ multiprec-literal-default inconsistency (and the solve leaving the global default at 16) is a latent precision-state quirk worth a separate look, but out of scope for this doctest fix.

## How found

Running the full tutorial doctest suite locally (`sphinx-build -b doctest`). This suite is **not** in the per-push PR `build_and_test` CI — only the dispatched `build_docs` workflow runs it — so this had been latent on develop. After the fix: **147 tests, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)