### PR TITLE
Fix parallel (MPI) multihomogeneous solve serialization; refresh #253 scaling tables; restore % comment parsing

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -207,6 +207,11 @@ jobs:
       # on each OS we support -- and, crucially, that it gives the SAME answer as the serial solve.
       # The blackbox CLI reads a file named `input` from the cwd and writes the solution count as
       # the first line of `main_data`.  mpirun -n 2 = one manager + one worker (the minimal pool).
+      #
+      # Run BOTH start-system families, because DistributeSystems broadcasts the start system to the
+      # workers and a dropped serialized member is invisible until that exact start system is sent.
+      # small.b2 (one affine group) infers total-degree; small_mhom.b2 (two groups) infers the
+      # multihomogeneous start system -- whose serialize() was once incomplete, crashing every worker.
       - name: MPI smoke test (CLI under mpirun)
         working-directory: build/core
         env:
@@ -214,14 +219,16 @@ jobs:
           DYLD_LIBRARY_PATH: /tmp/boost-base/lib
         run: |
           set -e
-          cp "$GITHUB_WORKSPACE/benchmark/inputs/small.b2" input
-          ./bertini2 >/dev/null 2>&1
-          serial=$(head -n1 main_data); rm -f main_data
-          mpirun -n 2 --bind-to none ./bertini2 >/dev/null 2>&1
-          parallel=$(head -n1 main_data)
-          echo "solution count: serial=$serial  mpi(-n 2)=$parallel"
-          test -n "$serial"
-          test "$serial" = "$parallel"   # MPI must match serial, not merely run
+          for case in small small_mhom; do
+            cp "$GITHUB_WORKSPACE/benchmark/inputs/${case}.b2" input
+            ./bertini2 >/dev/null 2>&1
+            serial=$(head -n1 main_data); rm -f main_data
+            mpirun -n 2 --bind-to none ./bertini2 >/dev/null 2>&1
+            parallel=$(head -n1 main_data); rm -f main_data
+            echo "${case}: solution count serial=$serial  mpi(-n 2)=$parallel"
+            test -n "$serial"
+            test "$serial" = "$parallel"   # MPI must match serial, not merely run
+          done
 
   test_cpp_windows:
     name: C++ tests on Windows

--- a/benchmark/inputs/small_mhom.b2
+++ b/benchmark/inputs/small_mhom.b2
@@ -1,0 +1,16 @@
+CONFIG
+
+tracktype: 0;
+
+END;
+
+INPUT
+
+variable_group x;
+variable_group y;
+function f1, f2;
+
+f1 = x*y - 1;
+f2 = x + y - 3;
+
+END;

--- a/benchmark/inputs/small_mhom.b2
+++ b/benchmark/inputs/small_mhom.b2
@@ -6,11 +6,15 @@ END;
 
 INPUT
 
+% Two variable groups => classic Bertini infers the multihomogeneous start system
+% (blackbox::InferStartType).  Exercises the mhom start-system MPI broadcast path that
+% the total-degree small.b2 input does not.  The % comments here also keep the classic
+% parser's comment-stripping (Bertini 1 compatibility) honest under mpirun in CI.
 variable_group x;
 variable_group y;
 function f1, f2;
 
-f1 = x*y - 1;
+f1 = x*y - 1;   % a comment trailing a real declaration line
 f2 = x + y - 3;
 
 END;

--- a/core/include/bertini2/io/parsing/classic_utilities.hpp
+++ b/core/include/bertini2/io/parsing/classic_utilities.hpp
@@ -396,14 +396,12 @@ namespace bertini {
 			 */
 			std::tuple<std::string, std::string> SplitIntoConfigAndInput(Path const& input_file)
 			{
-				auto file_as_string = FileToString(input_file);
-				
-				SplitInputFileParser<std::string::const_iterator> parser;
-				SplitInputFile config_and_input;
-				std::string::const_iterator iter = file_as_string.begin();
-				std::string::const_iterator end = file_as_string.end();
-				phrase_parse(iter, end, parser, boost::spirit::ascii::space, config_and_input);
-
+				// Route through ParseInputFile, which runs the CommentStripper pass BEFORE splitting.
+				// Bertini 1 uses '%' as its comment marker; calling the raw SplitInputFileParser here --
+				// as this used to -- left '%' comments in the text, and the downstream system/settings
+				// parsers then choked ("parser did not consume entire input").  A classic input file
+				// with comments must parse, for backwards compatibility.
+				auto config_and_input = ParseInputFile(FileToString(input_file));
 				return std::make_tuple(config_and_input.Config(), config_and_input.Input());
 			}
 

--- a/core/include/bertini2/system/start/mhom.hpp
+++ b/core/include/bertini2/system/start/mhom.hpp
@@ -124,7 +124,6 @@ namespace bertini
 			
 
 			
-			std::vector<unsigned long long> degrees_; ///< stores the degrees of the functions.
 			std::vector< VariableGroup > var_groups_;
 			/// Random linear-factor coefficients, one matrix per (function, variable group).
 			/// Entry (i,j) is a (degree_matrix_(i,j)) x (group_j_size + 1) matrix: each row is
@@ -141,10 +140,22 @@ namespace bertini
 			friend class boost::serialization::access;
 
 			template <typename Archive>
-			void serialize(Archive& ar, const unsigned /*version*/) 
+			void serialize(Archive& ar, const unsigned /*version*/)
 			{
+				// Serialize ALL persistent state.  This object is broadcast to MPI workers via
+				// ZeroDimSolver::DistributeSystems (a polymorphic shared_ptr<StartSystem> archive);
+				// dropping any member leaves a worker with a hollow start system whose
+				// NumStartPoints() returns 0, sizing the per-path metadata to nothing and crashing
+				// the parallel solve.  Order base-first so Boost object tracking re-links the
+				// var_groups_ shared_ptr<Variable> entries to the same Variable nodes serialized in
+				// the base System (variable_groups_/hom_variable_groups_), preserving node identity.
 				ar & boost::serialization::base_object<StartSystem>(*this);
-				ar & degrees_;
+				ar & degree_matrix_;
+				ar & valid_partitions_;
+				ar & var_groups_;
+				ar & linear_coeffs_;   // random factor coefficients: PRIMARY data, not recomputable
+				ar & variable_cols_;
+				ar & num_hom_groups_;
 			}
 
 		};

--- a/core/test/classes/m_hom_start_system.cpp
+++ b/core/test/classes/m_hom_start_system.cpp
@@ -27,8 +27,13 @@
 #include "bertini2/system/start_systems.hpp"
 #include "bertini2/system/blocks/block.hpp"
 #include "bertini2/system/blocks/blend_block.hpp"
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/archive/text_iarchive.hpp>
+#include <algorithm>
 #include <iostream>
 #include <iomanip>
+#include <memory>
+#include <sstream>
 
 using System = bertini::System;
 
@@ -636,6 +641,109 @@ BOOST_AUTO_TEST_CASE(variable_in_many_variable_groups_in_mhom_construction)
 
 	BOOST_CHECK_THROW(auto mhom_start_system = bertini::start_system::MHomogeneous(sys), std::runtime_error);
 
+}
+
+
+// --- serialization round-trip --------------------------------------------------------------
+//
+// Regression guard for the parallel-solve crash: ZeroDimSolver::DistributeSystems broadcasts the
+// owning shared_ptr<StartSystem> to MPI workers through a polymorphic boost archive.  If a derived
+// start system's serialize() drops a member, a worker deserializes a hollow object whose
+// NumStartPoints() is wrong, the per-path metadata sizes to nothing, and the solve segfaults.
+// MHomogeneous::serialize() used to persist only a vestigial degrees_ member, so this was silently
+// broken for the m-homogeneous start system (binomial/linear-product happened to be complete).
+//
+// Round-trip through the BASE pointer so we exercise exactly the path DistributeSystems uses, and
+// drive every generated start system through one helper so a future omission is caught everywhere.
+
+using bertini::start_system::StartSystem;
+
+static std::shared_ptr<StartSystem> RoundTripStart(std::shared_ptr<StartSystem> const& ss)
+{
+	std::stringstream buf;
+	{
+		boost::archive::text_oarchive oa(buf);
+		oa << ss;                         // serialized polymorphically as shared_ptr<StartSystem>
+	}
+	std::shared_ptr<StartSystem> out;
+	{
+		boost::archive::text_iarchive ia(buf);
+		ia >> out;
+	}
+	return out;
+}
+
+static void CheckStartRoundTrip(std::shared_ptr<StartSystem> const& orig)
+{
+	auto copy = RoundTripStart(orig);
+	BOOST_REQUIRE(copy);
+
+	// NumStartPoints() was the exact quantity that came back as 0 on a worker before the fix.
+	BOOST_CHECK_EQUAL(copy->NumStartPoints(), orig->NumStartPoints());
+	BOOST_REQUIRE(orig->NumStartPoints() > 0ull);
+
+	const auto n = std::min<unsigned long long>(orig->NumStartPoints(), 8ull);
+	for (unsigned long long i = 0; i < n; ++i)
+	{
+		auto a = orig->StartPoint<complex_dbl>(i);
+		auto b = copy->StartPoint<complex_dbl>(i);
+		BOOST_REQUIRE_EQUAL(a.size(), b.size());
+		for (Eigen::Index k = 0; k < a.size(); ++k)
+		{
+			BOOST_CHECK_CLOSE(a(k).real(), b(k).real(), 1e-10);
+			BOOST_CHECK_CLOSE(a(k).imag(), b(k).imag(), 1e-10);
+		}
+	}
+}
+
+BOOST_AUTO_TEST_CASE(mhomogeneous_survives_serialization_round_trip)
+{
+	DefaultPrecision(30);
+	bertini::SetGlobalSeed(1u);
+
+	System sys;
+	auto x  = Variable::Make("x");
+	auto y  = Variable::Make("y");
+	auto x1 = Variable::Make("x1");
+	auto y1 = Variable::Make("y1");
+	// size-2 hom groups (each P^1, dimension 1) so the target is square; see the small-example
+	// construction test above.
+	sys.AddHomVariableGroup(VariableGroup{x, x1});
+	sys.AddHomVariableGroup(VariableGroup{y, y1});
+	sys.AddFunction(x*y);
+	sys.AddFunction(pow(x,2)*pow(y,2));
+
+	CheckStartRoundTrip(std::make_shared<bertini::start_system::MHomogeneous>(sys));
+}
+
+BOOST_AUTO_TEST_CASE(total_degree_binomial_survives_serialization_round_trip)
+{
+	DefaultPrecision(30);
+	bertini::SetGlobalSeed(1u);
+
+	System sys;
+	auto x = Variable::Make("x");
+	auto y = Variable::Make("y");
+	sys.AddVariableGroup(VariableGroup{x, y});
+	sys.AddFunction(x*y + y - 1);
+	sys.AddFunction(x*x - real_mp("0.5")*y - x*y);
+
+	CheckStartRoundTrip(std::make_shared<bertini::start_system::TotalDegreeBinomial>(sys));
+}
+
+BOOST_AUTO_TEST_CASE(total_degree_linear_product_survives_serialization_round_trip)
+{
+	DefaultPrecision(30);
+	bertini::SetGlobalSeed(1u);
+
+	System sys;
+	auto x = Variable::Make("x");
+	auto y = Variable::Make("y");
+	sys.AddVariableGroup(VariableGroup{x, y});
+	sys.AddFunction(x*y + y - 1);
+	sys.AddFunction(x*x - real_mp("0.5")*y - x*y);
+
+	CheckStartRoundTrip(std::make_shared<bertini::start_system::TotalDegreeLinearProduct>(sys));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/core/test/classic/classic_parsing_test.cpp
+++ b/core/test/classic/classic_parsing_test.cpp
@@ -30,6 +30,8 @@
 #include <bertini2/io/parsing/system_parsers.hpp>
 #include <bertini2/io/classic_writer.hpp>
 #include <string>
+#include <fstream>
+#include <boost/filesystem.hpp>
 #include <boost/test/unit_test.hpp>
 
 
@@ -644,6 +646,54 @@ BOOST_AUTO_TEST_CASE(classic_writer_round_trips_a_system)
 	BOOST_REQUIRE_EQUAL(a.size(), b.size());
 	for (Eigen::Index i = 0; i < a.size(); ++i)
 		BOOST_CHECK_SMALL(abs(a(i) - b(i)), 1e-12);
+}
+
+
+// Regression: a classic input FILE with '%' comments must parse.  The blackbox reads files via
+// the Path overload of SplitIntoConfigAndInput, which used to split the raw text WITHOUT running
+// the CommentStripper first -- so a '%' comment (Bertini 1's comment marker) survived into the
+// input section and the system parser choked ("did not consume entire input").  Comments appear
+// here both on their own line and trailing real declarations, in both CONFIG and INPUT.
+BOOST_AUTO_TEST_CASE(file_with_percent_comments_parses)
+{
+	namespace fs = boost::filesystem;
+	auto path = fs::temp_directory_path() / fs::unique_path("b2_comment_%%%%-%%%%.b2");
+
+	{
+		std::ofstream out(path.string());
+		out <<
+			"CONFIG\n"
+			"% a full-line comment in config\n"
+			"tracktype: 0;   % trailing comment after a real setting\n"
+			"END;\n"
+			"INPUT\n"
+			"% two groups => multihomogeneous; this comment must be stripped\n"
+			"variable_group x;\n"
+			"variable_group y;   % trailing comment on a declaration\n"
+			"function f1, f2;\n"
+			"f1 = x*y - 1;\n"
+			"f2 = x + y - 3;   % and another\n"
+			"END;\n";
+	}
+
+	std::string config, input;
+	bertini::parsing::classic::SplitIntoConfigAndInput(config, input, path);
+	fs::remove(path);
+
+	// the '%' comment text is gone from both sections...
+	BOOST_CHECK(config.find('%') == std::string::npos);
+	BOOST_CHECK(input.find('%')  == std::string::npos);
+	// ...while the real declarations survive...
+	BOOST_CHECK(input.find("variable_group x;") != std::string::npos);
+	BOOST_CHECK(input.find("f1 = x*y - 1;")     != std::string::npos);
+
+	// ...and the system parser actually consumes the comment-free input.
+	bertini::System sys;
+	auto iter = input.begin();
+	auto end  = input.end();
+	bertini::parsing::classic::parse(iter, end, sys);
+	BOOST_CHECK_EQUAL(sys.NumNaturalFunctions(), 2u);
+	BOOST_CHECK_EQUAL(sys.NumVariables(), 2u);
 }
 
 

--- a/python/docs/source/tutorials/solving_at_scale.rst
+++ b/python/docs/source/tutorials/solving_at_scale.rst
@@ -19,10 +19,11 @@ scheduler in opposite ways, and the same manager-worker pool handles both.
 
 .. note::
 
-   The timing tables below were **measured on an 8-core machine**.  Your numbers will differ; the
-   *shape* (speedup grows with workers, then flattens once the single slowest path dominates the
-   wall) is the point.  Run ``tools/update_scaling_timings.py`` to repopulate every table for your
-   own hardware -- it pins a fixed seed so every layout solves the identical problem.
+   The timing tables below were **measured on a 16-core Apple M3 Max** (12 performance + 4
+   efficiency cores).  Your numbers will differ; the *shape* (speedup grows with workers, then
+   flattens once the single slowest path dominates the wall) is the point.  Run
+   ``tools/update_scaling_timings.py`` to repopulate every table for your own hardware -- it pins
+   a fixed seed so every layout solves the identical problem.
 
 The manager-worker model
 ========================
@@ -143,10 +144,11 @@ Run the ladder (serial, then 2, 4, 8 workers):
     $ mpirun -n 3 python python/examples/solve_cyclic.py --n 6  # 2 workers
     $ mpirun -n 5 python python/examples/solve_cyclic.py --n 6  # 4 workers
     $ mpirun -n 9 python python/examples/solve_cyclic.py --n 6  # 8 workers
+    $ mpirun -n 13 python python/examples/solve_cyclic.py --n 6 # 12 workers
 
 .. BEGIN-TIMING cyclic
 
-.. list-table:: cyclic-6 (720 paths, 156 finite solutions), measured on 8 cores, 2026-06-14 -- run tools/update_scaling_timings.py to refresh
+.. list-table:: cyclic-6 (720 paths, 156 finite solutions), measured on 16 cores, 2026-06-30 -- run tools/update_scaling_timings.py to refresh
    :header-rows: 1
    :widths: 20 15 25 15
 
@@ -156,31 +158,37 @@ Run the ladder (serial, then 2, 4, 8 workers):
      - speedup
    * - serial
      - --
-     - 357.5
+     - 160.1
      - 1.0x
    * - ``-n 3``
      - 2
-     - 316.6
-     - 1.1x
+     - 89.5
+     - 1.8x
    * - ``-n 5``
      - 4
-     - 167.4
-     - 2.1x
+     - 46.0
+     - 3.5x
    * - ``-n 9``
      - 8
-     - 120.6
-     - 3.0x
+     - 29.4
+     - 5.4x
+   * - ``-n 13``
+     - 12
+     - 23.7
+     - 6.8x
 
 .. END-TIMING cyclic
 
-The speedup grows with the worker count but flattens out -- here to about 3x on eight cores, not
-the ideal 8x.  That is the *slowest single path* from the opening showing through: once there are
-enough workers, the wall-clock is bounded below by the most expensive path, and cyclic-6 at this
-tracking tolerance has a few near-singular paths that grind far longer than the rest.  The jump
-from 2 to 4 workers is the largest because with only two workers those few heavy paths cannot help
-but pile onto one of them; more workers spread them out.  (Note that ``-n 9`` puts nine processes
-on eight cores -- the manager only dispatches, so eight workers share the cores with the near-idle
-manager.)
+The speedup grows steadily with the worker count -- here to about 6.8x at 12 workers.  cyclic-6 is
+720 paths, so there is plenty to spread, and it keeps gaining well past the point where the
+eigenvalue solve below has flattened.  It still falls short of the ideal 12x for two reasons: the
+*slowest single path* from the opening (a few near-singular paths grind far longer than the rest,
+so once the workers outnumber the heavy paths the extra ones idle), and the hardware -- only 12 of
+the M3 Max's 16 cores are performance cores, so beyond a dozen workers the slower efficiency cores
+set the floor.  The largest jumps are early (2->4->8 workers), where spreading the few heavy paths
+off a shared worker buys the most; the 8->12 step gains less.  (Note that ``-n 13`` is 13 processes
+-- 12 workers plus the near-idle manager -- which fit the 16 cores without oversubscription; the
+manager, which only dispatches, costs essentially nothing.)
 
 Scaling the eigenvalue solve
 ============================
@@ -210,10 +218,11 @@ Run the same ladder on a sizable matrix:
     $ mpirun -n 3 python python/examples/solve_eigenvalues.py --size 24  # 2 workers
     $ mpirun -n 5 python python/examples/solve_eigenvalues.py --size 24  # 4 workers
     $ mpirun -n 9 python python/examples/solve_eigenvalues.py --size 24  # 8 workers
+    $ mpirun -n 13 python python/examples/solve_eigenvalues.py --size 24 # 12 workers
 
 .. BEGIN-TIMING eigen
 
-.. list-table:: eigenvalues of a 24x24 symmetric matrix (24 paths), measured on 8 cores, 2026-06-14 -- run tools/update_scaling_timings.py to refresh
+.. list-table:: eigenvalues of a 24x24 symmetric matrix (24 paths), measured on 16 cores, 2026-06-30 -- run tools/update_scaling_timings.py to refresh
    :header-rows: 1
    :widths: 20 15 25 15
 
@@ -223,19 +232,23 @@ Run the same ladder on a sizable matrix:
      - speedup
    * - serial
      - --
-     - 728.1
+     - 12.6
      - 1.0x
    * - ``-n 3``
      - 2
-     - 477.4
-     - 1.5x
+     - 7.2
+     - 1.8x
    * - ``-n 5``
      - 4
-     - 269.0
-     - 2.7x
+     - 4.5
+     - 2.8x
    * - ``-n 9``
      - 8
-     - 195.5
+     - 3.3
+     - 3.8x
+   * - ``-n 13``
+     - 12
+     - 3.4
      - 3.7x
 
 .. END-TIMING eigen
@@ -244,9 +257,12 @@ With only 24 paths the dynamic, demand-driven dispatch earns its keep: under ada
 per-path cost varies a lot -- a near-collision of eigenvalues makes one path linger at high
 precision -- and a *static* split would leave most workers idle while one grinds.  Demand-driven
 dispatch keeps the others busy, but it cannot split a *single* path: once enough workers are on
-hand, that one slowest eigenvalue sets the floor (here ~195 s, the 3.7x plateau).  Same lesson as
-the cyclic case -- distributing helps right up until you hit the longest path, which is exactly the
-bound the opening promised.
+hand, that one slowest eigenvalue sets the floor (here ~3.3 s, the 3.8x plateau).  The plateau is
+unmistakable in the table -- **12 workers is no faster than 8** (3.7x vs 3.8x): past the point where
+every path has a worker, handing out more workers changes nothing, because there is no 25th path to
+give them.  That is the sharp contrast with cyclic-6 above, which has 720 paths and so keeps
+gaining out to 12 workers.  Same lesson either way -- distributing helps right up until you hit the
+longest path, which is exactly the bound the opening promised.
 
 Threads within ranks: the hybrid model
 ======================================
@@ -268,31 +284,34 @@ process with its own copy of the system.  Threads share one process's memory and
 machine, so they add parallelism without the per-rank memory cost.  The usual recipe: **one rank
 per machine (or per NUMA node), threads to fill that machine's cores.**
 
-At a fixed budget of 8 cores, here is the same cyclic-6 solve split between ranks and threads:
+At a fixed budget of 12 worker-cores, here is the same cyclic-6 solve split between ranks and threads:
 
 .. BEGIN-TIMING hybrid
 
-.. list-table:: cyclic-6 at 8 worker-cores, ranks x threads, measured on 8 cores, 2026-06-14 -- run tools/update_scaling_timings.py to refresh
+.. list-table:: cyclic-6 at 12 worker-cores, ranks x threads, measured on 16 cores, 2026-06-30 -- run tools/update_scaling_timings.py to refresh
    :header-rows: 1
    :widths: 40 25 15
 
    * - layout
      - wall-clock (s)
      - speedup
-   * - ``-n 9``, 8 workers x 1 thread
-     - 120.6
-     - 3.0x
-   * - ``-n 5``, 4 workers x 2 threads
-     - 126.0
-     - 2.8x
-   * - ``-n 3``, 2 workers x 4 threads
-     - 120.0
-     - 3.0x
+   * - ``-n 13``, 12 workers x 1 thread
+     - 23.7
+     - 6.8x
+   * - ``-n 7``, 6 workers x 2 threads
+     - 21.8
+     - 7.3x
+   * - ``-n 5``, 4 workers x 3 threads
+     - 22.9
+     - 7.0x
+   * - ``-n 3``, 2 workers x 6 threads
+     - 22.7
+     - 7.1x
 
 .. END-TIMING hybrid
 
-On a single shared-memory machine the three layouts land within a few percent of each other -- you
-are using the same eight cores either way, and they all bottom out at the same slowest-path floor.
+On a single shared-memory machine the four layouts land within a few percent of each other -- you
+are using the same twelve worker-cores either way, and they all bottom out at the same slowest-path floor.
 The reason to prefer more *ranks* shows up only across machines (more reach) or under memory
 pressure (threads share, ranks duplicate); the reason to prefer more *threads* is to keep the
 per-machine process count -- and memory footprint -- low.

--- a/python/test/classes/system_printing_test.py
+++ b/python/test/classes/system_printing_test.py
@@ -81,11 +81,45 @@ def test_linear_form_coefficients_short_in_terse_full_in_verbose():
     terse, verbose = s.describe(), s.describe(verbose=True)
     assert 'c.[x, y, z, 1]' in terse and 'c =' in terse
 
-    def longest_decimal(text):
-        return max((len(t) for t in re.findall(r'\d+\.\d+', text)), default=0)
+    # Count SIGNIFICANT FIGURES, not characters.  A character-width bound is magnitude-dependent
+    # and flaky: a 4-significant-figure coefficient below 1e-3 (e.g. 0.0003162) is 9 characters
+    # wide, so a `width <= 8` assertion fails on an unlucky small random draw.  Significant figures
+    # are magnitude-independent -- terse is 4 sig figs for ANY coefficient -- so this never flakes.
+    def most_sig_figs(text):
+        return max((len(t.replace('.', '').lstrip('0')) for t in re.findall(r'\d+\.\d+', text)),
+                   default=0)
 
-    assert longest_decimal(terse) <= 8             # ~4 significant figures, e.g. 0.3163 / 0.04692
-    assert longest_decimal(verbose) >= 12          # full working precision (~30 digits)
+    assert most_sig_figs(terse) <= 4               # terse: 4 significant figures, regardless of magnitude
+    assert most_sig_figs(verbose) >= 12            # verbose: full working precision (~30 digits)
+
+
+def test_terse_coefficient_width_varies_with_magnitude_but_sig_figs_do_not():
+    # Deterministic companion to the test above (which uses random coefficients): with KNOWN
+    # coefficients spanning magnitudes we pin the exact terse vs verbose rendering.  The small
+    # coefficient (< 1e-3) renders as `0.0003162` -- 9 characters but still 4 significant figures.
+    # This is the case that made the old `width <= 8` assertion flaky; it is correct behavior.
+    import re
+    pb.default_precision(30)
+    x, y = pb.Variable('x'), pb.Variable('y')
+    s = pb.System(); s.add_variable_group(_vg(x, y))
+    s.add_function(x*x + y*y - 1)
+    # exact decimal strings (add_linear rejects floats, which would cap block precision):
+    # one coefficient below 1e-3, one of order 1, with many digits so verbose stays long.
+    A = np.array([['0.00031622776601683794', '0.31622776601683794339']], dtype=object)
+    linalg.add_linear(s, A, np.array([x, y]))
+
+    terse, verbose = s.describe(), s.describe(verbose=True)
+
+    # terse: 4 significant figures for BOTH magnitudes ...
+    assert '0.0003162' in terse                    # small coeff: 9 characters wide, 4 sig figs
+    assert '0.3162' in terse                        # order-1 coeff: 6 characters wide, 4 sig figs
+    assert len('0.0003162') == 9                    # documents the width that broke `<= 8`
+    sig = lambda t: len(t.replace('.', '').lstrip('0'))
+    assert all(sig(t) <= 4 for t in re.findall(r'\d+\.\d+', terse))
+
+    # verbose: the full exact strings survive (full working precision, not 4 sig figs)
+    assert '0.00031622776601683794' in verbose
+    assert '0.31622776601683794339' in verbose
 
 
 def test_terse_truncates_many_forms_but_verbose_shows_all():

--- a/python/test/parallel/test_mpi_zerodim.py
+++ b/python/test/parallel/test_mpi_zerodim.py
@@ -157,3 +157,41 @@ def test_distributed_cyclic5_adaptive_matches_known_count():
     if pb.parallel.is_manager():
         assert len(solver.all_solutions()) == 120
         assert _distinct_finite(solver) == CYCLIC5_FINITE
+
+
+# Guards the multihomogeneous-start-system MPI serialization fix.  MHomogeneous::serialize() used to
+# drop every member except a vestigial degrees_, so a broadcast start system arrived hollow on each
+# worker: NumStartPoints() came back 0, the per-path metadata sized to nothing, and the parallel
+# solve segfaulted.  The binomial cyclic tests above never exercised the mhom path.  Here we solve a
+# small eigenvalue system (projective eigenvector => hom variable group => mhom start system, exactly
+# what python/examples/solve_eigenvalues.py uses) and demand the manager recover all n eigenvalues.
+def _eigen_system(A):
+    # (A - lam I) x = 0 with x a projective group and lam affine -- the mhom Bezout number is n.
+    from bertini import linalg
+    x = linalg.variable_vector('x', A.shape[0])
+    lam = pb.Variable('lam')
+    sys = pb.System()
+    linalg.add_functions(sys, A @ x - lam * x)
+    sys.add_hom_variable_group(pb.VariableGroup(list(x)))   # eigenvector in P^{n-1}
+    sys.add_variable_group(pb.VariableGroup([lam]))
+    return sys
+
+
+def test_distributed_mhom_eigenvalues_match_known_count():
+    pb.random.set_random_seed(3)
+    # small symmetric integer matrix: real, generically distinct spectrum, n paths under mhom.
+    A = np.array([[2, -1, 0, 1],
+                  [-1, 3, 1, 0],
+                  [0, 1, 2, -1],
+                  [1, 0, -1, 4]], dtype=int)
+    n = A.shape[0]
+    solver = ZeroDimSolver(_eigen_system(A), endgame='cauchy', mptype='adaptive', startsystem='mhom')
+
+    comm = MPI.COMM_WORLD
+    if comm.Get_size() > 1:
+        solver.solve(communicator=comm)   # this is the broadcast path that used to crash
+    else:
+        solver.solve()
+
+    if pb.parallel.is_manager():
+        assert _distinct_finite(solver) == n   # all n distinct eigenvalues recovered

--- a/tools/update_scaling_timings.py
+++ b/tools/update_scaling_timings.py
@@ -14,7 +14,7 @@ Run it **from the repository root, inside the bertini environment**::
     python tools/update_scaling_timings.py --quick      # tiny problems, to smoke-test this tool
 
 Each configuration is run **alone** (sequentially), so the wall-clock numbers are not polluted by
-contention; the full default sweep is ~20 minutes on 8 cores.  The tool **aborts without editing**
+contention; the full default sweep is a few minutes on a fast 12+-core machine.  The tool **aborts without editing**
 if any run fails its built-in correctness check, so it can never write numbers from a broken solve.
 
 This script is the single source of truth for the layouts shown in the tutorial: change the ladder
@@ -125,10 +125,16 @@ def splice(text, key, block):
 
 
 def rank_table(script, args, problem_caption):
-    """The serial -> 2/4/8-worker ladder shared by the cyclic and eigenvalue tables."""
+    """The serial -> 2/4/8/12-worker ladder shared by the cyclic and eigenvalue tables.
+
+    The top rung (12 workers, ``-n 13``) targets a 12-performance-core machine (e.g. Apple
+    M3 Max: 12 performance + 4 efficiency cores); the near-idle manager rides an efficiency
+    core.  On a smaller box the wide rungs oversubscribe -- measure() adds ``:OVERSUBSCRIBE``
+    automatically -- and the speedup simply plateaus, which is the honest result.
+    """
     serial, _ = measure(script, args, 1)
     rows = [["serial", "--", f"{serial:.1f}", "1.0x"]]
-    for nprocs, workers in ((3, 2), (5, 4), (9, 8)):
+    for nprocs, workers in ((3, 2), (5, 4), (9, 8), (13, 12)):
         t, _ = measure(script, args, nprocs)
         rows.append([f"``-n {nprocs}``", str(workers), f"{t:.1f}", speedup(serial, t)])
     header = ["launch", "workers", "wall-clock (s)", "speedup"]
@@ -183,15 +189,18 @@ def main():
 
     if "hybrid" in want:
         serial, _ = measure(CYCLIC, cyclic_args, 1)
-        t81, _ = measure(CYCLIC, cyclic_args, 9, omp=1)                  # == cyclic -n 9 row
-        t42, _ = measure(CYCLIC, cyclic_args, 5, omp=2, bind_none=True)
-        t24, _ = measure(CYCLIC, cyclic_args, 3, omp=4, bind_none=True)
+        # 12 worker-cores split every way the factors of 12 allow: ranks x threads = 12.
+        t12_1, _ = measure(CYCLIC, cyclic_args, 13, omp=1)                # == cyclic -n 13 row
+        t6_2, _  = measure(CYCLIC, cyclic_args, 7, omp=2, bind_none=True)
+        t4_3, _  = measure(CYCLIC, cyclic_args, 5, omp=3, bind_none=True)
+        t2_6, _  = measure(CYCLIC, cyclic_args, 3, omp=6, bind_none=True)
         rows = [
-            ["``-n 9``, 8 workers x 1 thread", f"{t81:.1f}", speedup(serial, t81)],
-            ["``-n 5``, 4 workers x 2 threads", f"{t42:.1f}", speedup(serial, t42)],
-            ["``-n 3``, 2 workers x 4 threads", f"{t24:.1f}", speedup(serial, t24)],
+            ["``-n 13``, 12 workers x 1 thread", f"{t12_1:.1f}", speedup(serial, t12_1)],
+            ["``-n 7``, 6 workers x 2 threads",  f"{t6_2:.1f}",  speedup(serial, t6_2)],
+            ["``-n 5``, 4 workers x 3 threads",  f"{t4_3:.1f}",  speedup(serial, t4_3)],
+            ["``-n 3``, 2 workers x 6 threads",  f"{t2_6:.1f}",  speedup(serial, t2_6)],
         ]
-        cap = (f"cyclic-{args.cyclic_n} at 8 worker-cores, ranks x threads, "
+        cap = (f"cyclic-{args.cyclic_n} at 12 worker-cores, ranks x threads, "
                f"measured on {cores} cores, {stamp} -- {refresh}")
         blocks["hybrid"] = render_table(cap, [40, 25, 15],
                                         ["layout", "wall-clock (s)", "speedup"], rows)


### PR DESCRIPTION
## Summary

Three related fixes, discovered while refreshing the `solving_at_scale` timing tables for #253 on real hardware (a 16-core M3 Max) — the eigenvalue table was blocked by a crash that turned out to be a serialization bug.

### 1. `fix(mhom)` — parallel multihomogeneous solve no longer segfaults
`MHomogeneous::serialize()` persisted only a vestigial `degrees_` member (never even assigned) and silently dropped five live ones: `degree_matrix_`, `valid_partitions_`, `var_groups_`, `linear_coeffs_`, `variable_cols_`, `num_hom_groups_`. `ZeroDimSolver::DistributeSystems` broadcasts the owning `shared_ptr<StartSystem>` to MPI workers via a polymorphic boost archive, so each worker deserialized a **hollow** start system: `NumStartPoints()` (which reads `valid_partitions_`) returned 0, the per-path metadata vectors sized to nothing, and `ExecuteBeforeEG` indexed out of bounds → **SIGSEGV on every worker** of any distributed mhom solve (e.g. the eigenvalue example). Total-degree (binomial) was unaffected because its `serialize()` is complete.

Fix: serialize all persistent members (`linear_coeffs_` is the critical random, primary data; the rest are recomputable but serializing them is low-risk and lets boost object-tracking re-link `var_groups_`'s `Variable` nodes to the base `System`). Dead `degrees_` removed. The other start systems were audited and are correct.

### 2. Tests + closing the CI blind spot
This sat in the one untested intersection (MPI **and** mhom): start-system serialization runs only on the MPI broadcast path (serial uses the live object, threaded uses `Clone()`), and the MPI tests were binomial-only.
- **C++ round-trip test** through `shared_ptr<StartSystem>` — the exact polymorphic path `DistributeSystems` uses — asserting `NumStartPoints()` and start points survive, for `MHomogeneous` / `TotalDegreeBinomial` / `TotalDegreeLinearProduct`. Runs in `ctest` on every platform, **no MPI required** — the durable guard.
- **Python MPI** distributed-mhom eigenvalue test in `test_mpi_zerodim.py`.
- **CI** `mpirun` smoke test now also runs an mhom input, exercising the real broadcast path.

### 3. `docs(scaling)` — refresh timing tables (closes #253)
Re-measured on the M3 Max with the ladder widened to 12 workers. cyclic-6 (720 paths) scales to ~6.8×; eigen-24 (24 heavy paths) plateaus at 3.8× with 12 workers no faster than 8 — a clean single-straggler-path bound. Prose reconciled (the old "8 cores" framing, the perf/efficiency-core split, etc.).

### 4. `fix(parse)` — restore `%` comment handling for classic input files
The blackbox reads files via the `Path` overload of `SplitIntoConfigAndInput`, which split raw text **without** the `CommentStripper` pass — so a Bertini 1 `%` comment survived into the input section and the system parser rejected the file. Now delegates to the comment-aware `ParseInputFile`. New temp-file regression test; `benchmark/inputs/small_mhom.b2` carries `%` comments so the CI MPI smoke test doubles as a comment-parsing guard. (The Python `parse.system` path already handled comments.)

## Verification
- `test_classes` and `test_classic` green; `test_mpi_zerodim.py` passes serial and under `mpirun -n 3`.
- Previously-crashing parallel eigen solve now recovers all eigenvalues; comment-laden mhom CLI gives serial == parallel.

Closes #253.

🤖 Generated with [Claude Code](https://claude.com/claude-code)