### PR TITLE
Unicode + emoji identifiers, name validation, collision-safe path variables

### DIFF
--- a/core/include/bertini2/io/file_utilities.hpp
+++ b/core/include/bertini2/io/file_utilities.hpp
@@ -95,7 +95,20 @@ namespace bertini{
 	{
 		ifstream infile;
 		OpenInFileThrowIfFail(infile, input_path);
-		return std::string ( std::istreambuf_iterator<char>(infile), std::istreambuf_iterator<char>() );
+		std::istreambuf_iterator<char> file_begin(infile), file_end;
+		std::string contents(file_begin, file_end);
+
+		// Treat file contents as UTF-8; drop a leading byte-order mark (EF BB BF)
+		// so it is not parsed as a stray leading character.
+		if (contents.size() >= 3 &&
+		    static_cast<unsigned char>(contents[0]) == 0xEF &&
+		    static_cast<unsigned char>(contents[1]) == 0xBB &&
+		    static_cast<unsigned char>(contents[2]) == 0xBF)
+		{
+			contents.erase(0, 3);
+		}
+
+		return contents;
 	}
 }
 

--- a/core/include/bertini2/io/parsing/function_rules.hpp
+++ b/core/include/bertini2/io/parsing/function_rules.hpp
@@ -200,7 +200,12 @@ namespace bertini {
 					
 					exp_elem_.name("exp_elem_");
 					exp_elem_ =
-					(symbol_  >> !qi::alnum) [_val = _1]
+					// The negative lookahead keeps a known symbol from matching a
+					// prefix of a longer identifier (e.g. `e` inside `exp`, or `x`
+					// inside `xy`).  It must use the UTF-8 continuation predicate so
+					// a following Unicode letter (e.g. `α` after a known `Ω`) also
+					// blocks the match -- a bare ASCII !qi::alnum would not.
+					(symbol_  >> utf8_ident_boundary_parser()) [_val = _1]
 					|   ( '(' > expression_  [_val = _1] > ')'  ) // using the > expectation here.
 					// unary +/- bind a single factor_, NOT the whole expression_: "-y+x" is
 					// (-y)+x, and "-x^2" is -(x^2).  (Binding expression_ here made a leading

--- a/core/include/bertini2/io/parsing/qi_files.hpp
+++ b/core/include/bertini2/io/parsing/qi_files.hpp
@@ -59,9 +59,26 @@
 #include <stdexcept>
 #include <string>
 
+#include "bertini2/io/parsing/unicode_ident.hpp"
+
 namespace bertini {
 namespace parsing {
 namespace classic {
+
+/// \brief Strip a leading UTF-8 byte-order mark (`EF BB BF`) from \p s in place,
+///        if present.  Editors (notably on Windows) may prepend a BOM; the Qi
+///        grammar treats input as raw UTF-8, so the BOM must be removed at the
+///        read boundary or it would appear as a stray leading "character".
+inline void StripUTF8BOM(std::string& s)
+{
+	if (s.size() >= 3 &&
+	    static_cast<unsigned char>(s[0]) == 0xEF &&
+	    static_cast<unsigned char>(s[1]) == 0xBB &&
+	    static_cast<unsigned char>(s[2]) == 0xBF)
+	{
+		s.erase(0, 3);
+	}
+}
 
 /// \brief Format a human-readable parse-error message (line, column, expected, and found text).
 inline std::string FormatParseError(

--- a/core/include/bertini2/io/parsing/settings_parsers/algorithm.hpp
+++ b/core/include/bertini2/io/parsing/settings_parsers/algorithm.hpp
@@ -242,8 +242,13 @@ namespace bertini {
 
 
 
+					// UTF-8 identifier (same policy as the system parser): a Unicode
+					// letter start, then Unicode alphanumerics or [ ] _ .  The parser
+					// is self-contained (never sub-skips inside the identifier), so no
+					// lexeme is needed even on this skippered rule.  See
+					// io/parsing/unicode_ident.hpp.
 					valid_variable_name_.name("valid_variable_name_");
-					valid_variable_name_ = +qi::alpha >> *(qi::alnum | qi::char_("[]_") );
+					valid_variable_name_ = utf8_identifier_parser();
 
 
 					path_variable_name_.name("path_variable_name_");

--- a/core/include/bertini2/io/parsing/system_parsers.hpp
+++ b/core/include/bertini2/io/parsing/system_parsers.hpp
@@ -77,11 +77,16 @@ namespace bertini {
 	System::System(std::string const& input)
 	{
 		System sys;
-		
+
 		parsing::classic::SystemParser<std::string::const_iterator> S;
-		
-		std::string::const_iterator iter = input.begin();
-		std::string::const_iterator end = input.end();
+
+		// Treat the input as UTF-8; drop a leading BOM so it is not seen as a
+		// stray leading character by the grammar.
+		std::string cleaned = input;
+		parsing::classic::StripUTF8BOM(cleaned);
+
+		std::string::const_iterator iter = cleaned.begin();
+		std::string::const_iterator end = cleaned.end();
 		
 		bool s = phrase_parse(iter, end, S,boost::spirit::ascii::space, sys);
 		

--- a/core/include/bertini2/io/parsing/system_rules.hpp
+++ b/core/include/bertini2/io/parsing/system_rules.hpp
@@ -224,9 +224,12 @@ namespace bertini {
 					
 					
 					
-					// get a string which fits the naming rules.
+					// get a string which fits the naming rules.  Identifiers are
+					// UTF-8: they start with a Unicode letter and continue with
+					// Unicode alphanumerics or [ ] _ .  The matched raw bytes are
+					// the stored name (already UTF-8).  See io/parsing/unicode_ident.hpp.
 					valid_variable_name_.name("valid_variable_name_");
-					valid_variable_name_ = +qi::alpha >> *(qi::alnum | qi::char_("[]_") );
+					valid_variable_name_ = utf8_identifier_parser();
 					
 					
 					

--- a/core/include/bertini2/io/parsing/unicode_ident.hpp
+++ b/core/include/bertini2/io/parsing/unicode_ident.hpp
@@ -49,28 +49,16 @@
 
 #include <boost/spirit/include/qi.hpp>
 #include <boost/regex/pending/unicode_iterator.hpp>
-#include <boost/spirit/home/support/char_encoding/unicode.hpp>
+
+#include "bertini2/naming.hpp"   // IsIdentStart / IsIdentCont -- the shared name policy
 
 namespace bertini {
 namespace parsing {
 namespace classic {
 
-/// \brief True if code point \p cp may START an identifier: any Unicode letter
-///        (ASCII `A-Z a-z`, plus Ω, α, CJK, ...).  This is the single policy
-///        point for identifier starts; an "emoji" variant would additionally
-///        accept symbol-category code points here (intentionally off by default).
-inline bool IsIdentStart(char32_t cp)
-{
-	return boost::spirit::char_encoding::unicode::isalpha(cp);
-}
-
-/// \brief True if code point \p cp may CONTINUE an identifier: any Unicode
-///        alphanumeric, or one of the legacy continuation characters `[ ] _`.
-inline bool IsIdentCont(char32_t cp)
-{
-	return boost::spirit::char_encoding::unicode::isalnum(cp)
-	    || cp == U'[' || cp == U']' || cp == U'_';
-}
+// IsIdentStart / IsIdentCont live in namespace bertini (bertini2/naming.hpp) so the
+// grammar and the object model share one definition of a legal name; they resolve
+// here by enclosing-namespace lookup.
 
 /// \cond UNICODE_IDENT_PARSERS
 

--- a/core/include/bertini2/io/parsing/unicode_ident.hpp
+++ b/core/include/bertini2/io/parsing/unicode_ident.hpp
@@ -1,0 +1,170 @@
+//This file is part of Bertini 2.
+//
+//bertini2/io/parsing/unicode_ident.hpp is free software: you can redistribute it and/or modify
+//it under the terms of the GNU General Public License as published by
+//the Free Software Foundation, either version 3 of the License, or
+//(at your option) any later version.
+//
+//bertini2/io/parsing/unicode_ident.hpp is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//GNU General Public License for more details.
+//
+//You should have received a copy of the GNU General Public License
+//along with bertini2/io/parsing/unicode_ident.hpp.  If not, see <http://www.gnu.org/licenses/>.
+//
+// Copyright(C) Bertini2 Development Team
+//
+// See <http://www.gnu.org/licenses/> for a copy of the license,
+// as well as COPYING.  Bertini2 is provided with permitted
+// additional terms in the b2/licenses/ directory.
+
+
+/**
+ \file bertini2/io/parsing/unicode_ident.hpp
+
+ \brief UTF-8-aware identifier building blocks for the classic (Bertini 1) Qi grammar.
+
+ The classic parser keeps byte iterators (`std::string::const_iterator`)
+ everywhere -- the symbol tables (`qi::symbols<char,...>`) and error handling are
+ all keyed on `char`.  To accept Unicode *letters* (Ω, α, CJK, ...) as variable
+ names without churning that whole pipeline, we make only the identifier rule
+ UTF-8-aware: code points are transiently decoded to UTF-32 via
+ `boost::u8_to_u32_iterator` and classified by Unicode character properties
+ (never the platform locale / `wchar_t`, which is the cp1252/latin-1 footgun).
+ Because the source string is already UTF-8, a matched identifier's raw bytes
+ *are* the desired `std::string` attribute.
+
+ Two self-contained Spirit primitives are provided so composition never needs a
+ unary/binary Spirit operator applied to a bare custom primitive (which requires
+ the terminal machinery): utf8_identifier_parser matches a whole identifier and
+ exposes it as a `std::string`; utf8_ident_boundary_parser is a zero-width
+ negative lookahead used to stop a known symbol from matching a prefix of a
+ longer identifier.
+ */
+
+#pragma once
+
+#include <string>
+
+#include <boost/spirit/include/qi.hpp>
+#include <boost/regex/pending/unicode_iterator.hpp>
+#include <boost/spirit/home/support/char_encoding/unicode.hpp>
+
+namespace bertini {
+namespace parsing {
+namespace classic {
+
+/// \brief True if code point \p cp may START an identifier: any Unicode letter
+///        (ASCII `A-Z a-z`, plus Ω, α, CJK, ...).  This is the single policy
+///        point for identifier starts; an "emoji" variant would additionally
+///        accept symbol-category code points here (intentionally off by default).
+inline bool IsIdentStart(char32_t cp)
+{
+	return boost::spirit::char_encoding::unicode::isalpha(cp);
+}
+
+/// \brief True if code point \p cp may CONTINUE an identifier: any Unicode
+///        alphanumeric, or one of the legacy continuation characters `[ ] _`.
+inline bool IsIdentCont(char32_t cp)
+{
+	return boost::spirit::char_encoding::unicode::isalnum(cp)
+	    || cp == U'[' || cp == U']' || cp == U'_';
+}
+
+/// \cond UNICODE_IDENT_PARSERS
+
+// Match a whole UTF-8 identifier (IsIdentStart, then zero or more IsIdentCont)
+// and expose the matched raw bytes as a std::string.  Self-contained: decodes
+// contiguous code points itself, so it never sub-skips inside an identifier even
+// when used in a rule that carries a space skipper.
+struct utf8_identifier_parser
+    : boost::spirit::qi::primitive_parser<utf8_identifier_parser>
+{
+	template <typename Context, typename Iterator>
+	struct attribute { typedef std::string type; };
+
+	template <typename Iterator, typename Context, typename Skipper, typename Attribute>
+	bool parse(Iterator& first, Iterator const& last,
+	           Context&, Skipper const& skipper, Attribute& attr) const
+	{
+		boost::spirit::qi::skip_over(first, last, skipper);
+		Iterator const begin = first;
+		Iterator it = first;
+		try
+		{
+			if (it == last)
+				return false;
+			{
+				boost::u8_to_u32_iterator<Iterator> u(it, it, last);
+				if (!IsIdentStart(*u))
+					return false;
+				++u;
+				it = u.base();
+			}
+			while (it != last)
+			{
+				boost::u8_to_u32_iterator<Iterator> u(it, it, last);
+				if (!IsIdentCont(*u))
+					break;
+				++u;
+				it = u.base();
+			}
+		}
+		catch (...)
+		{
+			return false; // malformed UTF-8 -> clean parse failure
+		}
+		std::string matched(begin, it);
+		boost::spirit::traits::assign_to(matched, attr);
+		first = it;
+		return true;
+	}
+
+	template <typename Context>
+	boost::spirit::info what(Context&) const
+	{
+		return boost::spirit::info("utf8_identifier");
+	}
+};
+
+// Zero-width negative lookahead: succeeds (consuming nothing beyond the skipper)
+// iff the next code point is NOT an identifier-continuation code point (or the
+// input has ended).  Replaces the ASCII `!qi::alnum` guard so a following
+// Unicode letter (e.g. `α` after a known `Ω`) also blocks a greedy symbol match.
+struct utf8_ident_boundary_parser
+    : boost::spirit::qi::primitive_parser<utf8_ident_boundary_parser>
+{
+	template <typename Context, typename Iterator>
+	struct attribute { typedef boost::spirit::unused_type type; };
+
+	template <typename Iterator, typename Context, typename Skipper, typename Attribute>
+	bool parse(Iterator& first, Iterator const& last,
+	           Context&, Skipper const& skipper, Attribute&) const
+	{
+		boost::spirit::qi::skip_over(first, last, skipper);
+		if (first == last)
+			return true; // nothing follows -> boundary holds
+		try
+		{
+			boost::u8_to_u32_iterator<Iterator> u(first, first, last);
+			return !IsIdentCont(*u); // followed by an ident char -> boundary fails
+		}
+		catch (...)
+		{
+			return true; // malformed following bytes -> treat as a boundary
+		}
+	}
+
+	template <typename Context>
+	boost::spirit::info what(Context&) const
+	{
+		return boost::spirit::info("utf8_ident_boundary");
+	}
+};
+
+/// \endcond
+
+} // namespace classic
+} // namespace parsing
+} // namespace bertini

--- a/core/include/bertini2/nag_algorithms/zero_dim_solve.hpp
+++ b/core/include/bertini2/nag_algorithms/zero_dim_solve.hpp
@@ -2035,7 +2035,10 @@ run the endgame, classify the endpoints, report.  See the forward-declare doc ab
 				RankCheck();                     // square, but can isolated solutions even exist?
 				PrepareTarget(owned_target_);    // homogenize + auto-patch the (now square) target
 				owned_start_    = owned_factory_(owned_target_);                         // start system over the prepared target
-				owned_homotopy_ = MakeHomotopy(owned_target_, *owned_start_, path_variable_name);
+				// Treat the configured name as a BASE: mangle it only if it would collide with a
+				// user variable, so the injected path variable can never overlap a user symbol.
+				owned_homotopy_ = MakeHomotopy(owned_target_, *owned_start_,
+				                               UniquePathVariableName(owned_target_, path_variable_name));
 			}
 
 			/// \return The built (cloned, prepared) target system.
@@ -2335,8 +2338,13 @@ HomotopySolver<TrackerType,EndgameType,SystemType>
 	// Only re-run setup in that case: re-running unconditionally re-randomizes
 	// gamma and the start system for no reason, and (before Homogenize() was made
 	// idempotent) re-corrupted the prepared target system.
+	// Compare against the collision-free name actually used at construction (the configured
+	// name is a base that UniquePathVariableName may have mangled), so an unchanged config
+	// does not spuriously look like a rename and force a rebuild.
+	auto const effective_path_variable_name =
+	    UniquePathVariableName(this->TargetSystem(), this->template Get<ZeroDimConf>().path_variable_name);
 	if (!Homotopy().HavePathVariable()
-	    || Homotopy().GetPathVariable()->name() != this->template Get<ZeroDimConf>().path_variable_name)
+	    || Homotopy().GetPathVariable()->name() != effective_path_variable_name)
 	{
 		DefaultSystemSetup();
 	}

--- a/core/include/bertini2/naming.hpp
+++ b/core/include/bertini2/naming.hpp
@@ -32,9 +32,19 @@
 
  These predicates are shared by the classic Qi grammar (see
  io/parsing/unicode_ident.hpp) and the object model (`node::Variable`), so the
- parser and direct construction agree on exactly what a name may be.  Emoji are
- symbol-category code points, not letters, so they are rejected by default; the
- two predicates below are the single opt-in point if that ever changes.
+ parser and direct construction agree on exactly what a name may be.
+
+ Emoji are allowed too (yes, really).  A "multipoint" emoji -- skin-toned (👍🏽),
+ ZWJ-joined (👩‍👩‍👧), a flag (🇺🇸), or variation-selected (❤️) -- is a *sequence*
+ of code points, not one character, in every encoding; UTF-16/UTF-32 would not
+ collapse it (we already decode to code points).  Rather than run full Unicode
+ grapheme segmentation (UAX #29, which needs break-property tables / ICU), we take
+ the pragmatic route: an emoji base code point may START a name, and the sequence
+ "glue" code points (ZWJ, variation selectors, skin-tone modifiers, regional
+ indicators, enclosing keycap) may CONTINUE one, so a whole emoji sequence reads
+ as a single contiguous identifier.  This is not strict UAX #29, but it is more
+ than good enough for variable names.  (Name identity is still by exact code-point
+ sequence; NFC normalization of names is a separate, deeper concern.)
  */
 
 #pragma once
@@ -47,19 +57,46 @@
 
 namespace bertini {
 
+namespace detail {
+
+/// \brief True if \p cp is in a primary emoji / pictographic range, so a name may
+///        start with it (🎉, 👍, ❤, ⭐, a regional-indicator letter, ...).
+inline bool IsEmojiBase(char32_t cp)
+{
+	return (cp >= 0x1F000 && cp <= 0x1FAFF)   // emoticons, pictographs, transport, supplemental & extended-A (incl. skin tones, regional indicators)
+	    || (cp >= 0x2600  && cp <= 0x27BF)    // miscellaneous symbols + dingbats (☀ ❤ ✨ ✅ ...)
+	    || (cp >= 0x2B00  && cp <= 0x2BFF);   // miscellaneous symbols and arrows (⭐ ⬅ ...)
+}
+
+/// \brief True if \p cp only *extends* an emoji cluster -- valid mid-name to glue a
+///        multi-code-point emoji, but not meaningful as a name's first character.
+inline bool IsEmojiGlue(char32_t cp)
+{
+	return cp == 0x200D              // ZERO WIDTH JOINER (👩‍👩‍👧)
+	    || cp == 0xFE0E || cp == 0xFE0F  // variation selectors 15 / 16 (❤️)
+	    || cp == 0x20E3;            // combining enclosing keycap
+	// skin-tone modifiers (U+1F3FB..FF) and regional indicators (U+1F1E6..FF) are
+	// already covered by IsEmojiBase, so they continue a name via that predicate.
+}
+
+} // namespace detail
+
 /// \brief True if code point \p cp may START an identifier: any Unicode letter
-///        (ASCII `A-Z a-z`, plus Ω, α, CJK, ...).
+///        (ASCII `A-Z a-z`, plus Ω, α, CJK, ...) or an emoji base code point.
 inline bool IsIdentStart(char32_t cp)
 {
-	return boost::spirit::char_encoding::unicode::isalpha(cp);
+	return boost::spirit::char_encoding::unicode::isalpha(cp)
+	    || detail::IsEmojiBase(cp);
 }
 
 /// \brief True if code point \p cp may CONTINUE an identifier: any Unicode
-///        alphanumeric, or one of the legacy continuation characters `[ ] _`.
+///        alphanumeric, one of the legacy continuation characters `[ ] _`, or an
+///        emoji base / sequence-glue code point (so a whole emoji reads as one name).
 inline bool IsIdentCont(char32_t cp)
 {
 	return boost::spirit::char_encoding::unicode::isalnum(cp)
-	    || cp == U'[' || cp == U']' || cp == U'_';
+	    || cp == U'[' || cp == U']' || cp == U'_'
+	    || detail::IsEmojiBase(cp) || detail::IsEmojiGlue(cp);
 }
 
 /// \brief True if \p s is a well-formed identifier: nonempty, a valid UTF-8

--- a/core/include/bertini2/naming.hpp
+++ b/core/include/bertini2/naming.hpp
@@ -1,0 +1,102 @@
+//This file is part of Bertini 2.
+//
+//bertini2/naming.hpp is free software: you can redistribute it and/or modify
+//it under the terms of the GNU General Public License as published by
+//the Free Software Foundation, either version 3 of the License, or
+//(at your option) any later version.
+//
+//bertini2/naming.hpp is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//GNU General Public License for more details.
+//
+//You should have received a copy of the GNU General Public License
+//along with bertini2/naming.hpp.  If not, see <http://www.gnu.org/licenses/>.
+//
+// Copyright(C) Bertini2 Development Team
+//
+// See <http://www.gnu.org/licenses/> for a copy of the license,
+// as well as COPYING.  Bertini2 is provided with permitted
+// additional terms in the b2/licenses/ directory.
+
+
+/**
+ \file bertini2/naming.hpp
+
+ \brief The single policy for what makes a legal identifier (variable/symbol name).
+
+ A name is UTF-8: it starts with a Unicode letter (ASCII `A-Z a-z`, or Ω, α, CJK,
+ ...) and continues with Unicode alphanumerics or `[ ] _`.  Classification decodes
+ code points to UTF-32 (`boost::u8_to_u32_iterator`) and tests Unicode character
+ properties -- never `wchar_t` / the platform locale (the cp1252/latin-1 footgun).
+
+ These predicates are shared by the classic Qi grammar (see
+ io/parsing/unicode_ident.hpp) and the object model (`node::Variable`), so the
+ parser and direct construction agree on exactly what a name may be.  Emoji are
+ symbol-category code points, not letters, so they are rejected by default; the
+ two predicates below are the single opt-in point if that ever changes.
+ */
+
+#pragma once
+
+#include <string>
+#include <stdexcept>
+
+#include <boost/regex/pending/unicode_iterator.hpp>
+#include <boost/spirit/home/support/char_encoding/unicode.hpp>
+
+namespace bertini {
+
+/// \brief True if code point \p cp may START an identifier: any Unicode letter
+///        (ASCII `A-Z a-z`, plus Ω, α, CJK, ...).
+inline bool IsIdentStart(char32_t cp)
+{
+	return boost::spirit::char_encoding::unicode::isalpha(cp);
+}
+
+/// \brief True if code point \p cp may CONTINUE an identifier: any Unicode
+///        alphanumeric, or one of the legacy continuation characters `[ ] _`.
+inline bool IsIdentCont(char32_t cp)
+{
+	return boost::spirit::char_encoding::unicode::isalnum(cp)
+	    || cp == U'[' || cp == U']' || cp == U'_';
+}
+
+/// \brief True if \p s is a well-formed identifier: nonempty, a valid UTF-8
+///        IsIdentStart code point followed by zero or more IsIdentCont code
+///        points.  Rejects the empty string, leading digits, operators,
+///        whitespace, and malformed UTF-8.
+inline bool IsValidVariableName(std::string const& s)
+{
+	if (s.empty())
+		return false;
+	try
+	{
+		boost::u8_to_u32_iterator<std::string::const_iterator> it(s.begin(), s.begin(), s.end());
+		boost::u8_to_u32_iterator<std::string::const_iterator> end(s.end(), s.begin(), s.end());
+		if (it == end || !IsIdentStart(*it))
+			return false;
+		for (++it; it != end; ++it)
+			if (!IsIdentCont(*it))
+				return false;
+		return true;
+	}
+	catch (...)
+	{
+		return false; // malformed UTF-8
+	}
+}
+
+/// \brief Throw std::runtime_error if \p s is not a valid variable name (\see
+///        IsValidVariableName).  A no-op for a valid name.
+inline void ThrowIfInvalidVariableName(std::string const& s)
+{
+	if (!IsValidVariableName(s))
+		throw std::runtime_error(
+			"invalid variable name \"" + s + "\": a name must be a nonempty identifier -- "
+			"it starts with a letter (ASCII or Unicode, e.g. x or \xCE\xA9) and continues with "
+			"letters, digits, or [ ] _ .  Expressions, operators, whitespace, and leading "
+			"digits are not allowed.");
+}
+
+} // namespace bertini

--- a/core/include/bertini2/system/system.hpp
+++ b/core/include/bertini2/system/system.hpp
@@ -33,6 +33,8 @@
 
 #include <assert.h>
 #include <vector>
+#include <set>
+#include <string>
 
 
 #include <boost/archive/text_oarchive.hpp>
@@ -1210,6 +1212,22 @@ namespace bertini {
 		const Var& GetPathVariable() const;
 
 		/**
+		 \brief Collect the names of every variable the user could reference.
+
+		 Gathers names from all variable groups (ungrouped, affine, projective),
+		 the homogenizing variables, and the implicit parameters.  Reads the raw
+		 group members directly, so it is safe on a partially-built or
+		 not-yet-homogenized system (unlike VariableOrdering, which throws on a
+		 hom-var/affine-group mismatch).  The path variable itself is not included.
+
+		 Used to guarantee an auto-constructed homotopy's path variable never
+		 collides with a user variable.  \see UniquePathVariableName, AddPathVariable.
+
+		 \return The set of variable/parameter names in the system.
+		 */
+		std::set<std::string> VariableNameSet() const;
+
+		/**
 		 Order the variables, by the order in which the groups were added.
 
 		 This function returns the variables in First In First Out (FIFO) ordering.
@@ -2036,6 +2054,22 @@ namespace bertini {
 
 
 	/**
+	\brief Produce a path-variable name guaranteed not to collide with any variable in `target`.
+
+	Returns `base` if `target` has no variable of that name; otherwise appends `_1`, `_2`, ...
+	to `base` and returns the first candidate absent from the system's VariableNameSet.  The
+	result is deterministic (depends only on `target`'s variable names and `base`), so a caller
+	that must recompute it later -- e.g. to decide whether a homotopy needs rebuilding -- gets the
+	same answer.  Used by the auto-construct homotopy path so a user variable named `t` (or even
+	the zero-dim sentinel name) can never clash with the injected path variable.
+
+	\param target The system whose variable names must be avoided.
+	\param base The desired path-variable name (mangled only if it collides).
+	\return A name not present in `target.VariableNameSet()`.
+	*/
+	std::string UniquePathVariableName(System const& target, std::string base = "t");
+
+	/**
 	\brief Form the gamma-trick straight-line homotopy H = (1-t)*target + gamma*t*start.
 
 	The path variable `t` (named `path_variable_name`) is added to the returned homotopy, tracked
@@ -2049,11 +2083,14 @@ namespace bertini {
 
 	\param target The target system (H at t=0).
 	\param start The start system whose solutions seed the homotopy (H at t=1).
-	\param path_variable_name The name to give the homotopy's path variable.
+	\param path_variable_name The name to give the homotopy's path variable.  Defaults to empty,
+	       meaning "choose a safe name": a collision-free name based on `t` is generated via
+	       UniquePathVariableName(target).  Pass a non-empty name to force it (it must not collide
+	       with a variable in `target`, or AddPathVariable throws).
 	\param gamma The gamma coefficient (a node).  If null, a random rational gamma is generated.
 	*/
 	System MakeHomotopy(System const& target, System const& start,
-	                    std::string const& path_variable_name = "t",
+	                    std::string const& path_variable_name = "",
 	                    std::shared_ptr<node::Node> const& gamma = nullptr);
 
 	/**
@@ -2079,11 +2116,14 @@ namespace bertini {
 	\param fixed The equations that do not move (evaluated once per point).
 	\param start_moving The moving rows at t=1 (their roots, with `fixed`, are the start points).
 	\param end_moving The moving rows at t=0 (the target rows).
-	\param path_variable_name The name to give the homotopy's path variable.
+	\param path_variable_name The name to give the homotopy's path variable.  Defaults to empty,
+	       meaning "choose a safe name": a collision-free name based on `t` is generated via
+	       UniquePathVariableName(fixed).  Pass a non-empty name to force it (it must not collide
+	       with a variable in `fixed`, or AddPathVariable throws).
 	\param gamma The gamma coefficient (a node).  If null, a random rational gamma is generated.
 	*/
 	System MakeMovingHomotopy(System const& fixed, System const& start_moving, System const& end_moving,
-	                          std::string const& path_variable_name = "t",
+	                          std::string const& path_variable_name = "",
 	                          std::shared_ptr<node::Node> const& gamma = nullptr);
 
 	/**

--- a/core/src/function_tree/symbols/variable.cpp
+++ b/core/src/function_tree/symbols/variable.cpp
@@ -27,15 +27,22 @@
 #include "bertini2/function_tree/symbols/variable.hpp"
 
 #include "bertini2/eigen_extensions.hpp"
+#include "bertini2/naming.hpp"
 
 
 
 namespace bertini{
 	namespace node{
 		using ::pow;
-		
+
+// The single funnel for a named Variable (Make("...") reaches here): reject a name
+// that is not a well-formed identifier, so an expression/operator/whitespace/leading-
+// digit string can never become a variable.  The default ctor's placeholder and
+// serialization (which restores the name directly) do not pass through here.
 Variable::Variable(std::string new_name) : NamedSymbol(new_name)
-{ }
+{
+	ThrowIfInvalidVariableName(new_name);
+}
 
 Variable::Variable() : NamedSymbol("unnamed_variable_be_scared")
 { }

--- a/core/src/system/system.cpp
+++ b/core/src/system/system.cpp
@@ -701,8 +701,35 @@ namespace bertini
 
 
 
+	std::set<std::string> System::VariableNameSet() const
+	{
+		std::set<std::string> names;
+		auto add_group = [&names](VariableGroup const& g) {
+			for (auto const& v : g)
+				if (v)
+					names.insert(v->name());
+		};
+		add_group(ungrouped_variables_);
+		for (auto const& g : variable_groups_)
+			add_group(g);
+		for (auto const& g : hom_variable_groups_)
+			add_group(g);
+		add_group(homogenizing_variables_);
+		add_group(implicit_parameters_);
+		return names;
+	}
+
+
 	void System::AddPathVariable(Var const& v)
 	{
+		// A homotopy's path variable must never share a name with a user variable
+		// (else references to the name are ambiguous, and it corrupts hash-consing).
+		// Auto-constructed homotopies avoid this via UniquePathVariableName; this is
+		// the backstop for any caller (all homotopy builders funnel through here).
+		if (v && VariableNameSet().count(v->name()))
+			throw std::runtime_error("System::AddPathVariable: path-variable name \"" + v->name()
+				+ "\" collides with an existing system variable.  Choose a different name "
+				  "(see UniquePathVariableName).");
 		path_variable_ = v;
 		InvalidateDifferentiation();
 		have_path_variable_ = true;
@@ -1683,11 +1710,30 @@ namespace bertini
 	}
 
 
+	std::string UniquePathVariableName(System const& target, std::string base)
+	{
+		auto const names = target.VariableNameSet();
+		if (!names.count(base))
+			return base;
+		for (unsigned long k = 1; ; ++k)
+		{
+			std::string candidate = base + "_" + std::to_string(k);
+			if (!names.count(candidate))
+				return candidate;
+		}
+	}
+
+
 	System MakeHomotopy(System const& target, System const& start,
 	                    std::string const& path_variable_name,
 	                    std::shared_ptr<node::Node> const& gamma)
 	{
-		auto t = node::Variable::Make(path_variable_name);
+		// Empty name means "choose a safe one": never inject a bare `t` that could
+		// collide with a user variable of the same name.
+		std::string const effective_name = path_variable_name.empty()
+			? UniquePathVariableName(target, "t")
+			: path_variable_name;
+		auto t = node::Variable::Make(effective_name);
 		auto g = gamma ? gamma
 		               : std::static_pointer_cast<node::Node>(node::Complex::Make(bertini::multiprecision::RandomUnit(MaxPrecisionAllowed())));  // gamma trick: norm-1 complex at max precision (a Complex node caps at its creation precision, so generate the constant at the AMP ceiling -- like patch coefficients -- rather than the current default)
 
@@ -1771,7 +1817,11 @@ namespace bertini
 					+ "`) is identical in start_moving and end_moving, so it does not move; put "
 					"non-moving equations in `fixed` instead.");
 
-		auto t = node::Variable::Make(path_variable_name);
+		// Empty name means "choose a safe one" relative to the fixed system's variables.
+		std::string const effective_name = path_variable_name.empty()
+			? UniquePathVariableName(fixed, "t")
+			: path_variable_name;
+		auto t = node::Variable::Make(effective_name);
 		auto g = gamma ? gamma
 		               : std::static_pointer_cast<node::Node>(node::Complex::Make(bertini::multiprecision::RandomUnit(MaxPrecisionAllowed())));  // gamma trick: norm-1 complex at max precision (a Complex node caps at its creation precision, so generate the constant at the AMP ceiling -- like patch coefficients -- rather than the current default)
 

--- a/core/test/classes/system_test.cpp
+++ b/core/test/classes/system_test.cpp
@@ -1834,6 +1834,83 @@ BOOST_AUTO_TEST_CASE(system_symbolic_jacobian_internal_includes_patch)
 }
 
 
+// ---- path-variable / user-variable collision avoidance ----
+// An auto-constructed homotopy's path variable must never share a name with a user
+// variable.  UniquePathVariableName generates a collision-free name; AddPathVariable
+// throws if a chosen name collides (the backstop all homotopy builders funnel through).
+
+BOOST_AUTO_TEST_CASE(unique_path_variable_name_passes_through_when_free)
+{
+	Var x = Variable::Make("x");
+	Var y = Variable::Make("y");
+	System sys;
+	sys.AddVariableGroup(VariableGroup{x, y});
+	BOOST_CHECK_EQUAL(UniquePathVariableName(sys, "t"), std::string("t"));
+}
+
+BOOST_AUTO_TEST_CASE(unique_path_variable_name_avoids_existing_t)
+{
+	Var t  = Variable::Make("t");
+	Var t1 = Variable::Make("t_1");
+	System sys;
+	sys.AddVariableGroup(VariableGroup{t});
+	BOOST_CHECK_EQUAL(UniquePathVariableName(sys, "t"), std::string("t_1"));
+
+	System sys2;
+	sys2.AddVariableGroup(VariableGroup{t, t1});
+	BOOST_CHECK_EQUAL(UniquePathVariableName(sys2, "t"), std::string("t_2"));
+}
+
+BOOST_AUTO_TEST_CASE(add_path_variable_colliding_name_throws)
+{
+	Var x = Variable::Make("x");
+	Var t = Variable::Make("t");
+	System S;
+	S.AddVariableGroup(VariableGroup{x, t});   // user variable named "t"
+	Var collider = Variable::Make("t");
+	BOOST_CHECK_THROW(S.AddPathVariable(collider), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(add_path_variable_noncolliding_ok)
+{
+	Var x = Variable::Make("x");
+	System S;
+	S.AddVariableGroup(VariableGroup{x});
+	Var s = Variable::Make("s");
+	BOOST_CHECK_NO_THROW(S.AddPathVariable(s));
+	BOOST_CHECK(S.HavePathVariable());
+}
+
+BOOST_AUTO_TEST_CASE(make_homotopy_auto_names_a_safe_path_variable)
+{
+	Var x = Variable::Make("x");
+	System target;
+	target.AddVariableGroup(VariableGroup{x});
+	target.AddFunction(x*x - 1);
+	System start;
+	start.AddVariableGroup(VariableGroup{x});
+	start.AddFunction(x - 1);
+
+	auto H = MakeHomotopy(target, start);   // empty name -> auto-choose a safe one
+	BOOST_CHECK(H.HavePathVariable());
+	BOOST_CHECK_EQUAL(H.GetPathVariable()->name(), std::string("t")); // "t" is free (only variable is x)
+}
+
+BOOST_AUTO_TEST_CASE(make_homotopy_with_colliding_pathvar_throws)
+{
+	Var x = Variable::Make("x");
+	System target;
+	target.AddVariableGroup(VariableGroup{x});
+	target.AddFunction(x*x - 1);
+	System start;
+	start.AddVariableGroup(VariableGroup{x});
+	start.AddFunction(x - 1);
+
+	// Forcing the path variable to be "x" collides with the user variable x.
+	BOOST_CHECK_THROW(MakeHomotopy(target, start, "x"), std::runtime_error);
+}
+
+
 BOOST_AUTO_TEST_SUITE_END()
 
 

--- a/core/test/classes/system_test.cpp
+++ b/core/test/classes/system_test.cpp
@@ -1834,6 +1834,28 @@ BOOST_AUTO_TEST_CASE(system_symbolic_jacobian_internal_includes_patch)
 }
 
 
+// ---- variable-name validation ----
+// A Variable's name must be a well-formed identifier; an expression, operator,
+// whitespace, leading digit, or empty string is rejected at construction.
+
+BOOST_AUTO_TEST_CASE(variable_name_expression_is_rejected)
+{
+	BOOST_CHECK_THROW(Variable::Make("x^2+1"), std::runtime_error);
+	BOOST_CHECK_THROW(Variable::Make("2x"),    std::runtime_error);
+	BOOST_CHECK_THROW(Variable::Make("a b"),   std::runtime_error);
+	BOOST_CHECK_THROW(Variable::Make(""),      std::runtime_error);
+	BOOST_CHECK_THROW(Variable::Make(") ; x"), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(variable_name_valid_identifiers_accepted)
+{
+	BOOST_CHECK_NO_THROW(Variable::Make("x"));
+	BOOST_CHECK_NO_THROW(Variable::Make("x_1"));
+	BOOST_CHECK_NO_THROW(Variable::Make("x[0]"));
+	BOOST_CHECK_NO_THROW(Variable::Make("\xCE\xA9")); // Ω
+}
+
+
 // ---- path-variable / user-variable collision avoidance ----
 // An auto-constructed homotopy's path variable must never share a name with a user
 // variable.  UniquePathVariableName generates a collision-free name; AddPathVariable

--- a/core/test/classes/system_test.cpp
+++ b/core/test/classes/system_test.cpp
@@ -1852,7 +1852,8 @@ BOOST_AUTO_TEST_CASE(variable_name_valid_identifiers_accepted)
 	BOOST_CHECK_NO_THROW(Variable::Make("x"));
 	BOOST_CHECK_NO_THROW(Variable::Make("x_1"));
 	BOOST_CHECK_NO_THROW(Variable::Make("x[0]"));
-	BOOST_CHECK_NO_THROW(Variable::Make("\xCE\xA9")); // Ω
+	BOOST_CHECK_NO_THROW(Variable::Make("\xCE\xA9"));         // Ω
+	BOOST_CHECK_NO_THROW(Variable::Make("\xF0\x9F\x8E\x89")); // 🎉 (emoji)
 }
 
 

--- a/core/test/classic/classic_parsing_test.cpp
+++ b/core/test/classic/classic_parsing_test.cpp
@@ -708,7 +708,12 @@ namespace {
 	const std::string kOmega = "\xCE\xA9";         // U+03A9 GREEK CAPITAL LETTER OMEGA
 	const std::string kAlpha = "\xCE\xB1";         // U+03B1 GREEK SMALL LETTER ALPHA
 	const std::string kCJK   = "\xE4\xB8\xAD";     // U+4E2D
-	const std::string kParty = "\xF0\x9F\x8E\x89"; // U+1F389 PARTY POPPER (an emoji, not a letter)
+	const std::string kParty = "\xF0\x9F\x8E\x89"; // U+1F389 PARTY POPPER (single-code-point emoji)
+	// 👍🏽 = THUMBS UP (U+1F44D) + skin-tone modifier (U+1F3FD): a two-code-point emoji.
+	const std::string kThumbsToned = "\xF0\x9F\x91\x8D" "\xF0\x9F\x8F\xBD";
+	// 👩‍👩‍👧 = WOMAN + ZWJ + WOMAN + ZWJ + GIRL: a five-code-point ZWJ sequence.
+	const std::string kFamily = "\xF0\x9F\x91\xA9" "\xE2\x80\x8D" "\xF0\x9F\x91\xA9"
+	                            "\xE2\x80\x8D" "\xF0\x9F\x91\xA7";
 }
 
 BOOST_AUTO_TEST_CASE(unicode_variable_group_omega_parses)
@@ -781,14 +786,29 @@ BOOST_AUTO_TEST_CASE(utf8_bom_is_stripped)
 	BOOST_CHECK_EQUAL(sys.NumNaturalFunctions(), 1u);
 }
 
-BOOST_AUTO_TEST_CASE(emoji_variable_rejected_by_default)
+BOOST_AUTO_TEST_CASE(emoji_variable_parses)
 {
-	// Emoji are symbol-category code points, not letters, so they are NOT valid
-	// identifiers under the default policy.
-	std::string input = "variable_group " + kParty + ";\n"
+	// Single-code-point emoji are valid identifiers.
+	std::string input = "variable_group " + kParty + ", y;\n"
 	                    "function f;\n"
-	                    "f = " + kParty + ";\n";
-	BOOST_CHECK_THROW(bertini::System sys{ input }, std::runtime_error);
+	                    "f = " + kParty + " + y;\n";
+	bertini::System sys{ input };
+	BOOST_CHECK_EQUAL(sys.NumVariables(), 2u);
+	BOOST_CHECK(sys.VariableNameSet().count(kParty) == 1);
+}
+
+BOOST_AUTO_TEST_CASE(multipoint_emoji_variable_parses)
+{
+	// A multi-code-point emoji (skin-toned, and a ZWJ sequence) reads as ONE
+	// contiguous identifier -- the whole byte sequence is the variable's name.
+	std::string input = "variable_group " + kThumbsToned + ", " + kFamily + ";\n"
+	                    "function f;\n"
+	                    "f = " + kThumbsToned + " + " + kFamily + ";\n";
+	bertini::System sys{ input };
+	BOOST_CHECK_EQUAL(sys.NumVariables(), 2u);
+	auto names = sys.VariableNameSet();
+	BOOST_CHECK(names.count(kThumbsToned) == 1);   // not split at the skin-tone modifier
+	BOOST_CHECK(names.count(kFamily) == 1);        // not split at the ZWJs
 }
 
 

--- a/core/test/classic/classic_parsing_test.cpp
+++ b/core/test/classic/classic_parsing_test.cpp
@@ -30,6 +30,7 @@
 #include <bertini2/io/parsing/system_parsers.hpp>
 #include <bertini2/io/classic_writer.hpp>
 #include <string>
+#include <set>
 #include <fstream>
 #include <boost/filesystem.hpp>
 #include <boost/test/unit_test.hpp>
@@ -694,6 +695,100 @@ BOOST_AUTO_TEST_CASE(file_with_percent_comments_parses)
 	bertini::parsing::classic::parse(iter, end, sys);
 	BOOST_CHECK_EQUAL(sys.NumNaturalFunctions(), 2u);
 	BOOST_CHECK_EQUAL(sys.NumVariables(), 2u);
+}
+
+
+// ---- Unicode (UTF-8) identifier support ----
+// The classic grammar accepts Unicode *letters* as identifiers (Ω, α, CJK, ...),
+// storing names as their raw UTF-8 bytes.  UTF-8 is spelled with byte escapes so
+// the source stays plain ASCII (portable across compilers), and inputs are built
+// by std::string concatenation so a hex escape never swallows a following digit.
+// See io/parsing/unicode_ident.hpp.
+namespace {
+	const std::string kOmega = "\xCE\xA9";         // U+03A9 GREEK CAPITAL LETTER OMEGA
+	const std::string kAlpha = "\xCE\xB1";         // U+03B1 GREEK SMALL LETTER ALPHA
+	const std::string kCJK   = "\xE4\xB8\xAD";     // U+4E2D
+	const std::string kParty = "\xF0\x9F\x8E\x89"; // U+1F389 PARTY POPPER (an emoji, not a letter)
+}
+
+BOOST_AUTO_TEST_CASE(unicode_variable_group_omega_parses)
+{
+	std::string input = "variable_group " + kOmega + ", " + kAlpha + ";\n"
+	                    "function f;\n"
+	                    "f = " + kOmega + "^2 + " + kAlpha + "^2 - 1;\n";
+	bertini::System sys{ input };
+	BOOST_CHECK_EQUAL(sys.NumNaturalFunctions(), 1u);
+	BOOST_CHECK_EQUAL(sys.NumVariables(), 2u);
+	auto names = sys.VariableNameSet();
+	BOOST_CHECK(names.count(kOmega) == 1);
+	BOOST_CHECK(names.count(kAlpha) == 1);
+}
+
+BOOST_AUTO_TEST_CASE(unicode_name_roundtrips_utf8)
+{
+	using namespace bertini;
+	std::string input = "variable_group " + kOmega + ";\n"
+	                    "function f;\n"
+	                    "f = " + kOmega + "^2 - 2;\n";
+	System sys{ input };
+	std::string emitted = classic::SystemToClassic(sys);   // the classic writer emits UTF-8
+	BOOST_CHECK(emitted.find(kOmega) != std::string::npos);
+}
+
+BOOST_AUTO_TEST_CASE(unicode_cjk_variable_parses)
+{
+	std::string input = "variable_group " + kCJK + ", y;\n"
+	                    "function f;\n"
+	                    "f = " + kCJK + " + y;\n";
+	bertini::System sys{ input };
+	BOOST_CHECK_EQUAL(sys.NumVariables(), 2u);
+	BOOST_CHECK(sys.VariableNameSet().count(kCJK) == 1);
+}
+
+BOOST_AUTO_TEST_CASE(unicode_mixed_ascii_unicode_identifier)
+{
+	// A single identifier mixing ASCII and Unicode letters/digits.
+	std::string ident = "x" + kOmega + "1";
+	std::string input = "variable_group " + ident + ", y;\n"
+	                    "function f;\n"
+	                    "f = " + ident + " + y;\n";
+	bertini::System sys{ input };
+	BOOST_CHECK_EQUAL(sys.NumVariables(), 2u);
+	BOOST_CHECK(sys.VariableNameSet().count(ident) == 1);
+}
+
+BOOST_AUTO_TEST_CASE(unicode_symbol_prefix_not_greedy)
+{
+	// Ω is declared but Ωα is not; the boundary guard stops the known symbol Ω from
+	// matching a prefix of Ωα, so referencing Ωα must fail to parse rather than
+	// silently becoming Ω (leaving α dangling).
+	std::string input = "variable_group " + kOmega + ";\n"
+	                    "function f;\n"
+	                    "f = " + kOmega + kAlpha + ";\n";
+	BOOST_CHECK_THROW(bertini::System sys{ input }, std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(utf8_bom_is_stripped)
+{
+	// A leading UTF-8 BOM must be dropped by System(std::string) so it is not seen
+	// as a stray leading character.
+	std::string input = std::string("\xEF\xBB\xBF") +
+	                    "variable_group x, y;\n"
+	                    "function f;\n"
+	                    "f = x^2 + y^2 - 1;\n";
+	bertini::System sys{ input };
+	BOOST_CHECK_EQUAL(sys.NumVariables(), 2u);
+	BOOST_CHECK_EQUAL(sys.NumNaturalFunctions(), 1u);
+}
+
+BOOST_AUTO_TEST_CASE(emoji_variable_rejected_by_default)
+{
+	// Emoji are symbol-category code points, not letters, so they are NOT valid
+	// identifiers under the default policy.
+	std::string input = "variable_group " + kParty + ";\n"
+	                    "function f;\n"
+	                    "f = " + kParty + ";\n";
+	BOOST_CHECK_THROW(bertini::System sys{ input }, std::runtime_error);
 }
 
 

--- a/python/test/classes/function_tree_test.py
+++ b/python/test/classes/function_tree_test.py
@@ -108,6 +108,12 @@ def test_Variable_expression_name_rejected():
             Variable(bad)
 
 
+def test_Variable_emoji_name():
+    # Emoji are valid names, including multi-code-point ones (skin tone, ZWJ sequence).
+    for good in ("🎉", "👍🏽", "👩‍👩‍👧"):
+        assert str(Variable(good)) == good
+
+
 def test_variables_count():
     v = variables('x', 3)
     assert len(v) == 3

--- a/python/test/classes/function_tree_test.py
+++ b/python/test/classes/function_tree_test.py
@@ -101,6 +101,13 @@ def test_Variable_cjk_name():
     assert str(x) == "中"
 
 
+def test_Variable_expression_name_rejected():
+    # A variable name must be an identifier, not an expression / operator / junk.
+    for bad in ("x^2+1", "2x", "a b", ""):
+        with pytest.raises(RuntimeError):
+            Variable(bad)
+
+
 def test_variables_count():
     v = variables('x', 3)
     assert len(v) == 3

--- a/python/test/classes/function_tree_test.py
+++ b/python/test/classes/function_tree_test.py
@@ -90,6 +90,17 @@ def test_Variable_construct():
     x = Variable("x")
 
 
+def test_Variable_unicode_name():
+    # Names are arbitrary UTF-8; a Unicode letter round-trips through str().
+    x = Variable("Ω")  # Ω
+    assert str(x) == "Ω"
+
+
+def test_Variable_cjk_name():
+    x = Variable("中")  # 中
+    assert str(x) == "中"
+
+
 def test_variables_count():
     v = variables('x', 3)
     assert len(v) == 3

--- a/python/test/classes/parser_test.py
+++ b/python/test/classes/parser_test.py
@@ -56,6 +56,20 @@ def test_create_system():
     sysJac = sys.eval_jacobian(vals)
 
 
+def test_parse_unicode_variable():
+    # The classic parser accepts Unicode letters (Ω, α) as variable names.
+    sys = pp.system('variable_group Ω, α; function f; f = Ω^2 + α^2 - 1;')
+    assert sys.num_variables() == 2
+    vals = np.array((complex(0.3, 0.0), complex(0.4, 0.0)))  # 0.09 + 0.16 - 1 = -0.75
+    assert abs(sys.eval(vals)[0] - (-0.75)) < 1e-12
+
+
+def test_parse_utf8_bom():
+    # A leading UTF-8 BOM is stripped before parsing.
+    sys = pp.system('﻿variable_group x, y; function f; f = x^2 + y^2 - 1;')
+    assert sys.num_variables() == 2
+
+
 def _f_eval(expr, vals):
     """Parse 'f = <expr>' over x,y,z and evaluate at vals."""
     return pp.system(f'function f; variable_group x,y,z; f = {expr};').eval(vals)[0]

--- a/python/test/classes/parser_test.py
+++ b/python/test/classes/parser_test.py
@@ -70,6 +70,14 @@ def test_parse_utf8_bom():
     assert sys.num_variables() == 2
 
 
+def test_parse_emoji_variable():
+    # Emoji variable names parse and evaluate (multi-code-point ones stay intact).
+    sys = pp.system('variable_group 🎉, 👍🏽; function f; f = 🎉^2 + 👍🏽 - 1;')
+    assert sys.num_variables() == 2
+    vals = np.array((complex(0.5, 0.0), complex(0.25, 0.0)))  # 0.25 + 0.25 - 1 = -0.5
+    assert abs(sys.eval(vals)[0] - (-0.5)) < 1e-12
+
+
 def _f_eval(expr, vals):
     """Parse 'f = <expr>' over x,y,z and evaluate at vals."""
     return pp.system(f'function f; variable_group x,y,z; f = {expr};').eval(vals)[0]

--- a/python_bindings/include/parser_export.hpp
+++ b/python_bindings/include/parser_export.hpp
@@ -59,6 +59,8 @@ namespace bertini{
 		template <typename ResultT, typename ParserT>
 		ResultT Parser(std::string str)
 		{
+			// Treat input as UTF-8; drop a leading BOM so it is not parsed as a stray character.
+			bertini::parsing::classic::StripUTF8BOM(str);
 			ResultT res;
 			bertini::parsing::classic::parse(str.begin(), str.end(), res);
 			return res;


### PR DESCRIPTION
## What & why

Several related naming improvements, each prompted by a curiosity from @silviana and each with tests.

### 1. Unicode + emoji variable names in the classic (Bertini 1) parser — `Ω`, `α`, CJK, `🎉`, `👩‍👩‍👧`

The object model and Python bindings already accepted any UTF-8 `std::string` name, but the Boost.Spirit Qi grammar was hard ASCII (`+qi::alpha >> *(qi::alnum | char_("[]_"))`), so Unicode names couldn't round-trip through classic input.

- New `core/include/bertini2/io/parsing/unicode_ident.hpp`: two **self-contained** Spirit.Qi primitives. Each classifies a code point by decoding to UTF-32 via `boost::u8_to_u32_iterator` and Unicode character properties — **never** `wchar_t`/`standard_wide` or the platform locale/ctype (that's the cp1252/latin-1 Windows footgun). Because the source is already UTF-8, a matched identifier's raw bytes *are* the stored name.
  - `utf8_identifier_parser` — matches a whole identifier, attribute `std::string`.
  - `utf8_ident_boundary_parser` — zero-width negative lookahead stopping a known symbol from matching a prefix of a longer identifier (replaces the ASCII `!qi::alnum` guard so a following Unicode letter also blocks the match).
  - *Note:* directly-instantiated custom Qi primitives don't get Spirit's `*`/`!`/`>>` operators without the terminal machinery, so each primitive does its whole job in one `parse()` call.
- Wired into `system_rules.hpp`, `function_rules.hpp`, and the `pathvarname:` rule in `settings_parsers/algorithm.hpp`. UTF-8 BOM stripped at the read boundaries (`FileToString`, `System(std::string const&)`, Python `parse` helper).

**Emoji, including multi-code-point ones.** A skin-toned (`👍🏽`), ZWJ-joined (`👩‍👩‍👧`), flag (`🇺🇸`), or variation-selected (`❤️`) emoji is a *sequence* of code points, not one character — in every encoding (UTF-16/32 don't collapse it; we already decode to code points). Rather than full UAX #29 grapheme segmentation (which needs Unicode break tables / ICU), the pragmatic route: an emoji **base** code point may start a name, and the sequence **glue** code points (ZWJ, variation selectors, skin-tone modifiers, regional indicators, enclosing keycap) may continue one, so a whole emoji sequence reads as a single contiguous identifier. Not strict UAX #29, but more than good enough for names. (Name identity is by exact code-point sequence; NFC normalization is a separate, deeper concern, not done here.)

### 2. Variable names must be well-formed identifiers (object model, not just the parser)

`Variable::Make` accepted *any* string, so `Variable("x^2+1")`, `Variable("2x")`, `Variable("")` all constructed and then got hashed/interned/printed as if they were names.

- Factored the identifier policy into a shared, Spirit-free `core/include/bertini2/naming.hpp` (`IsIdentStart`/`IsIdentCont` + emoji helpers + `IsValidVariableName` + `ThrowIfInvalidVariableName`), so the parser **and** the object model share one definition of a legal name.
- Enforced in the `Variable` string constructor — the single funnel every `Variable::Make("...")` (and the Python `Variable(...)` ctor) reaches.
- The default-ctor placeholder and serialization (name restored directly) are unaffected. Audited every `Variable::Make` site: `HOM_VAR_N`, path variables, `x0/x1` generators, and parser-validated names are all valid identifiers.

### 3. Collision-safe path variables

Auto-constructed homotopies mint a path variable by name; there was no guard against colliding with a user variable, and `MakeHomotopy` defaulted to a bare `"t"`.

- `System::VariableNameSet()` — all user-referenceable names (reads raw group members, safe on a partially-built system).
- Free `UniquePathVariableName(target, base = "t")` — returns `base` if free, else `base_1`, `base_2`, … (deterministic).
- `System::AddPathVariable` now **throws on a name collision** — the backstop every homotopy builder funnels through.
- `MakeHomotopy`/`MakeMovingHomotopy` drop the bare `"t"` default for a `""`-auto sentinel that generates a collision-free name.
- The zero-dim solver treats its `ZERO_DIM_PATH_VARIABLE` sentinel as a *base* (mangled only on collision), with the matching fix to the `ApplyParsedConfigs` rebuild predicate.

## Tests
- **C++** — `classic_parsing_test.cpp`: omega/CJK parse, UTF-8 round-trip, mixed ASCII+Unicode identifier, greedy-boundary guard, BOM strip, single + multipoint emoji parse. `system_test.cpp`: variable-name validation (expression/leading-digit/whitespace/empty rejected; identifiers incl. Ω and emoji accepted), unique-name generator, `AddPathVariable` collision throw/no-throw, `MakeHomotopy` auto-name and colliding-name throw.
- **Python** — `function_tree_test.py`: `Variable("Ω")`/CJK/emoji round-trip, expression-name rejected. `parser_test.py`: parse+eval Unicode- and emoji-variable systems, BOM strip.

## Verification
- `tools/doclint.sh` clean (baseline 0 held).
- C++ suites pass: `test_classic` (27), `test_classes` (494), `test_blackbox`, `test_settings`, `test_nag_algorithms`.
- Python: `function_tree_test.py` + `parser_test.py` (32 passed).
- End-to-end: solved `Ω²+α²−1, Ω−α`; solved a system with `🎉` / `👩‍👩‍👧` (ZWJ-sequence) variables; solved a system whose variable is literally named `ZERO_DIM_PATH_VARIABLE` (auto-uniquified — would have collided before). All 2 solutions.

## Behavior notes
- The settings `pathvarname:` rule previously would skip whitespace *inside* a name (a quirk of that skippered rule). The self-contained parser makes identifiers contiguous — stricter and more correct (whitespace in a variable name is a path to madness). All settings tests still pass.
- Constructing a `Variable` with a non-identifier name now throws where it previously silently succeeded. Intended; any internal caller relying on a junk name would have been erroneous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)