### PR TITLE
Config-model cleanup: max_num_refinements + single-source final_tolerance

### DIFF
--- a/core/include/bertini2/endgames/base_endgame.hpp
+++ b/core/include/bertini2/endgames/base_endgame.hpp
@@ -205,7 +205,7 @@ public:
 		{
 			auto refine_success = this->RefineSample(samples[ii], samples[ii],  times[ii], 
 										this->FinalTolerance() * this->EndgameSettings().sample_point_refinement_factor,
-										this->EndgameSettings().max_num_newton_iterations);
+										this->EndgameSettings().max_num_refinements);
 			if (refine_success != SuccessCode::Success)
 			{
 				// BOOST_LOG_TRIVIAL(severity_level::trace) << "refining failed, code " << int(refine_success);

--- a/core/include/bertini2/endgames/cauchy.hpp
+++ b/core/include/bertini2/endgames/cauchy.hpp
@@ -494,7 +494,7 @@ public:
 
 			// auto refinement_success = this->RefineSample(next_sample, next_sample, next_time,
 			// 							this->FinalTolerance() * this->EndgameSettings().sample_point_refinement_factor,
-			// 							this->EndgameSettings().max_num_newton_iterations);
+			// 							this->EndgameSettings().max_num_refinements);
 			// if (refinement_success != SuccessCode::Success)
 			// {
 			// 	return refinement_success;
@@ -721,8 +721,8 @@ public:
 			this->GetSystem().precision(new_precision);
 		}
 
-		this->GetTracker().Refine(samples.front(),samples.front(),times.front(),this->FinalTolerance(),this->EndgameSettings().max_num_newton_iterations);
-		this->GetTracker().Refine(samples.back(),samples.back(),times.back(),this->FinalTolerance(),this->EndgameSettings().max_num_newton_iterations);
+		this->GetTracker().Refine(samples.front(),samples.front(),times.front(),this->FinalTolerance(),this->EndgameSettings().max_num_refinements);
+		this->GetTracker().Refine(samples.back(),samples.back(),times.back(),this->FinalTolerance(),this->EndgameSettings().max_num_refinements);
 
 		if((samples.front() - samples.back()).template lpNorm<Eigen::Infinity>() < this->GetTracker().TrackingTolerance())
 		{

--- a/core/include/bertini2/endgames/config.hpp
+++ b/core/include/bertini2/endgames/config.hpp
@@ -112,7 +112,7 @@ namespace bertini{ namespace endgame{
 
 		mpq_rational sample_factor{1, 2}; ///< Geometric factor between successive sample times (exact rational).
 
-		unsigned max_num_newton_iterations = 15; ///< Maximum Newton iterations when refining endgame sample points.
+		unsigned max_num_refinements = 15; ///< Maximum Newton refinements when sharpening endgame sample points.
 
 		T final_tolerance = 1e-11;///< The tolerance to which to compute the endpoint using the endgame.
 

--- a/core/include/bertini2/endgames/powerseries.hpp
+++ b/core/include/bertini2/endgames/powerseries.hpp
@@ -643,7 +643,7 @@ public:
 
 		auto refine_success = this->RefineSample(samples.back(), next_sample,  times.back(),
 										this->FinalTolerance() * this->EndgameSettings().sample_point_refinement_factor,
-										this->EndgameSettings().max_num_newton_iterations);
+										this->EndgameSettings().max_num_refinements);
 		if (refine_success != SuccessCode::Success)
 		{
 			// Adaptive-numeric-type: a refine that double cannot satisfy is a request to cross to mpfr.

--- a/core/include/bertini2/nag_algorithms/zero_dim_solve.hpp
+++ b/core/include/bertini2/nag_algorithms/zero_dim_solve.hpp
@@ -1287,6 +1287,13 @@ run the endgame, classify the endpoints, report.  See the forward-declare doc ab
 
 				SetMidpathRetrackTol(this->template Get<Tolerances>().newton_before_endgame);
 
+				// The solver's Tolerances.final_tolerance is the single source of truth for how tightly
+				// a solve converges its endpoints.  Flow it into the endgame here (the endgame keeps its
+				// own EndgameConfig.final_tolerance for standalone, solver-independent use, but under a
+				// solve the solver wins).  Without this the endgame would silently ignore the solver's
+				// final_tolerance -- e.g. a classic-input FinalTol -- and use its own default instead.
+				endgame_.SetFinalTolerance(this->template Get<Tolerances>().final_tolerance);
+
 				// Default the start-point precision to the initial ambient precision.  A caller can
 				// override it via SetStartPointPrecision (e.g. to carry a higher precision forward
 				// from a previous solve whose output feeds this one).

--- a/core/test/nag_algorithms/zero_dim.cpp
+++ b/core/test/nag_algorithms/zero_dim.cpp
@@ -54,8 +54,6 @@ BOOST_AUTO_TEST_CASE(can_run_griewank_osborn)
 	using namespace tracking;
 
 	using Tolerances = algorithm::TolerancesConfig;
-	using EndgameConfT = endgame::EndgameConfig;
-	
 
 	auto sys = system::Precon::GriewankOsborn();
 
@@ -73,12 +71,17 @@ BOOST_AUTO_TEST_CASE(can_run_griewank_osborn)
 	tr.AddObserver(logger);
 
 
-	auto eg = zd.GetFromEndgame<EndgameConfT>();
-	eg.final_tolerance = 1e-12;
-	zd.SetToEndgame(eg);
+	// Tolerances.final_tolerance is the single source of truth; the solver flows it into the
+	// endgame in PreSolveSetup (no need to poke the EndgameConfig directly any more).
+	tols.final_tolerance = 1e-12;
+	zd.Set(tols);
 
 	zd.Solve();
 
+	// The solver's Tolerances.final_tolerance is canonical: PreSolveSetup must have flowed it into
+	// the endgame (before this fix, the endgame ignored it and kept its own EndgameConfig default).
+	BOOST_CHECK_EQUAL(zd.GetFromEndgame<endgame::EndgameConfig>().final_tolerance,
+	                  zd.Get<Tolerances>().final_tolerance);
 
 	bertini::algorithm::output::Classic<decltype(zd)>::All(std::cout, zd);
 }

--- a/python_bindings/src/endgame_config_export.cpp
+++ b/python_bindings/src/endgame_config_export.cpp
@@ -16,7 +16,7 @@ namespace bertini{
 				.def_readwrite("num_sample_points", &endgame::EndgameConfig::num_sample_points,"The number of points to use for extrapolant calculation.  In the Power Series Endgame, the is the number of geometrically spaces points on the path.  For Cauchy, this is the number of points on each circle tracked around the target time value.")
 				.def_readwrite("min_track_time", &endgame::EndgameConfig::min_track_time,"The minimum distance from the target time to track to.  Decreasing this may help failing runs succeed, or maybe not, because you are, after all, tracking toward a singularity.")
 				.def_readwrite("sample_factor", &endgame::EndgameConfig::sample_factor,"The factor by which to space the geometrically spaced 'distance' between sample points, or sample circles for Cauchy.")
-				.def_readwrite("max_num_newton_iterations", &endgame::EndgameConfig::max_num_newton_iterations,"the maximum number of newton iterations to be taken during sample point sharpening.  Increasing this can help speed convergence, at the risk of path jumping.")
+				.def_readwrite("max_num_refinements", &endgame::EndgameConfig::max_num_refinements,"the maximum number of Newton refinements to be taken during sample point sharpening.  Increasing this can help speed convergence, at the risk of path jumping.")
 				.def_readwrite("final_tolerance", &endgame::EndgameConfig::final_tolerance, "The tolerance to which to track the path, using the endgame.  Endgames require two consecutive estimates to be this close to each other under the relative infinity norm.  Default value is 1e-11.")
 				;
 


### PR DESCRIPTION
Two small config-model fixes, split out of the namespace-flattening PR (#65) because they touch the C++ core and carry their own numerics testing.

## 1. Rename `EndgameConfig.max_num_newton_iterations` → `max_num_refinements`
The endgame field counts Newton *refinements* of sample points, and its name collided with `tracking::NewtonConfig.max_num_newton_iterations` — a genuinely different setting (the tracker's per-correction Newton iterations). The rename says what it is; the Newton/tracker field is untouched. Touches the declaration, the `EndgameSettings()` call sites (`base_endgame`/`powerseries`/`cauchy`), and the Python property. No parser impact (the EndgameConfig classic parser never read it) and no test edits (endgame tests set `NewtonConfig`, not `EndgameConfig`).

## 2. Make `Tolerances.final_tolerance` the single source of truth
`EndgameConfig.final_tolerance` and `TolerancesConfig.final_tolerance` were **fully independent**: a solve's `Tolerances.final_tolerance` (e.g. from a classic-input `FinalTol`) never reached the endgame, which silently kept its own default. They agreed only by luck (both `1e-11`). Set `FinalTol: 1e-9` and the endgame still converged to `1e-11` — a latent bug.

Fix: the solver's `Tolerances.final_tolerance` is now canonical — flowed into the endgame in `PreSolveSetup()` (the common pre-solve path, right where the solver already pushes `newton_before_endgame` into the tracker). The endgame **keeps** its own `EndgameConfig.final_tolerance` for standalone, solver-independent use (e.g. the `manual_endgame_usage` tutorial constructs an endgame directly on a tracker with no solver); under a solve, the solver wins.

This is a **behavior change (bugfix):** classic inputs that set `FinalTol` will now actually converge the endgame to that tolerance.

## Verification
- Core C++ suites pass: `test_settings` (12), `test_endgames` (363), `test_nag_algorithms` — including a new assertion that the solver's `final_tolerance` reaches the endgame.
- Python `pytest`: 588 passed.
- `bash tools/doclint.sh`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)