### PR TITLE
fix(slp): stop over-reading the instruction tape by one word in Eval

### DIFF
--- a/core/src/system/straight_line_program.cpp
+++ b/core/src/system/straight_line_program.cpp
@@ -423,7 +423,12 @@ namespace bertini{
 			const bool r0 = opw & kArg0Real;   // first operand in real bank
 			const bool r1 = opw & kArg1Real;   // second operand in real bank (binary, non-IntPower)
 			const bool ro = opw & kOutReal;    // result in real bank
-			const size_t a = instructions_[ii+1], b = instructions_[ii+2], c = instructions_[ii+3];
+			const size_t a = instructions_[ii+1], b = instructions_[ii+2];
+			// c (the second operand / result word) exists only for binary ops (4-word instructions).
+			// A unary op is 3 words, so reading instructions_[ii+3] there is the NEXT instruction --
+			// and one past the end of the tape when the unary op is the last instruction (a trailing
+			// Assign is the common case: output wiring ends every program). Guard the read.
+			const size_t c = IsUnary(op) ? 0 : instructions_[ii+3];
 
 			switch (op) {
 

--- a/core/test/classes/eval_expression_test.cpp
+++ b/core/test/classes/eval_expression_test.cpp
@@ -186,4 +186,46 @@ BOOST_AUTO_TEST_CASE(derivatives_compile_and_evaluate_through_the_slp)
 	BOOST_CHECK_SMALL(std::abs(evald((x/y)->Differentiate(x), pt)   - complex_dbl(0.2)), tol); // d/dx x/y = 1/y, y=5 -> 0.2
 }
 
+// Regression: SLPProgram::Eval used to read instructions_[ii+3] unconditionally, over-reading the
+// instruction tape by one word for a *unary* op (3 words) that is the last instruction -- which is
+// the common case, since output wiring ends every program in a trailing Assign. It surfaced as a
+// heap-buffer-overflow (ASAN) / SIGSEGV under Guard Malloc for programs whose tape ends exactly on
+// an allocation boundary, e.g. the Jacobian of a squared-variable monomial like x*x*y. The value was
+// always correct (the stray word is discarded), so only a memory sanitizer/adverse allocator catches
+// it -- run this suite under ASAN. Both the bare-expression (EvalExpression) and the normal
+// System->StraightLineProgram solve path exercise the same evaluator.
+BOOST_AUTO_TEST_CASE(eval_of_trailing_unary_tape_is_memory_safe)
+{
+	bertini::DefaultPrecision(30);
+	auto x = Variable::Make("x");
+	auto y = Variable::Make("y");
+	std::map<std::string,complex_mp> values{
+		{"x", complex_mp(bertini::real_mp("0.6"), bertini::real_mp("-0.2"))},
+		{"y", complex_mp(bertini::real_mp("-1.1"), bertini::real_mp("0.4"))} };
+	// x^2*y at this point = -0.256 + 0.392i (over-read word never affected the result; check it holds)
+	auto v = EvalExpression<complex_mp>(x*x*y, values);
+	BOOST_CHECK(abs(v - complex_mp(bertini::real_mp("-0.256"), bertini::real_mp("0.392"))) < 1e-25);
+	// exercise several tapes that end in a trailing unary op after a squared-variable factor
+	for (Nd f : { Nd(x*x*y), Nd(x*y*y), Nd(x*x/y), Nd(x/(y*y)) })
+		EvalExpression<complex_mp>(f, values);
+}
+
+BOOST_AUTO_TEST_CASE(system_slp_of_squared_monomial_is_memory_safe)
+{
+	bertini::DefaultPrecision(30);
+	auto x = Variable::Make("x");
+	auto y = Variable::Make("y");
+	bertini::System sys;
+	sys.AddFunction(x*x*y);
+	sys.AddVariableGroup(bertini::VariableGroup{x,y});
+	bertini::StraightLineProgram slp(sys);      // compiles f + Jacobian; tape ends in a trailing Assign
+	bertini::Vec<complex_mp> point(2);
+	point << complex_mp(bertini::real_mp("0.6"), bertini::real_mp("-0.2")),
+	         complex_mp(bertini::real_mp("-1.1"), bertini::real_mp("0.4"));
+	slp.precision(30);
+	slp.Eval(point);
+	auto fv = slp.GetFuncVals<complex_mp>();
+	BOOST_CHECK(abs(fv(0) - complex_mp(bertini::real_mp("-0.256"), bertini::real_mp("0.392"))) < 1e-25);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## The bug

`SLPProgram::Eval` decoded every instruction with
```cpp
const size_t a = instructions_[ii+1], b = instructions_[ii+2], c = instructions_[ii+3];
```
reading the third operand word **unconditionally**. A *unary* op is only 3 words (`op, operand, result`), so its `instructions_[ii+3]` is the next instruction — and **one past the end of the `instructions_` vector when the unary op is the last instruction**. Every compiled program ends in trailing `Assign` output-wiring, so the last instruction is essentially always unary: this was a **one-element heap over-read on virtually every SLP evaluation**. `c` is only consumed by the binary switch cases, so results were always correct — only memory safety was violated.

## Why it hid as a "macOS / py3.14 CI flake"

The stray read normally lands in adjacent heap slack. It only *faults* when the tape ends exactly on an allocation boundary — e.g. the Jacobian of a squared-variable monomial like `x*x*y` compiles to a 32-word / 256-byte tape, so `instructions_[ii+3]` on the final `Assign` hits the redzone. The intermittent `Test wheels on macos-14 / py3.14` SIGSEGV was the sympy round-trip evaluating exactly such expressions; py3.14's framework-build heap (and macOS Guard Malloc) expose the over-read that ordinary heaps mask.

## The fix (one line)

```cpp
const size_t c = IsUnary(op) ? 0 : instructions_[ii+3];
```

## How it was found & verified

AddressSanitizer on the native `test_classes` executable — a **pure-C++ repro** (macOS can't ASan a `dlopen`'d Python extension, but a normal exe is fine) — pointed exactly at `straight_line_program.cpp:426` (the read) over the tape allocated in `PartitionInstructions`.

Verified:
- full `test_classes` **ASan-clean**;
- every formerly-crashing form (`x*x*y`, `x*x/y`, `x/(y*y)`, …) now **0/N** under Guard Malloc;
- values unchanged (`x²y = -0.256 + 0.392i`);
- normal Release build: `eval_expression` + `SLP_tests` suites green.

Regression tests added in `eval_expression_test.cpp` exercise both the `EvalExpression` and the normal `System → StraightLineProgram` solve paths. The over-read is invisible to a normal build (correct values), so the durable guard is running the C++ suite under ASan — an opt-in/periodic CI job is the intended follow-up.

Investigation trail (deterministic repro, bisection, tape diagram, ruled-out hypotheses) lives on the `investigate/macos-py314-sympy-segfault` branch (#57).

🤖 Generated with [Claude Code](https://claude.com/claude-code)