### PR TITLE
perf(linalg): stateful in-place multiprecision LU solver (replaces Eigen in the tracker)

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -806,6 +806,7 @@ if (ENABLE_UNIT_TESTING)
 		test/classes/system_identity_test.cpp
 		test/classes/slp_test.cpp
 		test/classes/slp_intern_test.cpp
+		test/classes/lu_bench_test.cpp
 		test/classes/eval_expression_test.cpp
 		test/classes/named_expression_test.cpp
 		test/classes/homogenization_test.cpp

--- a/core/include/bertini2/linalg/lu_solver.hpp
+++ b/core/include/bertini2/linalg/lu_solver.hpp
@@ -1,0 +1,210 @@
+//This file is part of Bertini 2.
+//
+//bertini2/linalg/lu_solver.hpp is free software: you can redistribute it and/or modify
+//it under the terms of the GNU General Public License as published by
+//the Free Software Foundation, either version 3 of the License, or
+//(at your option) any later version.
+//
+//bertini2/linalg/lu_solver.hpp is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//GNU General Public License for more details.
+//
+//You should have received a copy of the GNU General Public License
+//along with bertini2/linalg/lu_solver.hpp.  If not, see <http://www.gnu.org/licenses/>.
+//
+// silviana amethyst, university of wisconsin-eau claire
+
+/**
+ \file bertini2/linalg/lu_solver.hpp
+
+ \brief A stateful partial-pivot LU solver that owns precision-adjustable temporary banks.
+
+ Eigen's generic dense LU allocates one multiprecision temporary per elementary scalar
+ operation -- O(N^3) heap allocations (mpc_init2 / mpc_clear, plus the per-alloc MPFR
+ get_memory_functions fetch, the thread-local working-precision read, and the mimalloc
+ ownership check) per factorization.  For runtime-precision mpc that allocation churn is
+ a large fraction of the cost and it scales with N^3.
+
+ This class factors in place, reusing a single scratch scalar across the whole
+ elimination, so a factorization performs O(1) allocations instead of O(N^3).  It owns
+ its workspace across calls and exposes a ChangePrecision() so the owner (a Newton
+ corrector / predictor) can move it up and down in precision the way the AMP tracker and
+ endgames re-precision their scratch -- see NewtonCorrector::ChangePrecision.
+*/
+
+#ifndef BERTINI_LINALG_LU_SOLVER_HPP
+#define BERTINI_LINALG_LU_SOLVER_HPP
+
+#include "bertini2/eigen_extensions.hpp"
+
+namespace bertini {
+namespace linalg {
+
+/**
+ \class PartialPivLU
+
+ \brief Stateful partial-pivot LU factor/solve with preallocated, precision-adjustable banks.
+
+ \tparam NumT The (complex) scalar type -- complex_dbl or complex_mp.
+
+ Numerically this is the same right-looking Gaussian elimination with partial pivoting as
+ Eigen's PartialPivLU (unit lower-triangular L, upper-triangular U, row pivoting), so
+ solutions agree with Eigen to backward-stable accuracy.  The win is allocation behavior,
+ not the arithmetic.
+*/
+template<typename NumT>
+class PartialPivLU
+{
+	using RealT = typename Eigen::NumTraits<NumT>::Real;
+	static constexpr bool is_mp = !std::is_same<NumT, complex_dbl>::value;
+
+public:
+	/// \brief (Re)size the workspace to hold n x n systems.  Call on a system-size change.
+	/// \param n The matrix dimension.
+	void ChangeSize(unsigned n)
+	{
+		n_ = n;
+		lu_.resize(n, n);   // new mp elements come up at the thread default precision
+		piv_.resize(n);
+		y_.resize(n);
+		if (is_mp && precision_ != 0)   // re-establish a previously-set precision on the new storage
+			ApplyPrecision();
+	}
+
+	/// \brief Re-set the precision of every mp temporary bank (a no-op for complex_dbl).
+	/// \param prec The new working precision (digits).
+	void ChangePrecision(unsigned prec)
+	{
+		precision_ = prec;
+		if (is_mp)
+			ApplyPrecision();
+	}
+
+	/// \brief Get the current working precision (digits).
+	unsigned precision() const { return precision_; }
+
+	/// \brief Factor a copy of A with partial pivoting; A is preserved.  O(1) allocations.
+	/// \param A The square matrix to factor.
+	/// \return Success unless the factored diagonal looks near-singular / ill-conditioned.
+	MatrixSuccessCode Factor(Mat<NumT> const& A)
+	{
+		lu_ = A;                 // one copy into reusable workspace (A must survive)
+		return FactorInPlace();
+	}
+
+	/// \brief Factor A destructively (no copy): on return A holds the L\\U factors.
+	/// \param A The square matrix; overwritten with the factorization.
+	/// \return Success unless the factored diagonal looks near-singular / ill-conditioned.
+	MatrixSuccessCode FactorDestructive(Mat<NumT> & A)
+	{
+		lu_.swap(A);             // steal A's storage; A is left holding our old workspace
+		auto code = FactorInPlace();
+		return code;
+	}
+
+	/// \brief Solve A x = b using the stored factors.  Reuses scratch; O(1) allocations.
+	/// \tparam OutDerived The output type -- a Vec or a writable block such as K.col(stage).
+	/// \param b The right-hand side (must be materialized storage, distinct from x).
+	/// \param[out] x_out The solution (sized n).  A temporary expression (e.g. .col()) is fine.
+	template<typename OutDerived>
+	void Solve(Vec<NumT> const& b, Eigen::MatrixBase<OutDerived> const& x_out) const
+	{
+		// Eigen idiom for a write-to output that may be a temporary Block (e.g. K.col(stage)).
+		Eigen::MatrixBase<OutDerived>& x = const_cast<Eigen::MatrixBase<OutDerived>&>(x_out);
+
+		// y_ = P b : copy then replay the row swaps recorded during factorization.
+		y_ = b;
+		for (unsigned k = 0; k < n_; ++k)
+			if (piv_[k] != k)
+				std::swap(y_[k], y_[piv_[k]]);
+
+		// forward substitution: L y = P b, L unit lower-triangular (implicit unit diagonal).
+		for (unsigned i = 1; i < n_; ++i)
+			for (unsigned j = 0; j < i; ++j)
+			{
+				t_ = lu_(i, j);
+				t_ *= y_[j];
+				y_[i] -= t_;      // y_[i] -= lu_(i,j) * y_[j]
+			}
+
+		// back substitution: U x = y, U upper-triangular.
+		for (unsigned ii = n_; ii-- > 0; )
+		{
+			for (unsigned j = ii + 1; j < n_; ++j)
+			{
+				t_ = lu_(ii, j);
+				t_ *= x(j);
+				y_[ii] -= t_;     // y_[ii] -= lu_(ii,j) * x(j)
+			}
+			x(ii) = y_[ii];
+			x(ii) /= lu_(ii, ii);
+		}
+	}
+
+	/// \brief The factored matrix (L below the diagonal, U on and above), for the caller's
+	/// LUPartialPivotDecompositionSuccessful()-style health check.
+	Mat<NumT> const& Factors() const { return lu_; }
+
+private:
+	/// \brief Right-looking partial-pivot Gaussian elimination in place on lu_.
+	MatrixSuccessCode FactorInPlace()
+	{
+		for (unsigned k = 0; k < n_; ++k)
+		{
+			// partial pivot: pick the row p >= k with the largest |lu_(p,k)|.
+			unsigned p = k;
+			amax_ = abs(lu_(k, k));
+			for (unsigned i = k + 1; i < n_; ++i)
+			{
+				acur_ = abs(lu_(i, k));
+				if (acur_ > amax_) { amax_ = acur_; p = i; }
+			}
+			piv_[k] = p;
+			if (p != k)
+				lu_.row(k).swap(lu_.row(p));
+
+			// scale the sub-column below the pivot: l_ik = a_ik / a_kk (in place, no temp).
+			for (unsigned i = k + 1; i < n_; ++i)
+				lu_(i, k) /= lu_(k, k);
+
+			// rank-1 trailing-submatrix update, reusing t_ for every multiply-subtract so the
+			// whole O(N^3) sweep allocates nothing beyond the scratch scalar.
+			for (unsigned j = k + 1; j < n_; ++j)
+				for (unsigned i = k + 1; i < n_; ++i)
+				{
+					t_ = lu_(i, k);
+					t_ *= lu_(k, j);
+					lu_(i, j) -= t_;   // lu_(i,j) -= lu_(i,k) * lu_(k,j)
+				}
+		}
+		return LUPartialPivotDecompositionSuccessful(lu_);
+	}
+
+	/// \brief Set every mp bank to precision_ (called on resize / precision change).
+	void ApplyPrecision()
+	{
+		if constexpr (is_mp)
+		{
+			Precision(lu_, precision_);
+			Precision(y_, precision_);
+			Precision(t_, precision_);
+			Precision(amax_, precision_);
+			Precision(acur_, precision_);
+		}
+	}
+
+	unsigned n_ = 0;                 ///< The current matrix dimension.
+	unsigned precision_ = 0;         ///< The current working precision (digits).
+	Mat<NumT> lu_;                   ///< Factored-matrix workspace (reused across calls).
+	std::vector<unsigned> piv_;      ///< Row pivots: piv_[k] is the row swapped into position k.
+	mutable Vec<NumT> y_;            ///< Solve scratch (permuted rhs / forward-sub result).
+	mutable NumT t_;                 ///< Reused scalar scratch for multiply-subtract.
+	RealT amax_;                     ///< Reused scratch: running max magnitude in pivot search.
+	RealT acur_;                     ///< Reused scratch: current magnitude in pivot search.
+};
+
+} // namespace linalg
+} // namespace bertini
+
+#endif

--- a/core/include/bertini2/linalg/lu_solver.hpp
+++ b/core/include/bertini2/linalg/lu_solver.hpp
@@ -164,9 +164,17 @@ private:
 			if (p != k)
 				lu_.row(k).swap(lu_.row(p));
 
-			// scale the sub-column below the pivot: l_ik = a_ik / a_kk (in place, no temp).
+			// scale the sub-column below the pivot by the reciprocal of the pivot -- one (costly)
+			// mpc division per column instead of one per sub-row, then cheap multiplies.  Pin recip_
+			// to the pivot's own precision first: during AMP the working precision changes, and a
+			// reciprocal left at a stale precision would contaminate the factorization (and, through
+			// the solution, trip the endgame's uniform-precision checks).
+			if constexpr (is_mp)
+				Precision(recip_, Precision(lu_(k, k)));
+			recip_ = 1;
+			recip_ /= lu_(k, k);                 // recip_ = 1 / a_kk, at the pivot's precision
 			for (unsigned i = k + 1; i < n_; ++i)
-				lu_(i, k) /= lu_(k, k);
+				lu_(i, k) *= recip_;             // l_ik = a_ik * (1 / a_kk)
 
 			// rank-1 trailing-submatrix update, reusing t_ for every multiply-subtract so the
 			// whole O(N^3) sweep allocates nothing beyond the scratch scalar.
@@ -189,6 +197,7 @@ private:
 			Precision(lu_, precision_);
 			Precision(y_, precision_);
 			Precision(t_, precision_);
+			Precision(recip_, precision_);   // re-pinned per pivot in FactorInPlace, but keep it valid
 			Precision(amax_, precision_);
 			Precision(acur_, precision_);
 		}
@@ -200,6 +209,7 @@ private:
 	std::vector<unsigned> piv_;      ///< Row pivots: piv_[k] is the row swapped into position k.
 	mutable Vec<NumT> y_;            ///< Solve scratch (permuted rhs / forward-sub result).
 	mutable NumT t_;                 ///< Reused scalar scratch for multiply-subtract.
+	NumT recip_;                     ///< Reused scratch: reciprocal of the current pivot.
 	RealT amax_;                     ///< Reused scratch: running max magnitude in pivot search.
 	RealT acur_;                     ///< Reused scratch: current magnitude in pivot search.
 };

--- a/core/include/bertini2/trackers/explicit_predictors.hpp
+++ b/core/include/bertini2/trackers/explicit_predictors.hpp
@@ -41,6 +41,7 @@
 #include <boost/type_index.hpp>
 
 #include "bertini2/eigen_extensions.hpp"
+#include "bertini2/linalg/lu_solver.hpp"
 
 namespace bertini{
 	namespace tracking{
@@ -359,6 +360,9 @@ namespace bertini{
 				{
 					std::get< Mat<complex_dbl> >(K_).resize(numTotalFunctions_, s_);
 					std::get< Mat<complex_mp> >(K_).resize(numTotalFunctions_, s_);
+
+					std::get< linalg::PartialPivLU<complex_dbl> >(LU_).ChangeSize(numVariables_);
+					std::get< linalg::PartialPivLU<complex_mp> >(LU_).ChangeSize(numVariables_);
 				}
 
 
@@ -402,6 +406,7 @@ namespace bertini{
 					Precision(std::get< Vec<complex_mp> >(solve_temp_),new_precision);
 					Precision(std::get< Vec<complex_mp> >(stage_pt_temp_),new_precision);
 					Precision(std::get< Vec<complex_mp> >(err_temp_),new_precision);
+					std::get< linalg::PartialPivLU<complex_mp> >(LU_).ChangePrecision(new_precision);
 
 					Precision(std::get< Mat<real_mp> >(a_),new_precision);
 					Precision(std::get< Vec<real_mp> >(b_),new_precision);
@@ -637,12 +642,12 @@ namespace bertini{
 				void SetNormsCond(NumErrorT & norm_J, NumErrorT & norm_J_inverse, NumErrorT & condition_number_estimate, unsigned num_steps_since_last_condition_number_computation, unsigned frequency_of_CN_estimation)
 				{
 					// Calculate condition number and update if needed
-					Eigen::PartialPivLU<Mat<ComplexT>>& LUref = std::get< Eigen::PartialPivLU<Mat<ComplexT>> >(LU_);
+					linalg::PartialPivLU<ComplexT>& LUref = std::get< linalg::PartialPivLU<ComplexT> >(LU_);
 					Mat<ComplexT>& dhdxref = std::get< Mat<ComplexT> >(dh_dx_0_);
 
 					Vec<ComplexT> const& randy = std::get< Vec<ComplexT> >(rand_temp_);
 					Vec<ComplexT>& solve_ref = std::get< Vec<ComplexT> >(solve_temp_);
-					solve_ref = LUref.solve(randy);
+					LUref.Solve(randy, solve_ref);
 
 					norm_J = NumErrorT(dhdxref.norm());
 					norm_J_inverse = NumErrorT(solve_ref.norm());
@@ -764,7 +769,7 @@ namespace bertini{
 
 					if(stage == 0)
 					{
-						Eigen::PartialPivLU<Mat<ComplexT>>& LUref = std::get< Eigen::PartialPivLU<Mat<ComplexT>> >(LU_);
+						linalg::PartialPivLU<ComplexT>& LUref = std::get< linalg::PartialPivLU<ComplexT> >(LU_);
 						Mat<ComplexT>& dhdxref = std::get< Mat<ComplexT> >(dh_dx_0_);
 
 						if (!std::is_same<ComplexT,complex_dbl>::value)
@@ -778,19 +783,21 @@ namespace bertini{
 						}
 						S.SetAndReset<ComplexT>(space, time);
 						S.JacobianInPlace(dhdxref);
-						LUref.compute(dhdxref);
+						// Factor a copy of dh/dx (dh_dx_0_ is read again in SetNormsCond); health check folded in.
+						auto lu_code = LUref.Factor(dhdxref);
 						if (!std::is_same<ComplexT,complex_dbl>::value)
 						{
 							assert(Precision(dhdxref)==current_precision_);
-							assert(Precision(LUref.matrixLU())==current_precision_);
+							assert(Precision(LUref.Factors())==current_precision_);
 						}
 
-						if (LUPartialPivotDecompositionSuccessful(LUref.matrixLU())!=MatrixSuccessCode::Success)
+						if (lu_code!=MatrixSuccessCode::Success)
 							return SuccessCode::MatrixSolveFailureFirstPartOfPrediction;
-						
+
 						Vec<ComplexT>& dhdtref = std::get< Vec<ComplexT> >(dh_dt_temp_);
 						S.TimeDerivativeInPlace(dhdtref);
-						K.col(stage) = LUref.solve(-dhdtref);
+						dhdtref = -dhdtref;                     // in place; Solve needs materialized rhs
+						LUref.Solve(dhdtref, K.col(stage));
 						
 						return SuccessCode::Success;
 						
@@ -801,15 +808,15 @@ namespace bertini{
 
 						Mat<ComplexT>& dhdxtempref = std::get< Mat<ComplexT> >(dh_dx_temp_);
 						S.JacobianInPlace(dhdxtempref);
-						Eigen::PartialPivLU<Mat<ComplexT>>& LU_temp = std::get< Eigen::PartialPivLU<Mat<ComplexT>> >(LU_);
-						LU_temp.compute(dhdxtempref);
-
-						if (LUPartialPivotDecompositionSuccessful(LU_temp.matrixLU())!=MatrixSuccessCode::Success)
+						linalg::PartialPivLU<ComplexT>& LU_temp = std::get< linalg::PartialPivLU<ComplexT> >(LU_);
+						// dh_dx_temp_ is pure scratch here -> factor destructively, skipping the copy.
+						if (LU_temp.FactorDestructive(dhdxtempref)!=MatrixSuccessCode::Success)
 							return SuccessCode::MatrixSolveFailure;
 
 						Vec<ComplexT>& dhdtref = std::get< Vec<ComplexT> >(dh_dt_temp_);
 						S.TimeDerivativeInPlace(dhdtref);
-						K.col(stage) = LU_temp.solve(-dhdtref);
+						dhdtref = -dhdtref;                     // in place; Solve needs materialized rhs
+						LU_temp.Solve(dhdtref, K.col(stage));
 						
 						return SuccessCode::Success;
 					}
@@ -949,7 +956,7 @@ namespace bertini{
 				mutable std::tuple< Vec<complex_dbl>, Vec<complex_mp> > dh_dt_temp_;  // Temporary time derivative used for all stages
 				// std::tuple< Eigen::PartialPivLU<Mat<complex_dbl>>, Eigen::PartialPivLU<Mat<complex_mp>> > LU_0_;  // LU from the intial stage used for AMP testing
 
-				mutable std::tuple< Eigen::PartialPivLU<Mat<complex_dbl>>, Eigen::PartialPivLU<Mat<complex_mp>> > LU_;
+				mutable std::tuple< linalg::PartialPivLU<complex_dbl>, linalg::PartialPivLU<complex_mp> > LU_;
 
 				mutable std::tuple< Vec<complex_dbl>, Vec<complex_mp> > step_temp_;  // reused scratch for FullStep stage accumulation
 				mutable std::tuple< Vec<complex_dbl>, Vec<complex_mp> > rand_temp_;  // reused scratch: random RHS for norm_J_inverse

--- a/core/include/bertini2/trackers/newton_corrector.hpp
+++ b/core/include/bertini2/trackers/newton_corrector.hpp
@@ -12,6 +12,7 @@
 #include "bertini2/trackers/amp_criteria.hpp"
 #include "bertini2/trackers/config.hpp"
 #include "bertini2/system/system.hpp"
+#include "bertini2/linalg/lu_solver.hpp"
 
 
 namespace bertini{
@@ -87,6 +88,7 @@ namespace bertini{
 					Precision(std::get< Mat<complex_mp> >(J_temp_), new_precision);
 					Precision(std::get< Vec<complex_mp> >(rand_temp_), new_precision);
 					Precision(std::get< Vec<complex_mp> >(solve_temp_), new_precision);
+					std::get< linalg::PartialPivLU<complex_mp> >(LU_).ChangePrecision(new_precision);
 
 					current_precision_ = new_precision;
 				}
@@ -116,6 +118,8 @@ namespace bertini{
 					std::get< Vec<complex_mp> >(step_temp_).resize(numTotalFunctions_);
 					std::get< Vec<complex_dbl> >(solve_temp_).resize(numVariables_);
 					std::get< Vec<complex_mp> >(solve_temp_).resize(numVariables_);
+					std::get< linalg::PartialPivLU<complex_dbl> >(LU_).ChangeSize(numVariables_);
+					std::get< linalg::PartialPivLU<complex_mp> >(LU_).ChangeSize(numVariables_);
 					RefreshRandomDirection();
 				}
 
@@ -207,7 +211,7 @@ namespace bertini{
 
 						// Adaptive precision: fill metadata + enforce AMP criteria B and C.
 						Mat<ComplexT>& J_temp_ref = std::get< Mat<ComplexT> >(J_temp_);
-						Eigen::PartialPivLU< Mat<ComplexT> >& LU_ref = std::get< Eigen::PartialPivLU< Mat<ComplexT> > >(LU_);
+						linalg::PartialPivLU<ComplexT>& LU_ref = std::get< linalg::PartialPivLU<ComplexT> >(LU_);
 
 						meta.norm_delta_z = NumErrorT(step_ref.template lpNorm<Eigen::Infinity>());
 						meta.norm_J = NumErrorT(J_temp_ref.norm());
@@ -219,7 +223,7 @@ namespace bertini{
 							// condition estimates comparable across steps and keeps tracking deterministic.
 							Vec<ComplexT>& rand_ref = std::get< Vec<ComplexT> >(rand_temp_);
 							Vec<ComplexT>& solve_ref = std::get< Vec<ComplexT> >(solve_temp_);
-							solve_ref = LU_ref.solve(rand_ref);
+							LU_ref.Solve(rand_ref, solve_ref);   // reuse the factorization from EvalIterationStep
 							meta.norm_J_inverse = NumErrorT(solve_ref.norm());
 						}
 						meta.condition_number_estimate = NumErrorT(meta.norm_J*meta.norm_J_inverse);
@@ -265,21 +269,21 @@ namespace bertini{
 					Vec<ComplexT>& f_temp_ref = std::get< Vec<ComplexT> >(f_temp_);
 					Mat<ComplexT>& J_temp_ref = std::get< Mat<ComplexT> >(J_temp_);
 					
-					Eigen::PartialPivLU< Mat<ComplexT> >& LU_ref = std::get< Eigen::PartialPivLU< Mat<ComplexT> > >(LU_);
+					linalg::PartialPivLU<ComplexT>& LU_ref = std::get< linalg::PartialPivLU<ComplexT> >(LU_);
 
 					S.SetAndReset<ComplexT>(current_space, current_time);
 					S.EvalInPlace(f_temp_ref);
 					S.JacobianInPlace(J_temp_ref);
-					LU_ref.compute(J_temp_ref);
-					
-					if (LUPartialPivotDecompositionSuccessful(LU_ref.matrixLU())!=MatrixSuccessCode::Success)
+					// Factor a copy of J (J_temp_ref is read again afterward for meta.norm_J).  The health
+					// check is folded into Factor().
+					if (LU_ref.Factor(J_temp_ref)!=MatrixSuccessCode::Success)
 						return SuccessCode::MatrixSolveFailure;
-					
+
 					// Solve J*newton_step = f (NOT -f): this lets us skip materializing the negated RHS
 					// temporary.  newton_step therefore holds +J^{-1}f = -(true Newton step), so callers
 					// SUBTRACT it (next_space -= newton_step).  The convergence test uses lpNorm, which is
 					// sign-insensitive, so it is unaffected.
-					newton_step = LU_ref.solve(f_temp_ref);
+					LU_ref.Solve(f_temp_ref, newton_step);
 
 					return SuccessCode::Success;
 					
@@ -302,7 +306,7 @@ namespace bertini{
 				std::tuple< Vec<complex_dbl>, Vec<complex_mp> > rand_temp_;  // reused scratch: random RHS for norm_J_inverse
 				std::tuple< Vec<complex_dbl>, Vec<complex_mp> > solve_temp_; // reused scratch: LU solve result
 
-				std::tuple< Eigen::PartialPivLU<Mat<complex_dbl>>, Eigen::PartialPivLU<Mat<complex_mp>> > LU_;
+				std::tuple< linalg::PartialPivLU<complex_dbl>, linalg::PartialPivLU<complex_mp> > LU_;
 				
 				unsigned current_precision_;
 

--- a/core/test/classes/lu_bench_test.cpp
+++ b/core/test/classes/lu_bench_test.cpp
@@ -1,0 +1,149 @@
+// Parity + A/B benchmark for bertini::linalg::PartialPivLU (the stateful, allocation-lean
+// multiprecision LU) against Eigen::PartialPivLU.  The parity suite runs in the normal test
+// run; the timing suite is skipped unless BERTINI2_BENCH is set in the environment.
+
+#include <boost/test/unit_test.hpp>
+
+#include "bertini2/linalg/lu_solver.hpp"
+#include "bertini2/mpfr_complex.hpp"
+
+#include <Eigen/LU>
+#include <chrono>
+#include <cstdlib>
+#include <iostream>
+#include <iomanip>
+#include <vector>
+
+using complex_dbl = bertini::complex_dbl;
+using complex_mp  = bertini::complex_mp;
+template<typename T> using Vec = bertini::Vec<T>;
+template<typename T> using Mat = bertini::Mat<T>;
+
+namespace {
+	using Clock = std::chrono::steady_clock;
+
+	// deterministic, well-conditioned (diagonally dominant) n x n matrix.
+	template<typename NumT>
+	Mat<NumT> MakeMatrix(unsigned n)
+	{
+		Mat<NumT> A(n, n);
+		for (unsigned i = 0; i < n; ++i)
+			for (unsigned j = 0; j < n; ++j)
+			{
+				double re = 0.3 + 0.017 * double((i * 7 + j * 3) % 11);
+				double im = -0.2 + 0.011 * double((i * 5 + j * 13) % 9);
+				A(i, j) = NumT(re, im);
+			}
+		for (unsigned i = 0; i < n; ++i)
+			A(i, i) += NumT(double(n), 0.0);   // diagonal dominance -> well conditioned
+		return A;
+	}
+
+	template<typename NumT>
+	Vec<NumT> MakeRHS(unsigned n)
+	{
+		Vec<NumT> b(n);
+		for (unsigned i = 0; i < n; ++i)
+			b(i) = NumT(0.5 + 0.1 * double(i), 0.3 - 0.05 * double(i));
+		return b;
+	}
+}
+
+BOOST_AUTO_TEST_SUITE(LU_solver)
+
+// Custom solver must agree with Eigen's PartialPivLU (small residual, matching solution).
+BOOST_AUTO_TEST_CASE(parity_double)
+{
+	for (unsigned n : {3u, 5u, 20u, 50u})
+	{
+		auto A = MakeMatrix<complex_dbl>(n);
+		auto b = MakeRHS<complex_dbl>(n);
+
+		Eigen::PartialPivLU<Mat<complex_dbl>> elu(A);
+		Vec<complex_dbl> xe = elu.solve(b);
+
+		bertini::linalg::PartialPivLU<complex_dbl> blu;
+		blu.ChangeSize(n);
+		BOOST_CHECK(blu.Factor(A) == bertini::MatrixSuccessCode::Success);
+		Vec<complex_dbl> xc(n);
+		blu.Solve(b, xc);
+
+		double resid = (A * xc - b).norm();
+		double diff  = (xc - xe).norm();
+		BOOST_CHECK_SMALL(resid, 1e-12);
+		BOOST_CHECK_SMALL(diff,  1e-12);
+	}
+}
+
+BOOST_AUTO_TEST_CASE(parity_mp)
+{
+	auto saved = bertini::DefaultPrecision();
+	bertini::DefaultPrecision(40);
+
+	for (unsigned n : {3u, 5u, 20u, 50u})
+	{
+		auto A = MakeMatrix<complex_mp>(n);
+		auto b = MakeRHS<complex_mp>(n);
+
+		Eigen::PartialPivLU<Mat<complex_mp>> elu(A);
+		Vec<complex_mp> xe = elu.solve(b);
+
+		bertini::linalg::PartialPivLU<complex_mp> blu;
+		blu.ChangeSize(n);
+		blu.ChangePrecision(40);
+		BOOST_CHECK(blu.Factor(A) == bertini::MatrixSuccessCode::Success);
+		Vec<complex_mp> xc(n);
+		blu.Solve(b, xc);
+
+		double resid = static_cast<double>((A * xc - b).norm());
+		double diff  = static_cast<double>((xc - xe).norm());
+		BOOST_CHECK_SMALL(resid, 1e-30);
+		BOOST_CHECK_SMALL(diff,  1e-30);
+	}
+
+	bertini::DefaultPrecision(saved);
+}
+
+// A/B timing: Eigen vs custom, factor+solve, ns/op.  Skipped unless BERTINI2_BENCH is set.
+BOOST_AUTO_TEST_CASE(ab_timing)
+{
+	if (!std::getenv("BERTINI2_BENCH")) return;
+
+	bertini::DefaultPrecision(40);
+	std::cout << "\nLU_BENCH_BEGIN  (factor+solve, complex_mp @ 40 digits; ns/op, lower=better)\n";
+	std::cout << "| N | eigen ns | custom ns | speedup |\n|---|---:|---:|---:|\n";
+
+	struct Case { unsigned n; std::size_t iters; };
+	for (Case c : std::vector<Case>{ {5, 20000}, {20, 2000}, {50, 300}, {100, 60} })
+	{
+		unsigned n = c.n;
+		auto A = MakeMatrix<complex_mp>(n);
+		auto b = MakeRHS<complex_mp>(n);
+		Vec<complex_mp> x(n);
+
+		// Eigen
+		Eigen::PartialPivLU<Mat<complex_mp>> elu(n);
+		elu.compute(A); x = elu.solve(b);                       // warmup
+		auto t0 = Clock::now();
+		for (std::size_t m = 0; m < c.iters; ++m) { elu.compute(A); x = elu.solve(b); }
+		auto t1 = Clock::now();
+		double eigen_ns = std::chrono::duration<double, std::nano>(t1 - t0).count() / double(c.iters);
+
+		// custom
+		bertini::linalg::PartialPivLU<complex_mp> blu;
+		blu.ChangeSize(n); blu.ChangePrecision(40);
+		blu.Factor(A); blu.Solve(b, x);                          // warmup
+		t0 = Clock::now();
+		for (std::size_t m = 0; m < c.iters; ++m) { blu.Factor(A); blu.Solve(b, x); }
+		t1 = Clock::now();
+		double custom_ns = std::chrono::duration<double, std::nano>(t1 - t0).count() / double(c.iters);
+
+		std::cout << "| " << n
+		          << " | " << std::fixed << std::setprecision(0) << eigen_ns
+		          << " | " << custom_ns
+		          << " | " << std::setprecision(2) << (eigen_ns / custom_ns) << "x |\n";
+	}
+	std::cout << "LU_BENCH_END\n";
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/core/test/classes/lu_bench_test.cpp
+++ b/core/test/classes/lu_bench_test.cpp
@@ -47,6 +47,19 @@ namespace {
 			b(i) = NumT(0.5 + 0.1 * double(i), 0.3 - 0.05 * double(i));
 		return b;
 	}
+
+	// Well-conditioned but pivot-heavy: a diagonally dominant matrix with its rows cyclically
+	// shifted, so the dominant entries sit OFF the diagonal and partial pivoting must swap every
+	// row.  Same singular values as MakeMatrix (a row permutation), so still well conditioned.
+	template<typename NumT>
+	Mat<NumT> MakePivotMatrix(unsigned n)
+	{
+		Mat<NumT> D = MakeMatrix<NumT>(n);
+		Mat<NumT> A(n, n);
+		for (unsigned i = 0; i < n; ++i)
+			A.row(i) = D.row((i + 1) % n);
+		return A;
+	}
 }
 
 BOOST_AUTO_TEST_SUITE(LU_solver)
@@ -54,7 +67,7 @@ BOOST_AUTO_TEST_SUITE(LU_solver)
 // Custom solver must agree with Eigen's PartialPivLU (small residual, matching solution).
 BOOST_AUTO_TEST_CASE(parity_double)
 {
-	for (unsigned n : {3u, 5u, 20u, 50u})
+	for (unsigned n : {3u, 5u, 20u, 50u, 100u})
 	{
 		auto A = MakeMatrix<complex_dbl>(n);
 		auto b = MakeRHS<complex_dbl>(n);
@@ -80,7 +93,7 @@ BOOST_AUTO_TEST_CASE(parity_mp)
 	auto saved = bertini::DefaultPrecision();
 	bertini::DefaultPrecision(40);
 
-	for (unsigned n : {3u, 5u, 20u, 50u})
+	for (unsigned n : {3u, 5u, 20u, 50u, 100u})
 	{
 		auto A = MakeMatrix<complex_mp>(n);
 		auto b = MakeRHS<complex_mp>(n);
@@ -101,6 +114,45 @@ BOOST_AUTO_TEST_CASE(parity_mp)
 		BOOST_CHECK_SMALL(diff,  1e-30);
 	}
 
+	bertini::DefaultPrecision(saved);
+}
+
+// Pivot-heavy: dominant entries off the diagonal, so partial pivoting must swap every row.
+// Exercises the pivot-selection + row-swap path against Eigen on both scalar types.
+BOOST_AUTO_TEST_CASE(parity_pivoting)
+{
+	for (unsigned n : {5u, 20u, 60u})
+	{
+		auto Ad = MakePivotMatrix<complex_dbl>(n);
+		auto bd = MakeRHS<complex_dbl>(n);
+		Eigen::PartialPivLU<Mat<complex_dbl>> eld(Ad);
+		Vec<complex_dbl> xed = eld.solve(bd);
+		bertini::linalg::PartialPivLU<complex_dbl> bld;
+		bld.ChangeSize(n);
+		BOOST_CHECK(bld.Factor(Ad) == bertini::MatrixSuccessCode::Success);
+		Vec<complex_dbl> xcd(n);
+		bld.Solve(bd, xcd);
+		BOOST_CHECK_SMALL((Ad * xcd - bd).norm(), 1e-12);
+		BOOST_CHECK_SMALL((xcd - xed).norm(),      1e-12);
+	}
+
+	auto saved = bertini::DefaultPrecision();
+	bertini::DefaultPrecision(40);
+	for (unsigned n : {5u, 20u, 60u})
+	{
+		auto A = MakePivotMatrix<complex_mp>(n);
+		auto b = MakeRHS<complex_mp>(n);
+		Eigen::PartialPivLU<Mat<complex_mp>> elu(A);
+		Vec<complex_mp> xe = elu.solve(b);
+		bertini::linalg::PartialPivLU<complex_mp> blu;
+		blu.ChangeSize(n);
+		blu.ChangePrecision(40);
+		BOOST_CHECK(blu.Factor(A) == bertini::MatrixSuccessCode::Success);
+		Vec<complex_mp> xc(n);
+		blu.Solve(b, xc);
+		BOOST_CHECK_SMALL(static_cast<double>((A * xc - b).norm()), 1e-30);
+		BOOST_CHECK_SMALL(static_cast<double>((xc - xe).norm()),    1e-30);
+	}
 	bertini::DefaultPrecision(saved);
 }
 


### PR DESCRIPTION
## What

Replaces `Eigen::PartialPivLU` in the path tracker (Newton corrector + RK predictor) with a purpose-built stateful multiprecision LU solver, `bertini::linalg::PartialPivLU<NumT>` (`core/include/bertini2/linalg/lu_solver.hpp`).

## Why

Profiling the multiprecision hot path (targeting large, ~100×100 Jacobians) showed the linear algebra dominates, and Eigen's generic dense LU allocates **one `mpc` temporary per elementary scalar op** — O(N³) `mpc_init2`/`mpc_clear` per factorization, each dragging the MPFR `get_memory_functions` fetch, a thread-local working-precision read, and the mimalloc ownership check. That allocation churn was ~24% of compute and scales with N³.

Workspace-level fixes were tried first and **measured flat** (documented so we don't revisit): the predictor `-dhdtref` sign-fold (Eigen already fuses it) and in-place LU via Eigen `Ref` (the matrix *copy* was never the cost — the per-element allocations were). That pointed to a custom solver.

## How

A stateful function-object owning precision-adjustable temporary banks (factored-matrix workspace, pivots, solve scratch, reused scalars) with `ChangeSize(n)` / `ChangePrecision(prec)`, held by the corrector/predictor and re-precisioned exactly like the AMP tracker/endgame scratch. Right-looking partial-pivot elimination **reuses one scratch scalar across the whole O(N³) sweep**, so a factorization does **O(1) allocations instead of O(N³)**. Reciprocal-multiply pivot scaling (one mpc division per column, not per sub-row). Numerically the same partial-pivot LU as Eigen (unit-lower L, upper U, row pivoting). Predictor scratch-Jacobian stages factor destructively to skip the copy.

## Measured (serial, seed 1, best-of-N)

LU factor+solve in isolation, `complex_mp @ 40 digits`, custom vs Eigen:

| N | Eigen | Custom | Speedup |
|---|--:|--:|--:|
| 5 | 60.4 µs | 31.9 µs | 1.89× |
| 20 | 1.48 ms | 0.86 ms | 1.71× |
| 50 | 16.6 ms | 11.1 ms | 1.50× |
| 100 | 114.4 ms | 83.0 ms | 1.38× |

End-to-end cyclic-5: **fixed-MP (mptype 1, prec 96) 17.8 s → 13.4 s (−25%)**, **adaptive (mptype 2) 5.1 s → 4.1 s (−20%)**. The win grows with N (the removed overhead is a fixed fraction over growing O(N³) arithmetic), so the ~100×100 targets should see more. The double path improves too — the lean solver beats Eigen's decomposition-object overhead.

## Verification

- **Parity** (`core/test/classes/lu_bench_test.cpp`, runs in the normal suite): matches Eigen residual + solution to `<1e-12` (dbl) / `<1e-30` (mp@40) up to **N=100**, plus a **pivot-heavy** case (dominant entries off-diagonal via cyclic row shift, forcing row swaps).
- **Green:** `test_classes`, `test_tracking_basics` (101), `test_endgames` (363), `test_nag_algorithms`. `tools/doclint.sh` clean.
- The endgame suite caught a real bug in an early cut of the reciprocal-multiply (a constant left at a stale precision during AMP contaminated the solution and tripped the Cauchy endgame's uniform-precision check); fixed by pinning the reciprocal to the live pivot's precision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)