### PR TITLE
Investigate: intermittent macOS py3.14 SIGSEGV in sympy round-trip eval

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -37,6 +37,11 @@ on:
         required: false
         type: string
         default: ''
+      probe_alloc:
+        description: 'Allocator probe: build+test ONLY macos-14 / py3.14 and A/B the BERTINI2_NO_FAST_ALLOC hook (investigation, not a full matrix).'
+        required: false
+        type: boolean
+        default: false
   workflow_dispatch:
     inputs:
       full_matrix:
@@ -46,6 +51,11 @@ on:
         default: false
       minimal:
         description: 'Build only the ubuntu-latest / python-3.11 wheel; skip C++ tests, Windows, macOS, and wheel tests.'
+        required: false
+        type: boolean
+        default: false
+      probe_alloc:
+        description: 'Allocator probe: build+test ONLY macos-14 / py3.14 and A/B the BERTINI2_NO_FAST_ALLOC hook (investigation, not a full matrix).'
         required: false
         type: boolean
         default: false
@@ -87,7 +97,11 @@ jobs:
           # Mac available to the maintainer). Intel macOS support is paused
           # pending a reproducer or an upstream fix. Re-add "macos-15-intel"
           # below when ready to revisit.
-          if [[ "${{ inputs.minimal }}" == "true" ]]; then
+          if [[ "${{ inputs.probe_alloc }}" == "true" ]]; then
+            # allocator probe: the SIGSEGV is macos-14 / py3.14 only, so build+test just that one
+            echo 'os=["macos-14"]' >> $GITHUB_OUTPUT
+            echo 'python_versions=["3.14"]' >> $GITHUB_OUTPUT
+          elif [[ "${{ inputs.minimal }}" == "true" ]]; then
             echo 'os=["ubuntu-latest"]' >> $GITHUB_OUTPUT
             echo 'python_versions=["3.11"]' >> $GITHUB_OUTPUT
           elif [[ "${{ github.ref }}" == "refs/heads/main" || "${{ github.ref }}" == "refs/heads/develop" || "${{ github.ref }}" == refs/tags/* || "${{ inputs.full_matrix }}" == "true" || "${{ github.event.pull_request.base.ref }}" == "develop" || "${{ github.event.pull_request.base.ref }}" == "main" ]]; then
@@ -571,6 +585,78 @@ jobs:
         run: |
           pip install numpy
           pip install --no-index --find-links dist/ bertini2
+
+      # Investigation (#57): characterize the runtime where the intermittent SIGSEGV in
+      # sympy_bridge_test.py lives (macOS / py3.14).  We have NOT reproduced it on Homebrew or
+      # python-build-standalone py3.14 with this exact wheel, so the suspect is the python.org
+      # framework build + this runner's heap.  Dump the exact environment so we can match it.
+      - name: Environment report (py3.14 SIGSEGV investigation)
+        if: ${{ contains(matrix.python-version, '3.14') }}
+        run: |
+          set +e
+          echo "## Environment report (${{ matrix.os }} / py${{ matrix.python-version }})" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo '```'
+            echo "runner.os=${{ runner.os }}  runner.arch=${{ runner.arch }}"
+            sw_vers || true
+            uname -a
+            echo "--- python ---"
+            which python; python -VV
+            python -c "import sys, sysconfig; print('prefix', sys.prefix); print('framework', sysconfig.get_config_var('PYTHONFRAMEWORK')); print('config_args', sysconfig.get_config_var('CONFIG_ARGS')); print('gil_disabled', sysconfig.get_config_var('Py_GIL_DISABLED'))"
+            echo "--- key package versions ---"
+            python -c "import numpy, sympy, mpmath; print('numpy', numpy.__version__, '| sympy', sympy.__version__, '| mpmath', mpmath.__version__)"
+            python -c "import sympy.external.gmpy as g; print('sympy GROUND_TYPES:', g.GROUND_TYPES)"   # 'python' = no gmpy2 (expected)
+            python -c "import importlib.util as u; print('gmpy2 importable:', u.find_spec('gmpy2') is not None)"
+            pip freeze | grep -iE '^(bertini2|numpy|sympy|mpmath|pandas|pytest|gmpy2)==' || true
+            echo "--- bertini build/runtime ---"
+            python -c "import bertini, os; print('bertini', bertini.__file__); print('BERTINI2_NO_FAST_ALLOC=', os.environ.get('BERTINI2_NO_FAST_ALLOC'))"
+            echo "--- bertini._pybertini shared lib + vendored deps (delocated) ---"
+            python -c "import bertini._pybertini as m; print(m.__file__)"
+            SO=$(python -c "import bertini._pybertini as m; print(m.__file__)")
+            otool -L "$SO" || true
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY" 2>&1
+          cat "$GITHUB_STEP_SUMMARY"
+
+      # A/B the mimalloc GMP-limb hook: the SIGSEGV is allocator-sensitive, so run the sympy bridge
+      # tests in a loop with the hook ON (default) and OFF (BERTINI2_NO_FAST_ALLOC=1), under random
+      # ordering + faulthandler.  Diagnostic only -- never fails the job (the verdict is the output).
+      - name: Allocator A/B probe (py3.14 SIGSEGV)
+        if: ${{ contains(matrix.python-version, '3.14') }}
+        continue-on-error: true
+        env:
+          PROBE_ITERS: '40'
+        run: |
+          pip install pytest pytest-timeout pytest-randomly sympy pandas
+          TEST=python/test/classes/sympy_bridge_test.py
+          echo "## Allocator A/B probe (sympy round-trip eval, $PROBE_ITERS iters each)" >> "$GITHUB_STEP_SUMMARY"
+          probe () {                       # $1=label; remaining args = env prefix for the run
+            local label="$1"; shift
+            local i ec
+            for i in $(seq 1 "$PROBE_ITERS"); do
+              "$@" python -X faulthandler -m pytest "$TEST" -p randomly -q >/tmp/probe.out 2>&1
+              ec=$?
+              if [ "$ec" -ge 130 ]; then
+                echo "::warning::$label CRASHED exit=$ec on iter $i/$PROBE_ITERS"
+                tail -50 /tmp/probe.out
+                printf -- '- **%s**: CRASHED (exit %s, likely SIGSEGV) on iter %s/%s\n' "$label" "$ec" "$i" "$PROBE_ITERS" >> "$GITHUB_STEP_SUMMARY"
+                return 1
+              fi
+            done
+            printf -- '- **%s**: %s/%s clean\n' "$label" "$PROBE_ITERS" "$PROBE_ITERS" >> "$GITHUB_STEP_SUMMARY"
+            return 0
+          }
+          set +e
+          probe 'hook ON  (default mimalloc GMP allocator)';                          on=$?
+          probe 'hook OFF (BERTINI2_NO_FAST_ALLOC=1)' env BERTINI2_NO_FAST_ALLOC=1;    off=$?
+          {
+            echo
+            if   [ "$on" -ne 0 ] && [ "$off" -eq 0 ]; then echo '**Verdict:** mimalloc GMP hook is the trigger (crashes ON, clean OFF) → gate the hook off on this platform / fix the hook.'
+            elif [ "$on" -ne 0 ] && [ "$off" -ne 0 ]; then echo '**Verdict:** allocator exonerated (crashes both ways) → next is an ASAN wheel-test build.'
+            elif [ "$on" -eq 0 ] && [ "$off" -ne 0 ]; then echo '**Verdict:** UNEXPECTED — clean with hook ON but crashes with it OFF; re-run.'
+            else echo "**Verdict:** did not reproduce in $PROBE_ITERS iters (intermittent); bump PROBE_ITERS and re-run."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Run Python tests
         run: |

--- a/python/test/classes/sympy_bridge_test.py
+++ b/python/test/classes/sympy_bridge_test.py
@@ -167,6 +167,29 @@ def test_round_trip_bertini_to_sympy_to_bertini():
     assert mp.abs(eval_at(rebuilt, **pt) - eval_at(tree, **pt)) <= mp.Float('1e-25')
 
 
+def test_round_trip_then_eval_repeatedly_is_stable():
+    # Regression guard for a SIGSEGV seen on CI (macOS / py3.14) in
+    # test_round_trip_bertini_to_sympy_to_bertini, at eval_at -> node.eval through the SLP.
+    # The crash is intermittent and allocator-sensitive (the GMP/mpfr limb hook), so a single
+    # round-trip+eval does not reliably surface it.  Hammer the exact bertini->sympy->bertini->eval
+    # path many times over a battery of expressions -- including transcendentals and high powers
+    # that churn mpfr/mpc temporaries -- and require every reconstruction to evaluate identically
+    # to the original.  A correctness divergence OR a crash here both fail the guard.
+    x, y = pb.Variable('x'), pb.Variable('y')
+    trees = [
+        x**2 * y - Rational('2/5') + sin(x),
+        x**3 - y**2 + Rational('7/3'),
+        sin(x) * x - y + Rational('1/9'),
+        x**4 * y**2 - Rational('5/11') + sin(y),
+        sin(x) + sin(y) - x * y,
+    ]
+    pt = dict(x=complex(0.6, -0.2), y=complex(-1.1, 0.4))
+    for _ in range(200):
+        for tree in trees:
+            rebuilt = from_sympy(to_sympy(tree), [x, y])
+            assert mp.abs(eval_at(rebuilt, **pt) - eval_at(tree, **pt)) <= mp.Float('1e-25')
+
+
 # --- the acceptance test: define in sympy, solve with bertini ---
 
 def test_end_to_end_solve_matches_sympy(sxy):


### PR DESCRIPTION
**Draft / investigation** — split out of #56 so it doesn't block the serialization fix.

## The bug
CI hits an intermittent **SIGSEGV** on `macos-14 / py3.14` wheel tests in
`sympy_bridge_test.py::test_round_trip_bertini_to_sympy_to_bertini`, crashing at `eval_at` →
`node.eval` (the SLP evaluating a node rebuilt from sympy, doing mpfr/mpc work). py3.11–3.13 macOS
pass; only py3.14 crashes, intermittently.

## Ruled out (all reproduced locally, M3 Max)
- **gmpy2** — not a transitive dep (sympy→mpmath only); CI installs none, so `sympy GROUND_TYPES == 'python'`. Installing gmpy2 (→ 'gmpy') still didn't crash. Exonerated.
- **The wheel** — ran the exact CI artifact (`cp314-macosx_14_0_arm64`) clean: 3× full suite + 50× sympy under Homebrew py3.14.5, and 3× + 80× under python-build-standalone py3.14.6. Not the vendored libs / build flags.
- **py3.14 generically** — two non-Homebrew py3.14 builds run the CI wheel clean.
- **Test order** — 60× full-suite under `pytest-randomly` + 100× fresh-process sympy: clean.

## Working hypothesis
The only remaining variable is the **python.org *framework* py3.14 build + the macos-14 runner heap**. The intermittency + environment-sensitivity is the signature of a **latent memory-safety bug** that stays silent on newer macOS / other py builds but trips the runner's heap. Prime suspect: the **mimalloc GMP-limb hook** (`fast_allocator.cpp`); the crash is allocator-sensitive. Second: eigenpy/boost.python refcounts under py3.14.

Local ASAN is blocked — macOS can't ASAN a dlopen'd extension ("interceptors loaded too late"), and there's no Docker for Linux ASAN locally.

## This PR — investigation tooling (no fix yet)
- **Allocator A/B probe** on the macos-14/py3.14 wheel-test job: loops the sympy bridge tests with the mimalloc GMP hook **ON** (default) vs **OFF** (`BERTINI2_NO_FAST_ALLOC=1`), randomized order + faulthandler, prints a verdict. Diagnostic only (never fails the job). **Runs automatically in this PR's CI** — the verdict lands in the `Test wheels on macos-14 / py3.14` job summary.
- **Environment report** step: python build (framework?/GIL?), package versions, sympy GROUND_TYPES, gmpy2 presence, `otool -L` of `_pybertini` — to match the runtime.
- **`probe_alloc`** dispatch input: collapses `set_matrix` to **macos-14 / py3.14 only** for cheap single-config reruns (available once merged to develop, per the workflow_dispatch default-branch rule).
- `test_round_trip_then_eval_repeatedly_is_stable`: 1000× round-trip+eval hammer.

## Next steps
1. Read this CI run's allocator A/B verdict.
   - crashes ON / clean OFF → mimalloc hook is the trigger; fix = gate it off on macOS/py3.14.
   - crashes both ways → allocator exonerated → (2).
2. Add a **Linux ASAN CI job** (LD_PRELOAD works there; no local Docker needed) to get the exact UAF/overflow site.
3. Apply fix, drop the temporary probe steps, un-draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)