### PR TITLE
fix(trackers): fully initialize default AMPConfig (deterministic epsilon/Phi/Psi)

### DIFF
--- a/core/include/bertini2/trackers/config.hpp
+++ b/core/include/bertini2/trackers/config.hpp
@@ -258,8 +258,17 @@ namespace tracking{
 		}
 
 		/// \brief Construct with default AMP bounds and safety digits.
-		AdaptiveMultiplePrecisionConfig() : coefficient_bound(1000), degree_bound(5), safety_digits_1(1), safety_digits_2(1), maximum_precision(300)
-		{}
+		///
+		/// epsilon, Phi, and Psi are error bounds that are normally recomputed from the
+		/// system before tracking (\see SetAMPConfigFrom).  They are nonetheless initialized
+		/// here so that a default-constructed config is fully deterministic: epsilon takes the
+		/// single-variable value (\f$1^2\f$), and Phi/Psi are derived from the default bounds so
+		/// the object is internally consistent.  Leaving them uninitialized produced garbage
+		/// (e.g. NaN) that broke value comparison and pickle round-tripping.
+		AdaptiveMultiplePrecisionConfig() : coefficient_bound(1000), degree_bound(5), epsilon(1), safety_digits_1(1), safety_digits_2(1), maximum_precision(300)
+		{
+			SetPhiPsiFromBounds();
+		}
 
 		/// \brief Construct AMP settings derived from a system's bounds.
 		explicit


### PR DESCRIPTION
## Problem

`Test wheel on windows-3.13` intermittently fails on `pickle_test.py::test_config_struct_round_trips[AMPConfig]` — two objects print **identically** yet compare unequal:

```
assert AMPConfig(..., epsilon=nan, phi=0.0, psi=2.121995841e-314, ...)
    == AMPConfig(..., epsilon=nan, phi=0.0, psi=2.121995841e-314, ...)
```

`psi=2.12e-314` (denormal) and `epsilon=nan` are **uninitialized memory**. Equality fails because `operator==` compares `epsilon`, and `nan != nan`. Same commit passes one run, fails the next — it only bites when the garbage lands as NaN.

## Root cause

`AdaptiveMultiplePrecisionConfig`'s default constructor set the bounds and safety digits but left **`epsilon`, `Phi`, `Psi` uninitialized**.

## Fix

These bounds are always recomputed from the system before tracking (`AMPConfigFrom` / `SetAMPConfigFrom`), so the defaults are placeholders — but a public default-constructed config must still be deterministic. Initialize `epsilon` to the single-variable value (`1`) and derive `Phi`/`Psi` from the default bounds via the existing `SetPhiPsiFromBounds()`:

```
epsilon = 1, Phi = 20000 (= D(D-1)B), Psi = 5000 (= D·B)
```

## Verification

- `pickle_test.py` 17/17; full `pytest` green (bar the pre-existing editable-build CLI-binary tests, unrelated).
- `bash tools/doclint.sh` clean; bindings recompile clean.

Merging this into `develop` clears the flaky Windows-3.13 failure on #238.

🤖 Generated with [Claude Code](https://claude.com/claude-code)